### PR TITLE
Incorporate the collapsible code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ must stay in the front _if it is given_:
 
     [<language>] ["collapse"] ["title" <your title>]
 
-[code block macro]: https://confluence.atlassian.com/doc/code-block-macro-139390.html
+[Code Block Macro]: https://confluence.atlassian.com/doc/code-block-macro-139390.html
 
 ## Template & Macros
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,33 @@ for example:
        Ticket: ${0} -->
 ```
 
+### Code Blocks
+
+If you have long code blocks, you can make them collapsible with the [Code Block Macro]:
+
+    ```bash collapse
+    ...
+    some long bash code block
+    ...
+    ```
+
+And you can also add a title:
+
+    ```bash collapse title Some long long bash function
+    ...
+    some long bash code block
+    ...
+    ```
+
+You can collapse or have a title without language or any mix, but the language
+must stay in the front _if it is given_:
+
+    [<language>] ["collapse"] ["title" <your title>]
+
+[code block macro]: https://confluence.atlassian.com/doc/code-block-macro-139390.html
+
+## Template & Macros
+
 By default, mark provides several built-in templates and macros:
 
 * template `ac:status` to include badge-like text, which accepts following

--- a/pkg/mark/stdlib/stdlib.go
+++ b/pkg/mark/stdlib/stdlib.go
@@ -105,11 +105,12 @@ func templates(api *confluence.API) (*template.Template, error) {
 
 		// This template is used for rendering code in ```
 		`ac:code`: text(
-			`<ac:structured-macro ac:name="code">`,
-			`<ac:parameter ac:name="language">{{ .Language }}</ac:parameter>`,
-			`<ac:parameter ac:name="collapse">false</ac:parameter>`,
-			`<ac:plain-text-body><![CDATA[{{ .Text | cdata }}]]></ac:plain-text-body>`,
-			`</ac:structured-macro>`,
+			`<ac:structured-macro ac:name="code">{{printf "\n"}}`,
+			`<ac:parameter ac:name="language">{{ .Language }}</ac:parameter>{{printf "\n"}}`,
+			`<ac:parameter ac:name="collapse">{{ .Collapse }}</ac:parameter>{{printf "\n"}}`,
+			`<ac:parameter ac:name="title">{{ .Title }}</ac:parameter>{{printf "\n"}}`,
+			`<ac:plain-text-body><![CDATA[{{ .Text | cdata }}]]></ac:plain-text-body>{{printf "\n"}}`,
+			`</ac:structured-macro>{{printf "\n"}}`,
 		),
 
 		`ac:status`: text(


### PR DESCRIPTION
Something I use in the docs often is the `<details><summary>` html block which allows to embed code blocks of any size without losing out on the readibility - you can open and close the thing as you like.

Now the problem is that Confluence doesn't parse it (or does it in a weird way - I don't remember) and instead they have their own _collapsible_ something, which is enabled through a flag in the `code` macro. This PR enables it, as well as the `title` field.

It's a bit of funky way to do it, but luckily `github`'s markdown/codeblock parser is flexible enough to allow this:

    ```python collapse title Hello this is a Beautiful codeblock

    def func():
        print("Beautiful")

    # ... and 200 more lines of funk
    ```

And on confluence it looks this way:

![image](https://user-images.githubusercontent.com/16212750/100541075-5bd2d300-3239-11eb-802c-a7fadc791ab0.png)

Best part is that github's version looks as usual, seems like they just ignore the extra words.

If we wrap it in

    <details>
    <summary>Hello this is a Beautiful codeblock</summary>

    ```python collapse title Hello this is a Beautiful codeblock

    def func():
        print("Beautiful")

    # ... and 200 more lines of funk
    ```
    </details>

We get

<details>
<summary>Hello this is a Beautiful codeblock</summary>

```python collapse title Hello this is a Beautiful codeblock

def func():
    print("Beautiful")

# ... and 200 more lines of funk
```
</details>

The lines that contain these tags have to be removed before uploading to confluence but that's specific to how I use it so may not apply to everyone - otherwise piping the file through `sed /<\/\?details>\|<\/\?summary>/d` removes them.

Let me know if I should remove the `printfs` from the template - it's a rather subjective change so I'm happy to let them go if you have doubts about them.