### PR TITLE
Space from config and title from h1

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,9 @@ mark -h | --help
 - `-c <path>` or `--config <path>` — Specify a path to the configuration file.
 - `-k` — Lock page editing to current user only to prevent accidental
     manual edits over Confluence Web UI.
+- `--space <space>` - Use specified space key. If not specified space ley must be set in a page metadata.
 - `--drop-h1` – Don't include H1 headings in Confluence output.
+- `--title-from-h1` - Extract page title from a leading H1 heading. If no H1 heading on a page then title must be set in a page metadata.
 - `--dry-run` — Show resulting HTML and don't update Confluence page content.
 - `--minor-edit` — Don't send notifications while updating Confluence page.
 - `--trace` — Enable trace logs.

--- a/pkg/mark/markdown.go
+++ b/pkg/mark/markdown.go
@@ -147,3 +147,14 @@ func DropDocumentLeadingH1(
 	markdown = h1.ReplaceAll(markdown, []byte(""))
 	return markdown
 }
+
+// ExtractDocumentLeadingH1 will extract leading H1 heading
+func ExtractDocumentLeadingH1(markdown []byte) string {
+	h1 := regexp.MustCompile(`^#[^#]\s*(.*)\s*\n`)
+	groups := h1.FindSubmatch(markdown)
+	if groups == nil {
+		return ""
+	} else {
+		return string(groups[1])
+	}
+}

--- a/pkg/mark/markdown_test.go
+++ b/pkg/mark/markdown_test.go
@@ -48,3 +48,16 @@ func TestCompileMarkdown(t *testing.T) {
 		test.EqualValues(string(html), actual, filename+" vs "+htmlname)
 	}
 }
+
+func TestExtractDocumentLeadingH1(t *testing.T) {
+	filename := "testdata/header.md"
+
+	markdown, err := ioutil.ReadFile(filename)
+	if err != nil {
+		panic(err)
+	}
+
+	actual := ExtractDocumentLeadingH1(markdown)
+
+	assert.Equal(t, "a", actual)
+}

--- a/pkg/mark/meta.go
+++ b/pkg/mark/meta.go
@@ -128,19 +128,5 @@ func ExtractMeta(data []byte) (*Meta, []byte, error) {
 		return nil, data, nil
 	}
 
-	if meta.Space == "" {
-		return nil, nil, fmt.Errorf(
-			"space key is not set (%s header is not set)",
-			HeaderSpace,
-		)
-	}
-
-	if meta.Title == "" {
-		return nil, nil, fmt.Errorf(
-			"page title is not set (%s header is not set)",
-			HeaderTitle,
-		)
-	}
-
 	return meta, data[offset:], nil
 }


### PR DESCRIPTION
This PR resolves:
Support defining space from config #96
Support page title from first h1 #95

--space and --title-from-h1 options were added. If Space is defined both in metadata and in a command line then the value from file metadata overrides the value from CL. If Title is defined in metadata it's being used regardless of is H1 header was set in a file or not.