### PR TITLE
Response for updated attachment corrected for jira cloud

### DIFF
--- a/pkg/confluence/api.go
+++ b/pkg/confluence/api.go
@@ -262,12 +262,7 @@ func (api *API) UpdateAttachment(
 		return AttachmentInfo{}, err
 	}
 
-	var result struct {
-		Links struct {
-			Context string `json:"context"`
-		} `json:"_links"`
-		Results []AttachmentInfo `json:"results"`
-	}
+	var result AttachmentInfo
 
 	resource := api.rest.Res(
 		"content/"+pageID+"/child/attachment/"+attachID+"/data", &result,
@@ -288,22 +283,7 @@ func (api *API) UpdateAttachment(
 		return info, newErrorStatusNotOK(request)
 	}
 
-	if len(result.Results) == 0 {
-		return info, errors.New(
-			"Confluence REST API for creating attachments returned " +
-				"0 json objects, expected at least 1",
-		)
-	}
-
-	for i, info := range result.Results {
-		if info.Links.Context == "" {
-			info.Links.Context = result.Links.Context
-		}
-
-		result.Results[i] = info
-	}
-
-	info = result.Results[0]
+	info = result
 
 	return info, nil
 }


### PR DESCRIPTION
Fixes issue #94

I am debugging this and looks like for `POST /wiki/rest/api/content/{id}/child/attachment/{attachmentId}/data` the API returns a 

```
{ attachment }
```

instead of

```
{ "results": [attachment] }
```

The [docs on the cloud version](https://developer.atlassian.com/cloud/confluence/rest/api-group-content---attachments/#api-wiki-rest-api-content-id-child-attachment-attachmentid-data-post) do not specify the return format so I cannot be sure the hosted version works the same way exactly.

Be aware that I only have a Jira Cloud available so maybe this breaks Jira hosted.