### PR TITLE
Add label support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ File in the extended format should follow the specification:
 <!-- Parent: <parent 2> -->
 <!-- Title: <title> -->
 <!-- Attachment: <local path> -->
+<!-- Label: <label 1> -->
+<!-- Label: <label 2> -->
 
 <page contents>
 ```

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ mark -h | --help
     manual edits over Confluence Web UI.
 - `--drop-h1` – Don't include H1 headings in Confluence output.
 - `--dry-run` — Show resulting HTML and don't update Confluence page content.
+- `--minor-edit` — Don't send notifications while updating Confluence page.
 - `--trace` — Enable trace logs.
 - `-v | --version` — Show version.
 - `-h | --help` — Show help screen and call 911.
@@ -283,6 +284,8 @@ password = "matrixishere"
 # If you are using Confluence Cloud add the /wiki suffix to base_url
 base_url = "http://confluence.local"
 ```
+
+**NOTE**: Labels aren't supported when using `minor-edit`!
 
 # Tricks
 

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ Options:
   --drop-h1            Don't include H1 headings in Confluence output.
   --dry-run            Resolve page and ancestry, show resulting HTML and exit.
   --compile-only       Show resulting HTML and don't update Confluence page content.
+  --minor-edit         Don't send notifications while updating Confluence page.
   --debug              Enable debug logs.
   --trace              Enable trace logs.
   -h --help            Show this screen and call 911.
@@ -62,6 +63,7 @@ func main() {
 		dryRun        = args["--dry-run"].(bool)
 		editLock      = args["-k"].(bool)
 		dropH1        = args["--drop-h1"].(bool)
+		minorEdit     = args["--minor-edit"].(bool)
 	)
 
 	if args["--debug"].(bool) {
@@ -240,7 +242,7 @@ func main() {
 		html = buffer.String()
 	}
 
-	err = api.UpdatePage(target, html, meta.Labels)
+	err = api.UpdatePage(target, html, minorEdit, meta.Labels)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -240,7 +240,7 @@ func main() {
 		html = buffer.String()
 	}
 
-	err = api.UpdatePage(target, html)
+	err = api.UpdatePage(target, html, meta.Labels)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/confluence/api.go
+++ b/pkg/confluence/api.go
@@ -434,7 +434,7 @@ func (api *API) CreatePage(
 }
 
 func (api *API) UpdatePage(
-	page *PageInfo, newContent string, newLabels []string,
+	page *PageInfo, newContent string, minorEdit bool, newLabels []string,
 ) error {
 	nextPageVersion := page.Version.Number + 1
 
@@ -467,7 +467,7 @@ func (api *API) UpdatePage(
 		"title": page.Title,
 		"version": map[string]interface{}{
 			"number":    nextPageVersion,
-			"minorEdit": false,
+			"minorEdit": minorEdit,
 		},
 		"ancestors": oldAncestors,
 		"body": map[string]interface{}{

--- a/pkg/confluence/api.go
+++ b/pkg/confluence/api.go
@@ -434,7 +434,7 @@ func (api *API) CreatePage(
 }
 
 func (api *API) UpdatePage(
-	page *PageInfo, newContent string,
+	page *PageInfo, newContent string, newLabels []string,
 ) error {
 	nextPageVersion := page.Version.Number + 1
 
@@ -448,6 +448,17 @@ func (api *API) UpdatePage(
 	// picking only the last one, which is required by confluence
 	oldAncestors := []map[string]interface{}{
 		{"id": page.Ancestors[len(page.Ancestors)-1].Id},
+	}
+
+	labels := []map[string]interface{}{}
+	for _, label := range newLabels {
+		if label != "" {
+			item := map[string]interface{}{
+				"prexix": "global",
+				"name":   label,
+			}
+			labels = append(labels, item)
+		}
 	}
 
 	payload := map[string]interface{}{
@@ -464,6 +475,9 @@ func (api *API) UpdatePage(
 				"value":          string(newContent),
 				"representation": "storage",
 			},
+		},
+		"metadata": map[string]interface{}{
+			"labels": labels,
 		},
 	}
 

--- a/pkg/mark/meta.go
+++ b/pkg/mark/meta.go
@@ -16,6 +16,7 @@ const (
 	HeaderTitle      = `Title`
 	HeaderLayout     = `Layout`
 	HeaderAttachment = `Attachment`
+	HeaderLabel      = `Label`
 )
 
 type Meta struct {
@@ -24,6 +25,7 @@ type Meta struct {
 	Title       string
 	Layout      string
 	Attachments map[string]string
+	Labels      []string
 }
 
 var (
@@ -89,6 +91,9 @@ func ExtractMeta(data []byte) (*Meta, []byte, error) {
 
 		case HeaderAttachment:
 			meta.Attachments[value] = value
+
+		case HeaderLabel:
+			meta.Labels = append(meta.Labels, value)
 
 		default:
 			log.Errorf(


### PR DESCRIPTION
Closes #34
Closes #50

Labeling support has been added intentionally into UpdatePage, so that labels can also be reset/removed easily. Tested successfully with Confluence server 7.4.1.