### PR TITLE
Fix for subdirectories related attachments (issue #31)

### DIFF
--- a/main.go
+++ b/main.go
@@ -289,7 +289,7 @@ func processFile(
 		target = page
 	}
 
-	attaches, err := mark.ResolveAttachments(api, target, ".", meta.Attachments)
+	attaches, err := mark.ResolveAttachments(api, target, filepath.Dir(file), meta.Attachments)
 	if err != nil {
 		log.Fatalf(err, "unable to create/update attachments")
 	}

--- a/pkg/mark/attachment_test.go
+++ b/pkg/mark/attachment_test.go
@@ -1,0 +1,55 @@
+package mark
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var (
+	replacements = []string{
+		"image1.jpg",
+		"images/image2.jpg",
+		"../image3.jpg",
+	}
+)
+
+func TestPrepareAttachmentsWithWorkDirBase(t *testing.T) {
+
+	attaches, err := prepareAttachments(".", replacements)
+	if err != nil {
+		println(err.Error())
+	}
+
+	assert.Equal(t, "image1.jpg", attaches[0].Name)
+	assert.Equal(t, "image1.jpg", attaches[0].Replace)
+	assert.Equal(t, "image1.jpg", attaches[0].Path)
+
+	assert.Equal(t, "images/image2.jpg", attaches[1].Name)
+	assert.Equal(t, "images/image2.jpg", attaches[1].Replace)
+	assert.Equal(t, "images/image2.jpg", attaches[1].Path)
+
+	assert.Equal(t, "../image3.jpg", attaches[2].Name)
+	assert.Equal(t, "../image3.jpg", attaches[2].Replace)
+	assert.Equal(t, "../image3.jpg", attaches[2].Path)
+
+	assert.Equal(t, len(attaches), 3)
+}
+
+func TestPrepareAttachmentsWithSubDirBase(t *testing.T) {
+
+	attaches, _ := prepareAttachments("a/b", replacements)
+
+	assert.Equal(t, "image1.jpg", attaches[0].Name)
+	assert.Equal(t, "image1.jpg", attaches[0].Replace)
+	assert.Equal(t, "a/b/image1.jpg", attaches[0].Path)
+
+	assert.Equal(t, "images/image2.jpg", attaches[1].Name)
+	assert.Equal(t, "images/image2.jpg", attaches[1].Replace)
+	assert.Equal(t, "a/b/images/image2.jpg", attaches[1].Path)
+
+	assert.Equal(t, "../image3.jpg", attaches[2].Name)
+	assert.Equal(t, "../image3.jpg", attaches[2].Replace)
+	assert.Equal(t, "a/image3.jpg", attaches[2].Path)
+
+	assert.Equal(t, len(attaches), 3)
+}

--- a/pkg/mark/meta.go
+++ b/pkg/mark/meta.go
@@ -29,7 +29,7 @@ type Meta struct {
 	Title       string
 	Layout      string
 	Sidebar     string
-	Attachments map[string]string
+	Attachments []string
 	Labels      []string
 }
 
@@ -72,7 +72,6 @@ func ExtractMeta(data []byte) (*Meta, []byte, error) {
 		if meta == nil {
 			meta = &Meta{}
 			meta.Type = "page" //Default if not specified
-			meta.Attachments = make(map[string]string)
 		}
 
 		header := strings.Title(matches[1])
@@ -103,7 +102,7 @@ func ExtractMeta(data []byte) (*Meta, []byte, error) {
 			meta.Sidebar = strings.TrimSpace(value)
 
 		case HeaderAttachment:
-			meta.Attachments[value] = value
+			meta.Attachments = append(meta.Attachments, value)
 
 		case HeaderLabel:
 			meta.Labels = append(meta.Labels, value)


### PR DESCRIPTION
Fixed by setting the base path to the current file directory. Also replaced map with an array for 'replacements' as map has the same key and value.