### PR TITLE
feat: update to go 1.17

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set Up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.14
+        go-version: 1.17
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/go.mod
+++ b/go.mod
@@ -1,25 +1,34 @@
 module github.com/kovetskiy/mark
 
-go 1.14
+go 1.17
 
 require (
-	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
-	github.com/go-yaml/yaml v2.1.0+incompatible // indirect
-	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334 // indirect
 	github.com/kovetskiy/blackfriday/v2 v2.3.0
 	github.com/kovetskiy/gopencils v0.0.0-20210811071033-d690b7a013fb
 	github.com/kovetskiy/ko v0.0.0-20190324102900-26b8dd0988bf
 	github.com/kovetskiy/lorg v0.0.0-20200107130803-9a7136a95634
-	github.com/kovetskiy/toml v0.2.0 // indirect
-	github.com/kr/pretty v0.1.0 // indirect
 	github.com/reconquest/karma-go v0.0.0-20200326104714-79480464fdb5
 	github.com/reconquest/pkg v0.0.0-20201028091908-8e9a5e0226ef
 	github.com/reconquest/regexputil-go v0.0.0-20160905154124-38573e70c1f4
 	github.com/stretchr/testify v1.5.1
+	gopkg.in/yaml.v2 v2.2.8
+)
+
+require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-yaml/yaml v2.1.0+incompatible // indirect
+	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334 // indirect
+	github.com/kovetskiy/toml v0.2.0 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/reconquest/cog v0.0.0-20191208202052-266c2467b936 // indirect
+	github.com/reconquest/colorgful v0.0.0-20190805091748-28d18b838c4a // indirect
+	github.com/reconquest/loreley v0.0.0-20200601121626-621c1cd37fd1 // indirect
+	github.com/zazab/zhash v0.0.0-20170403032415-ad45b89afe7a // indirect
 	golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f // indirect
 	golang.org/x/sys v0.0.0-20200116001909-b77594299b42 // indirect
+	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/yaml.v2 v2.2.8
 )


### PR DESCRIPTION
https://github.com/kovetskiy/mark/runs/4466809768?check_suite_focus=true#step:4:32

```
      • building binaries
         • DEPRECATED: skipped darwin/arm64 build on Go < 1.16 for compatibility, check https://goreleaser.com/deprecations/#builds-for-darwinarm64 for more info.
         • DEPRECATED: skipped windows/arm64 build on Go < 1.17 for compatibility, check https://goreleaser.com/deprecations/#builds-for-windowsarm64 for more info.
```

These artifacts were being blocked by goreleaser.  I added https://github.com/jfreeland/asdf-mark to https://github.com/asdf-vm/asdf-plugins and it works great on everything except my M1. 🤦

I:
* updated go.mod to `go 1.17`
* ran `go mod tidy`
* confirmed that the binary still builds and works as intended