### PR TITLE
update the panel format

### DIFF
--- a/pkg/mark/stdlib/stdlib.go
+++ b/pkg/mark/stdlib/stdlib.go
@@ -149,10 +149,8 @@ func templates(api *confluence.API) (*template.Template, error) {
 		`ac:box`: text(
 			`<ac:structured-macro ac:name="{{ .Name }}">{{printf "\n"}}`,
 			`<ac:parameter ac:name="icon">{{ or .Icon "false" }}</ac:parameter>{{printf "\n"}}`,
-			`<ac:parameter ac:name="title">{{ or .Title "" }}</ac:parameter>{{printf "\n"}}`,
-			`<ac:rich-text-body>{{printf "\n"}}`,
-			`{{ .Body }}{{printf "\n"}}`,
-			`</ac:rich-text-body>{{printf "\n"}}`,
+			`{{ if .Title }}<ac:parameter ac:name="title">{{ .Title }}</ac:parameter>{{printf "\n"}}{{ end }}`,
+			`<ac:rich-text-body>{{ .Body }}</ac:rich-text-body>{{printf "\n"}}`,
 			`</ac:structured-macro>{{printf "\n"}}`,
 		),
 


### PR DESCRIPTION
I've tried to use the panel format but the output was not what I was expecting

![master](https://user-images.githubusercontent.com/1081600/125176394-56783680-e1d3-11eb-9290-08f0a6321408.png)

After applying the fix I have the expected output:

![fork](https://user-images.githubusercontent.com/1081600/125176412-74459b80-e1d3-11eb-8b45-ce16db165983.png)

---

I don't really know why the feature from https://github.com/kovetskiy/mark/pull/77 was not working. Is it a change from the new Confluence editor?
