### PR TITLE
Join lines in compiled markdown so lists render in Confluence without…

### DIFF
--- a/pkg/mark/markdown.go
+++ b/pkg/mark/markdown.go
@@ -117,6 +117,7 @@ func CompileMarkdown(
 				blackfriday.EXTENSION_TITLEBLOCK |
 				blackfriday.EXTENSION_BACKSLASH_LINE_BREAK |
 				blackfriday.EXTENSION_DEFINITION_LISTS |
+				blackfriday.EXTENSION_JOIN_LINES |
 				blackfriday.EXTENSION_NO_EMPTY_LINE_BEFORE_BLOCK,
 		},
 	)


### PR DESCRIPTION
… extra whitespace