### PR TITLE
Fixed #11: Allow Confluence Space to be mixed case

### DIFF
--- a/pkg/mark/meta.go
+++ b/pkg/mark/meta.go
@@ -78,7 +78,7 @@ func ExtractMeta(data []byte) (*Meta, []byte, error) {
 			meta.Parents = append(meta.Parents, value)
 
 		case HeaderSpace:
-			meta.Space = strings.ToUpper(value)
+			meta.Space = strings.TrimSpace(value)
 
 		case HeaderTitle:
 			meta.Title = strings.TrimSpace(value)


### PR DESCRIPTION
Swap `ToUpper` for `TrimSpace` in meta parser to leave the case as it
was passed.