### PR TITLE
bugfix: Force pages to default width.

### DIFF
--- a/pkg/confluence/api.go
+++ b/pkg/confluence/api.go
@@ -552,6 +552,16 @@ func (api *API) UpdatePage(
 		},
 		"metadata": map[string]interface{}{
 			"labels": labels,
+			// The Confluence API randomly sets page width for some reason:
+			// https://community.developer.atlassian.com/t/confluence-rest-api-create-content-at-random-width/57001
+
+			// This is a workaround to compensate for that bug. It forces the page to be created
+			// with the default appearance, which is "fixed" (not full-width).
+			"properties": map[string]interface{}{
+				"content-appearance-published": map[string]interface{}{
+					"value": "default",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
This change is to compensate for an API bug in Confluence where newly
create pages end up getting a random width of either "fixed" or "full".

Fixes #173