### PR TITLE
Parametrize the toc but have default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,29 @@ This is my article.
 <!-- Include: ac:toc -->
 ```
 
+If default TOC looks don't find a way to your heart, try [parametrizing it][Confluence TOC Macro], for example:
+
+```markdown
+<!-- Macro: :toc:
+     Template: ac:toc
+     Printable: 'false'
+     MinLevel: 2 -->
+
+# This is my nice title
+
+:toc:
+```
+
+You can call the `Macro` as you like but the `Template` field must have the `ac:toc` value.
+Also, note the single quotes around `'false'`.
+
+See [Confluence TOC Macro] for the list of parameters - keep in mind that here
+they start with capital letters. Every skipped field will have the default
+value, so feel free to include only the ones that you require.
+
+
+[Confluence TOC Macro]:https://confluence.atlassian.com/conf59/table-of-contents-macro-792499210.html
+
 ### Insert Jira Ticket
 
 **article.md**

--- a/pkg/mark/stdlib/stdlib.go
+++ b/pkg/mark/stdlib/stdlib.go
@@ -139,14 +139,17 @@ func templates(api *confluence.API) (*template.Template, error) {
 		/* https://confluence.atlassian.com/conf59/table-of-contents-macro-792499210.html */
 
 		`ac:toc`: text(
-			`<ac:structured-macro ac:name="toc">`,
-			`<ac:parameter ac:name="printable">true</ac:parameter>`,
-			`<ac:parameter ac:name="style">disc</ac:parameter>`,
-			`<ac:parameter ac:name="maxLevel">7</ac:parameter>`,
-			`<ac:parameter ac:name="minLevel">1</ac:parameter>`,
-			`<ac:parameter ac:name="exclude">{{ .Exclude }}</ac:parameter>`,
-			`<ac:parameter ac:name="outline">false</ac:parameter>`,
-			`</ac:structured-macro>`,
+			`<ac:structured-macro ac:name="toc">{{printf "\n"}}`,
+			`<ac:parameter ac:name="printable">{{ or .Printable "true" }}</ac:parameter>{{printf "\n"}}`,
+			`<ac:parameter ac:name="style">{{ or .Style "disc" }}</ac:parameter>{{printf "\n"}}`,
+			`<ac:parameter ac:name="maxLevel">{{ or .MaxLevel "7" }}</ac:parameter>{{printf "\n"}}`,
+			`<ac:parameter ac:name="indent">{{ or .Indent "" }}</ac:parameter>{{printf "\n"}}`,
+			`<ac:parameter ac:name="minLevel">{{ or .MinLevel "1" }}</ac:parameter>{{printf "\n"}}`,
+			`<ac:parameter ac:name="exclude">{{ or .Exclude "" }}</ac:parameter>{{printf "\n"}}`,
+			`<ac:parameter ac:name="type">{{ or .Type "list" }}</ac:parameter>{{printf "\n"}}`,
+			`<ac:parameter ac:name="outline">{{ or .Outline "clear" }}</ac:parameter>{{printf "\n"}}`,
+			`<ac:parameter ac:name="include">{{ or .Include "" }}</ac:parameter>{{printf "\n"}}`,
+			`</ac:structured-macro>{{printf "\n"}}`,
 		),
 
 		// TODO(seletskiy): more templates here


### PR DESCRIPTION
Hey, firstly - you're an absolute legend for coming up with this tool. It's saving me hours every week and I stopped dreaming nightmares not having to deal with that editor.

Sorry that this is coming without an issue or a request - I just extended the code when I quickly needed to change things in the default TOC.

The template includes something that be unusual - newlines for each of the parameters. I do sometimes double-check the xhtmls before uploading, and they end up a bit more readable this way. The output on confluence isn't different as far as I could tell. For example:

Input:
```markdown
<!-- Macro: :toc:
     Template: ac:toc
     Style: circle
     MaxLevel: 3 -->
```

Output:
```html
<p><ac:structured-macro ac:name="toc">
<ac:parameter ac:name="printable">true</ac:parameter>
<ac:parameter ac:name="style">circle</ac:parameter>
<ac:parameter ac:name="maxLevel">3</ac:parameter>
<ac:parameter ac:name="indent"></ac:parameter>
<ac:parameter ac:name="minLevel">1</ac:parameter>
<ac:parameter ac:name="exclude"></ac:parameter>
<ac:parameter ac:name="type">list</ac:parameter>
<ac:parameter ac:name="outline">clear</ac:parameter>
<ac:parameter ac:name="include"></ac:parameter>
</ac:structured-macro></p>
```

I'll be adding another PR with a little extension to the code blocks.