### PR TITLE
feat(sidebar): Add sidebar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Also, optional following headers are supported:
 * (default) page: normal Confluence page - defaults to this if omitted
 * blogpost: [Blog post](https://confluence.atlassian.com/doc/blog-posts-834222533.html) in `Space`.  Cannot have `Parent`(s) 
 
+```markdown
+<!-- Sidebar: <h2>Test</h2> -->
+```
+
+Setting the sidebar creates a column on the right side.  You're able to add any valid HTML content. Adding this property sets the layout to `article`.
+
 Mark supports Go templates, which can be included into article by using path
 to the template relative to current working dir, e.g.:
 

--- a/main.go
+++ b/main.go
@@ -299,11 +299,13 @@ func processFile(
 			&buffer,
 			"ac:layout",
 			struct {
-				Layout string
-				Body   string
+				Layout  string
+				Sidebar string
+				Body    string
 			}{
-				Layout: meta.Layout,
-				Body:   html,
+				Layout:  meta.Layout,
+				Sidebar: meta.Sidebar,
+				Body:    html,
 			},
 		)
 		if err != nil {

--- a/pkg/mark/meta.go
+++ b/pkg/mark/meta.go
@@ -19,6 +19,7 @@ const (
 	HeaderAttachment = `Attachment`
 	HeaderLabel      = `Label`
 	HeaderInclude    = `Include`
+	HeaderSidebar    = `Sidebar`
 )
 
 type Meta struct {
@@ -27,6 +28,7 @@ type Meta struct {
 	Type        string
 	Title       string
 	Layout      string
+	Sidebar     string
 	Attachments map[string]string
 	Labels      []string
 }
@@ -95,6 +97,10 @@ func ExtractMeta(data []byte) (*Meta, []byte, error) {
 
 		case HeaderLayout:
 			meta.Layout = strings.TrimSpace(value)
+
+		case HeaderSidebar:
+			meta.Layout = "article"
+			meta.Sidebar = strings.TrimSpace(value)
 
 		case HeaderAttachment:
 			meta.Attachments[value] = value

--- a/pkg/mark/stdlib/stdlib.go
+++ b/pkg/mark/stdlib/stdlib.go
@@ -95,7 +95,7 @@ func templates(api *confluence.API) (*template.Template, error) {
 			/**/ `<ac:layout>`,
 			/**/ `<ac:layout-section ac:type="two_right_sidebar">`,
 			/**/ `<ac:layout-cell>{{ .Body }}</ac:layout-cell>`,
-			/**/ `<ac:layout-cell></ac:layout-cell>`,
+			/**/ `<ac:layout-cell>{{ .Sidebar }}</ac:layout-cell>`,
 			/**/ `</ac:layout-section>`,
 			/**/ `</ac:layout>`,
 			`{{ else }}`,


### PR DESCRIPTION
Added an optional metadata header that allows users to set content in the right-side column. It does explicitly set the `Layout` to `article` when this option is enabled.