### PR TITLE
Add support for Confluence blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Also, optional following headers are supported:
   reading;
 * plain: content will fill all page;
 
+```markdown
+<!-- Type: (page|blogpost) -->
+```
+
+* (default) page: normal Confluence page - defaults to this if omitted
+* blogpost: [Blog post](https://confluence.atlassian.com/doc/blog-posts-834222533.html) in `Space`.  Cannot have `Parent`(s) 
+
 Mark supports Go templates, which can be included into article by using path
 to the template relative to current working dir, e.g.:
 

--- a/main.go
+++ b/main.go
@@ -191,16 +191,18 @@ func main() {
 		if err != nil {
 			log.Fatalf(
 				karma.Describe("title", meta.Title).Reason(err),
-				"unable to resolve page",
+				"unable to resolve %s",
+				meta.Type,
 			)
 		}
 
 		if page == nil {
-			page, err = api.CreatePage(meta.Space, parent, meta.Title, ``)
+			page, err = api.CreatePage(meta.Space, meta.Type, parent, meta.Title, ``)
 			if err != nil {
 				log.Fatalf(
 					err,
-					"can't create page %q",
+					"can't create %s %q",
+					meta.Type,
 					meta.Title,
 				)
 			}

--- a/pkg/mark/ancestry.go
+++ b/pkg/mark/ancestry.go
@@ -20,7 +20,7 @@ func EnsureAncestry(
 	rest := ancestry
 
 	for i, title := range ancestry {
-		page, err := api.FindPage(space, title)
+		page, err := api.FindPage(space, title, "page")
 		if err != nil {
 			return nil, karma.Format(
 				err,
@@ -66,7 +66,7 @@ func EnsureAncestry(
 
 	if !dryRun {
 		for _, title := range rest {
-			page, err := api.CreatePage(space, parent, title, ``)
+			page, err := api.CreatePage(space, "page", parent, title, ``)
 			if err != nil {
 				return nil, karma.Format(
 					err,
@@ -95,7 +95,7 @@ func ValidateAncestry(
 	space string,
 	ancestry []string,
 ) (*confluence.PageInfo, error) {
-	page, err := api.FindPage(space, ancestry[len(ancestry)-1])
+	page, err := api.FindPage(space, ancestry[len(ancestry)-1], "page")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mark/link.go
+++ b/pkg/mark/link.go
@@ -163,7 +163,7 @@ func getConfluenceLink(api *confluence.API, space, title string) (string, error)
 		url.QueryEscape(title),
 	)
 
-	page, err := api.FindPage(space, title)
+	page, err := api.FindPage(space, title, "page")
 	if err != nil {
 		return "", karma.Format(err, "api: find page")
 	}

--- a/pkg/mark/mark.go
+++ b/pkg/mark/mark.go
@@ -13,13 +13,23 @@ func ResolvePage(
 	api *confluence.API,
 	meta *Meta,
 ) (*confluence.PageInfo, *confluence.PageInfo, error) {
-	page, err := api.FindPage(meta.Space, meta.Title)
+	page, err := api.FindPage(meta.Space, meta.Title, meta.Type)
 	if err != nil {
 		return nil, nil, karma.Format(
 			err,
 			"error while finding page %q",
 			meta.Title,
 		)
+	}
+
+	if meta.Type == "blogpost" {
+		log.Infof(
+			nil,
+			"Blog post will be stored as: %s",
+			meta.Title,
+		)
+
+		return nil, page, nil
 	}
 
 	ancestry := meta.Parents

--- a/pkg/mark/meta.go
+++ b/pkg/mark/meta.go
@@ -13,6 +13,7 @@ import (
 const (
 	HeaderParent     = `Parent`
 	HeaderSpace      = `Space`
+	HeaderType       = `Type`
 	HeaderTitle      = `Title`
 	HeaderLayout     = `Layout`
 	HeaderAttachment = `Attachment`
@@ -23,6 +24,7 @@ const (
 type Meta struct {
 	Parents     []string
 	Space       string
+	Type        string
 	Title       string
 	Layout      string
 	Attachments map[string]string
@@ -67,6 +69,7 @@ func ExtractMeta(data []byte) (*Meta, []byte, error) {
 
 		if meta == nil {
 			meta = &Meta{}
+			meta.Type = "page" //Default if not specified
 			meta.Attachments = make(map[string]string)
 		}
 
@@ -83,6 +86,9 @@ func ExtractMeta(data []byte) (*Meta, []byte, error) {
 
 		case HeaderSpace:
 			meta.Space = strings.TrimSpace(value)
+
+		case HeaderType:
+			meta.Type = strings.TrimSpace(value)
 
 		case HeaderTitle:
 			meta.Title = strings.TrimSpace(value)


### PR DESCRIPTION
Addresses #78 by adding a `Type` metadata header that enables markdown files to be specified as `<!-- Type: blogpost -->`

Usage:

To post a blog post based given the following `my_blog_post.md`:
 
```
<!-- Space: ~myusername -->
<!-- Type: blogpost -->
<!-- Title: My Blog Post -->

This is my blog post content
```
simply run
```
$ mark -f my_blog_post.md
```