### PR TITLE
allow space home update and its children pages

### DIFF
--- a/pkg/confluence/api.go
+++ b/pkg/confluence/api.go
@@ -474,18 +474,10 @@ func (api *API) UpdatePage(
 	nextPageVersion := page.Version.Number + 1
 	oldAncestors := []map[string]interface{}{}
 
-	if page.Type != "blogpost" {
-		if len(page.Ancestors) == 0 {
-			oldAncestors = nil
-			//return fmt.Errorf(
-			//	"page %q info does not contain any information about parents",
-			//	page.ID,
-			//)
-		} else {
-			// picking only the last one, which is required by confluence
-			oldAncestors = []map[string]interface{}{
-				{"id": page.Ancestors[len(page.Ancestors)-1].Id},
-			}
+	if page.Type != "blogpost" && len(page.Ancestors) > 0 {
+		// picking only the last one, which is required by confluence
+		oldAncestors = []map[string]interface{}{
+			{"id": page.Ancestors[len(page.Ancestors)-1].Id},
 		}
 	}
 

--- a/pkg/mark/ancestry.go
+++ b/pkg/mark/ancestry.go
@@ -104,7 +104,7 @@ func ValidateAncestry(
 		return nil, nil
 	}
 
-	is_homepage := false
+	isHomepage := false
 	if len(page.Ancestors) < 1 {
 		homepage, err := api.FindHomePage(space)
 		if err != nil {
@@ -117,13 +117,13 @@ func ValidateAncestry(
 
 		if page.ID == homepage.ID {
 			log.Debugf(nil, "page is homepage for space %q", space)
-			is_homepage = true
+			isHomepage = true
 		} else {
 			return nil, fmt.Errorf(`page %q has no parents`, page.Title)
 		}
 	}
 
-	if len(page.Ancestors) < len(ancestry) && is_homepage != true {
+	if len(page.Ancestors) < len(ancestry) && isHomepage != true {
 		actual := []string{}
 		for _, ancestor := range page.Ancestors {
 			actual = append(actual, ancestor.Title)

--- a/pkg/mark/ancestry.go
+++ b/pkg/mark/ancestry.go
@@ -104,11 +104,26 @@ func ValidateAncestry(
 		return nil, nil
 	}
 
+	is_homepage := false
 	if len(page.Ancestors) < 1 {
-		return nil, fmt.Errorf(`page %q has no parents`, page.Title)
+		homepage, err := api.FindHomePage(space)
+		if err != nil {
+			return nil, karma.Format(
+				err,
+				"can't obtain home page from space %q",
+				space,
+			)
+		}
+
+		if page.ID == homepage.ID {
+			log.Debugf(nil, "page is homepage for space %q", space)
+			is_homepage = true
+		} else {
+			return nil, fmt.Errorf(`page %q has no parents`, page.Title)
+		}
 	}
 
-	if len(page.Ancestors) < len(ancestry) {
+	if len(page.Ancestors) < len(ancestry) && is_homepage != true {
 		actual := []string{}
 		for _, ancestor := range page.Ancestors {
 			actual = append(actual, ancestor.Title)

--- a/pkg/mark/ancestry.go
+++ b/pkg/mark/ancestry.go
@@ -123,7 +123,7 @@ func ValidateAncestry(
 		}
 	}
 
-	if len(page.Ancestors) < len(ancestry) && isHomepage != true {
+	if !isHomepage && len(page.Ancestors) < len(ancestry) {
 		actual := []string{}
 		for _, ancestor := range page.Ancestors {
 			actual = append(actual, ancestor.Title)

--- a/pkg/mark/mark.go
+++ b/pkg/mark/mark.go
@@ -50,7 +50,7 @@ func ResolvePage(
 	}
 
 	ancestry := meta.Parents
-	if page != nil && skipHomeAncestry == false {
+	if page != nil && !skipHomeAncestry {
 		ancestry = append(ancestry, page.Title)
 	}
 

--- a/pkg/mark/mark.go
+++ b/pkg/mark/mark.go
@@ -32,8 +32,25 @@ func ResolvePage(
 		return nil, page, nil
 	}
 
+	// check to see if home page is in Parents
+	homepage, err := api.FindHomePage(meta.Space)
+	if err != nil {
+		return nil, nil, karma.Format(
+			err,
+			"can't obtain home page from space %q",
+			meta.Space,
+		)
+	}
+
+	skip_home_ancestry := false
+	if len(meta.Parents) > 0 {
+		if homepage.Title == meta.Parents[0] {
+			skip_home_ancestry = true
+		}
+	}
+
 	ancestry := meta.Parents
-	if page != nil {
+	if page != nil && skip_home_ancestry == false {
 		ancestry = append(ancestry, page.Title)
 	}
 

--- a/pkg/mark/mark.go
+++ b/pkg/mark/mark.go
@@ -42,15 +42,15 @@ func ResolvePage(
 		)
 	}
 
-	skip_home_ancestry := false
+	skipHomeAncestry := false
 	if len(meta.Parents) > 0 {
 		if homepage.Title == meta.Parents[0] {
-			skip_home_ancestry = true
+			skipHomeAncestry = true
 		}
 	}
 
 	ancestry := meta.Parents
-	if page != nil && skip_home_ancestry == false {
+	if page != nil && skipHomeAncestry == false {
 		ancestry = append(ancestry, page.Title)
 	}
 


### PR DESCRIPTION
This patch allows editing a Space Home Page as defined in Confluence Space Settings. It also allows to create/update the home page's direct children using a parent meta:

```
<!-- Parent: Space Home -->
```

If a page isn't a direct child of the space homepage, the above parent *should not* be present.

Notice that this will also query confluence API on `/space/{spaceKey}` to check which page is defined as the Space Home. This happens on every run.

Should resolve Issue #88 