### PR TITLE
Align ancestors printouts (actual, expected) while validating ancestry

### DIFF
--- a/pkg/mark/ancestry.go
+++ b/pkg/mark/ancestry.go
@@ -116,7 +116,7 @@ func ValidateAncestry(
 
 		return nil, karma.Describe("title", page.Title).
 			Describe("actual", strings.Join(actual, " > ")).
-			Describe("expected", strings.Join(ancestry, ">")).
+			Describe("expected", strings.Join(ancestry, " > ")).
 			Format(nil, "the page has fewer parents than expected")
 	}
 


### PR DESCRIPTION
Hi @kovetskiy ,

this tiny PR will just do a formating while printing out the expected ancestors while validating the ancestry tree.

### Before

```
2021-02-02 08:23:19.164 FATAL unable to resolve page
                              └─ the page has fewer parents than expected
                                 ├─ title: Test Page
                                 ├─ actual: Parent1 > Parent2 > Parent3 > Parent4 > Parent5 > Parent6
                                 ├─ expected: Parent1>Parent2>Parent3>Parent4>Parent5>Parent6>Test Page
                                 └─ title: Test Page
```

### After
```
2021-02-02 08:23:19.164 FATAL unable to resolve page
                              └─ the page has fewer parents than expected
                                 ├─ title: Test Page
                                 ├─ actual: Parent1 > Parent2 > Parent3 > Parent4 > Parent5 > Parent6
                                 ├─ expected: Parent1 > Parent2 > Parent3 > Parent4 > Parent5 > Parent6 > Test Page
                                 └─ title: Test Page
```

Best regards,