### PR TITLE
do not break ancestry tree

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,10 +56,15 @@ Options:
 )
 
 type PageInfo struct {
-	Title   string `json:"title"`
+	Title string `json:"title"`
+
 	Version struct {
 		Number int64 `json:"number"`
 	} `json:"version"`
+
+	Ancestors []struct {
+		Id string `json:"id"`
+	} `json:"ancestors"`
 }
 
 func main() {
@@ -188,6 +193,9 @@ func updatePage(
 			"number":    nextPageVersion,
 			"minorEdit": false,
 		},
+		"ancestors": []map[string]interface{}{
+			{"id": pageInfo.Ancestors[len(pageInfo.Ancestors)-1].Id},
+		},
 		"body": map[string]interface{}{
 			"storage": map[string]interface{}{
 				"value":          string(newContent),
@@ -220,7 +228,10 @@ func updatePage(
 func getPageInfo(
 	api *gopencils.Resource, pageID string,
 ) (PageInfo, error) {
-	request, err := api.Res("content/"+pageID, &PageInfo{}).Get()
+	request, err := api.Res(
+		"content/"+pageID, &PageInfo{},
+	).Get(map[string]string{"expand": "ancestors,version"})
+
 	if err != nil {
 		return PageInfo{}, err
 	}

--- a/main.go
+++ b/main.go
@@ -185,6 +185,18 @@ func updatePage(
 ) error {
 	nextPageVersion := pageInfo.Version.Number + 1
 
+	if len(pageInfo.Ancestors) == 0 {
+		return fmt.Errorf(
+			"Page '%s' info does not contain any information about parents",
+			pageID,
+		)
+	}
+
+	// picking only the last one, which is required by confluence
+	oldAncestors := []map[string]interface{}{
+		{"id": pageInfo.Ancestors[len(pageInfo.Ancestors)-1].Id},
+	}
+
 	payload := map[string]interface{}{
 		"id":    pageID,
 		"type":  "page",
@@ -193,9 +205,7 @@ func updatePage(
 			"number":    nextPageVersion,
 			"minorEdit": false,
 		},
-		"ancestors": []map[string]interface{}{
-			{"id": pageInfo.Ancestors[len(pageInfo.Ancestors)-1].Id},
-		},
+		"ancestors": oldAncestors,
 		"body": map[string]interface{}{
 			"storage": map[string]interface{}{
 				"value":          string(newContent),


### PR DESCRIPTION
Running `mark` for updating page, deeply nested in some tree, ended up page
being shifted to the Ctulhu's void, e.g. not belonging to any parent.