### PR TITLE
Add support to reading password from stdin

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"errors"
+	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/reconquest/karma-go"
@@ -45,6 +47,17 @@ func GetCredentials(
 					"flag or be stored in configuration file",
 			)
 		}
+	}
+
+	if password == "-" {
+		b, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, karma.Format(
+				err,
+				"unable to read password from stdin",
+			)
+		}
+		password = string(b)
 	}
 
 	url, err := url.Parse(targetURL)


### PR DESCRIPTION
I don't like passwords in configs or my bash history. This MR checks if the password is - and then reads from stdin instead. Blocks otherwise like other applications which do the same.

This allows you to pull your password out of a password manager and push it into the application with a pipe. 