### PR TITLE
Automate Releases with GoReleaser

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,26 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set Up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.14
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        version: latest
+        args: release --rm-dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,26 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod download
+builds:
+- env:
+  - CGO_ENABLED=0
+archives:
+- replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,8 @@ before:
 builds:
 - env:
   - CGO_ENABLED=0
+  gcflags:
+    - all=-trimpath={{.Env.GOPATH}}
 archives:
 - replacements:
     darwin: Darwin


### PR DESCRIPTION
This adds [GoReleaser](https://goreleaser.com) as well as a GitHub Action to run it whenever there's a tag pushed to the repo.