### PR TITLE
Use default GOOS and allow to specify GOOS on cmd-line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ get:
 
 build:
 	@echo :: building go binary $(VERSION)
-	CGO_ENABLED=0 GOOS=linux go build \
+	CGO_ENABLED=0 go build \
 		-ldflags "-X main.version=$(VERSION)" \
 		-gcflags "-trimpath $(GOPATH)/src"
 


### PR DESCRIPTION
```
# Build for current OS
make build

# Build for Linux
GOOS=linux make build
```