### PR TITLE
Add ExactAttachment header

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Confluence), so `ExactAttachment` has been introduced:
 An attached link is [here](<path>)
 ```
 
-*NOTE* Be careful with `ExactAttachment`! If your path string is a subset of
+**NOTE**: Be careful with `ExactAttachment`! If your path string is a subset of
 another longer string or referenced in text, you may get undesired behavior.
 
 Mark also supports macro definitions, which are defined as regexps which will

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ File in extended format should follow specification
 <!-- Parent: <parent 1> -->
 <!-- Parent: <parent 2> -->
 <!-- Title: <title> -->
+<!-- ExactAttachment: <local path> -->
+<!-- Attachment: <local path> -->
 
 <page contents>
 ```
@@ -60,6 +62,33 @@ follows include tag:
 <!-- Include: <path>
      <yaml-data> -->
 ```
+
+Mark also supports attachments. The standard way involves declaring an
+`Attachment` along with the other items in the header, then have any links
+start with an `attachment://` pseudo-URL:
+
+```markdown
+<!-- Attachment: <path> -->
+
+<beginning of page content>
+
+An attached link is [here](attachment://<path>)
+```
+
+The standard attachment mechanism may not work in some circumstances (e.g.
+keeping content as close to identical as possible between GitHub and
+Confluence), so `ExactAttachment` has been introduced:
+
+```markdown
+<!-- ExactAttachment: <path> -->
+
+<beginning of page content>
+
+An attached link is [here](<path>)
+```
+
+*NOTE* Be careful with `ExactAttachment`! If your path string is a subset of
+another longer string or referenced in text, you may get undesired behavior.
 
 Mark also supports macro definitions, which are defined as regexps which will
 be replaced with specified template:

--- a/pkg/mark/meta.go
+++ b/pkg/mark/meta.go
@@ -11,11 +11,12 @@ import (
 )
 
 const (
-	HeaderParent     = `Parent`
-	HeaderSpace      = `Space`
-	HeaderTitle      = `Title`
-	HeaderLayout     = `Layout`
-	HeaderAttachment = `Attachment`
+	HeaderParent          = `Parent`
+	HeaderSpace           = `Space`
+	HeaderTitle           = `Title`
+	HeaderLayout          = `Layout`
+	HeaderAttachment      = `Attachment`
+	HeaderExactAttachment = `ExactAttachment`
 )
 
 type Meta struct {
@@ -23,7 +24,7 @@ type Meta struct {
 	Space       string
 	Title       string
 	Layout      string
-	Attachments []string
+	Attachments map[string]string
 }
 
 var (
@@ -64,6 +65,7 @@ func ExtractMeta(data []byte) (*Meta, []byte, error) {
 
 		if meta == nil {
 			meta = &Meta{}
+			meta.Attachments = make(map[string]string)
 		}
 
 		header := strings.Title(matches[1])
@@ -87,7 +89,10 @@ func ExtractMeta(data []byte) (*Meta, []byte, error) {
 			meta.Layout = strings.TrimSpace(value)
 
 		case HeaderAttachment:
-			meta.Attachments = append(meta.Attachments, value)
+			meta.Attachments["attachment://"+value] = value
+
+		case HeaderExactAttachment:
+			meta.Attachments[value] = value
 
 		default:
 			log.Errorf(


### PR DESCRIPTION
Added an `ExactAttachment` header that doesn't require the use of an `attachment://` URL scheme. This should simplify using `mark` as a tool for something like keeping GitHub and Confluence in sync at the cost of adding a tool that may give undesired behavior in some circumstances if used without caution.

Unfortunately, I had to change the `pkg/mark/Meta` data structure to get an approach that was relatively easy on the eyes. However, I figured it might be a good place to make the change in case a syntactic change is preferable over `ExactAttachment` and/or regular expression replacement becomes a priority.

I tried both attachment mechanisms with my local build and everything _seems_ to be working with the refactor and the new header. In fact, I now have a GitHub and Confluence page that look more or less identical (including locally generated images) from the same markdown code, which was at least my own goal.