### PR TITLE
Homebrew tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,7 +50,7 @@ brews:
 
     homepage: "https://github.com/kovetskiy/mark"
     description: "Sync your markdown files with Confluence pages."
-    license: "Apache 2,0"
+    license: "Apache 2.0"
 
     test: |
       system "#{bin}/program", "version"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,3 +30,27 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+
+# Publish on Homebrew Tap
+brews:
+  -
+    name: mark
+    tap:
+      owner: kovetskiy
+      name: homebrew-mark
+      branch: master
+
+    commit_author:
+      name: Egor Kovetskiy
+      email: e.kovetskiy@gmail.com
+
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+
+    folder: Formula
+
+    homepage: "https://github.com/kovetskiy/mark"
+    description: "Sync your markdown files with Confluence pages."
+    license: "Apache 2,0"
+
+    test: |
+      system "#{bin}/program", "version"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Also, optional following headers are supported:
 ```
 
 * (default) page: normal Confluence page - defaults to this if omitted
-* blogpost: [Blog post](https://confluence.atlassian.com/doc/blog-posts-834222533.html) in `Space`.  Cannot have `Parent`(s) 
+* blogpost: [Blog post](https://confluence.atlassian.com/doc/blog-posts-834222533.html) in `Space`.  Cannot have `Parent`(s)
 
 ```markdown
 <!-- Sidebar: <h2>Test</h2> -->
@@ -376,6 +376,13 @@ See task MYJIRA-123.
 ```
 
 ## Installation
+
+### Homebrew
+
+```bash
+brew tap kovetskiy/mark
+brew install mark
+```
 
 ### Go Get
 


### PR DESCRIPTION
This PR address #135 

Since Goreleaser already has a brew step feature we can take advantage of it.

**Requirements:**

* @kovetskiy needs to create a new repo named `homebrew-mark` which will be used to store the tap
* Make sure the `secrets.TOKEN` used in your Github actions has permissions to write on that repo

**How does it work?**

1. You create a new tag and push it, and your Github actions will trigger goreleaser (it already happens today)
2. Goreleaser build the application and upload binaries to the release (also happening today)
3. Go release go further and create a new commit in the new repo homebrew-mark
4. Mac and Linux users profit