### PR TITLE
Add Option for Dropping Leading H1 Heading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /mark
 /docker
 /testdata
+.idea/

--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ $ docker run --rm -i kovetskiy/mark:latest mark <params>
 
 ```
 mark [options] [-u <username>] [-p <password>] [-k] [-l <url>] -f <file>
-mark [options] [-u <username>] [-p <password>] [-k] [-n] -c <file>
+mark [options] [-u <username>] [-p <password>] [-k] [-b <url>] -f <file>
+mark [options] [-u <username>] [-p <password>] [--drop-h1] -f <file>
 mark -v | --version
 mark -h | --help
 ```
@@ -208,14 +209,17 @@ mark -h | --help
 - `-p <password>` — Use specified password for updating Confluence page.
 - `-l <url>` — Edit specified Confluence page.
     If -l is not specified, file should contain metadata (see above).
+- `-b <url>` or `--base-url <url>` – Base URL for Confluence.
+    Alternative option for base_url config field.
 - `-f <file>` — Use specified markdown file for converting to html.
 - `-c <file>` — Specify configuration file which should be used for reading
     Confluence page URL and markdown file path.
 - `-k` — Lock page editing to current user only to prevent accidental
     manual edits over Confluence Web UI.
+- `--drop-h1` – Don't include H1 headings in Confluence output.
 - `--dry-run` — Show resulting HTML and don't update Confluence page content.
 - `--trace` — Enable trace logs.
-- `-v | --version`  — Show version.
+- `-v | --version` — Show version.
 - `-h | --help` — Show help screen and call 911.
 
 You can store user credentials in the configuration file, which should be

--- a/main.go
+++ b/main.go
@@ -108,7 +108,6 @@ By default, mark provides several built-in templates and macros:
 Usage:
   mark [options] [-u <username>] [-p <token>] [-k] [-l <url>] -f <file>
   mark [options] [-u <username>] [-p <password>] [-k] [-b <url>] -f <file>
-  mark [options] [-u <username>] [-p <password>] [-k] [-n] -c <file>
   mark -v | --version
   mark -h | --help
 

--- a/main.go
+++ b/main.go
@@ -108,7 +108,6 @@ By default, mark provides several built-in templates and macros:
 Usage:
   mark [options] [-u <username>] [-p <token>] [-k] [-l <url>] -f <file>
   mark [options] [-u <username>] [-p <password>] [-k] [-b <url>] -f <file>
-  mark [options] [-u <username>] [-p <password>] [--drop-h1] -f <file>
   mark -v | --version
   mark -h | --help
 

--- a/main.go
+++ b/main.go
@@ -108,6 +108,7 @@ By default, mark provides several built-in templates and macros:
 Usage:
   mark [options] [-u <username>] [-p <token>] [-k] [-l <url>] -f <file>
   mark [options] [-u <username>] [-p <password>] [-k] [-b <url>] -f <file>
+  mark [options] [-u <username>] [-p <password>] [--drop-h1] -f <file>
   mark -v | --version
   mark -h | --help
 

--- a/main.go
+++ b/main.go
@@ -123,6 +123,7 @@ Options:
   -f <file>            Use specified markdown file for converting to html.
   -k                   Lock page editing to current user only to prevent accidental
                         manual edits over Confluence Web UI.
+  --drop-h1            Don't include H1 headings in Confluence output.
   --dry-run            Resolve page and ancestry, show resulting HTML and exit.
   --compile-only       Show resulting HTML and don't update Confluence page content.
   --debug              Enable debug logs.
@@ -143,6 +144,7 @@ func main() {
 		compileOnly   = args["--compile-only"].(bool)
 		dryRun        = args["--dry-run"].(bool)
 		editLock      = args["-k"].(bool)
+		dropH1        = args["--drop-h1"].(bool)
 	)
 
 	if args["--debug"].(bool) {
@@ -285,6 +287,11 @@ func main() {
 	}
 
 	markdown = mark.CompileAttachmentLinks(markdown, attaches)
+
+	if dropH1 {
+		log.Info("Leading H1 heading will be excluded from the Confluence output")
+		markdown = mark.DropH1Markdown(markdown)
+	}
 
 	html := mark.CompileMarkdown(markdown, stdlib)
 

--- a/main.go
+++ b/main.go
@@ -290,7 +290,7 @@ func main() {
 
 	if dropH1 {
 		log.Info("Leading H1 heading will be excluded from the Confluence output")
-		markdown = mark.DropH1Markdown(markdown)
+		markdown = mark.DropDocumentLeadingH1(markdown)
 	}
 
 	html := mark.CompileMarkdown(markdown, stdlib)

--- a/pkg/mark/markdown.go
+++ b/pkg/mark/markdown.go
@@ -91,9 +91,11 @@ func CompileMarkdown(
 	return string(html)
 }
 
-// dropH1Markdown will drop leading H1 headings to prevent
-// duplication of or conflict with page titles.
-func DropH1Markdown(
+// DropDocumentLeadingH1 will drop leading H1 headings to prevent
+// duplication of or visual conflict with page titles.
+// NOTE: This is intended only to operate on the whole markdown document.
+// Operating on individual lines will clear them if the begin with `#`.
+func DropDocumentLeadingH1(
 	markdown []byte,
 ) []byte {
 	h1 := regexp.MustCompile(`^#[^#].*\n`)

--- a/pkg/mark/markdown.go
+++ b/pkg/mark/markdown.go
@@ -90,3 +90,13 @@ func CompileMarkdown(
 
 	return string(html)
 }
+
+// dropH1Markdown will drop leading H1 headings to prevent
+// duplication of or conflict with page titles.
+func DropH1Markdown(
+	markdown []byte,
+) []byte {
+	h1 := regexp.MustCompile(`^#[^#].*\n`)
+	markdown = h1.ReplaceAll(markdown, []byte(""))
+	return markdown
+}


### PR DESCRIPTION
This functionality is designed to eliminate duplicate page titles in Confluence (once from the page title itself, and a second from the rendered H1), but preserve them for display in GitHub or other non-contextual environments.

- Adds a `--drop-h1` flag that removes leading ATX H1 headings, excluding them from the Confluence wiki markup output.
- Adds `.idea/` (GoLand) IDE preferences to `.gitignore`
