### PR TITLE
Update Readme for new Docker usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ go get -v github.com/kovetskiy/mark
 ### Docker
 
 ```bash
-$ docker run --rm -i kovetskiy/mark:latest <params>
+$ docker run --rm -i kovetskiy/mark:latest mark <params>
 ```
 
 ## Usage


### PR DESCRIPTION
Since you patched your Entrypoint to a shell instead of directly calling `mark` the documentation should reflect that. 
