### PR TITLE
fix: remove double collapse for codeboxes

### DIFF
--- a/pkg/mark/stdlib/stdlib.go
+++ b/pkg/mark/stdlib/stdlib.go
@@ -106,10 +106,6 @@ func templates(api *confluence.API) (*template.Template, error) {
 
 		// This template is used for rendering code in ```
 		`ac:code`: text(
-			`{{ if .Collapse }}<ac:structured-macro ac:name="expand">{{printf "\n"}}`,
-			`{{ if .Title }}<ac:parameter ac:name="title">{{ .Title }}</ac:parameter>{{printf "\n"}}{{ end }}`,
-			`<ac:rich-text-body>{{printf "\n"}}{{ end }}`,
-
 			`<ac:structured-macro ac:name="{{ if eq .Language "mermaid" }}cloudscript-confluence-mermaid{{ else }}code{{ end }}">{{printf "\n"}}`,
 			/**/ `{{ if eq .Language "mermaid" }}<ac:parameter ac:name="showSource">true</ac:parameter>{{printf "\n"}}{{ else }}`,
 			/**/ `<ac:parameter ac:name="language">{{ .Language }}</ac:parameter>{{printf "\n"}}{{ end }}`,
@@ -117,9 +113,6 @@ func templates(api *confluence.API) (*template.Template, error) {
 			/**/ `{{ if .Title }}<ac:parameter ac:name="title">{{ .Title }}</ac:parameter>{{printf "\n"}}{{ end }}`,
 			/**/ `<ac:plain-text-body><![CDATA[{{ .Text | cdata }}]]></ac:plain-text-body>{{printf "\n"}}`,
 			`</ac:structured-macro>{{printf "\n"}}`,
-
-			`{{ if .Collapse }}</ac:rich-text-body>{{printf "\n"}}`,
-			`</ac:structured-macro>{{printf "\n"}}{{ end }}`,
 		),
 
 		`ac:status`: text(

--- a/pkg/mark/testdata/codes.html
+++ b/pkg/mark/testdata/codes.html
@@ -34,25 +34,16 @@ text 2</p>
 <ac:parameter ac:name="title">A b c</ac:parameter>
 <ac:plain-text-body><![CDATA[no-collapse-title]]></ac:plain-text-body>
 </ac:structured-macro>
-<ac:structured-macro ac:name="expand">
-<ac:parameter ac:name="title">A b c</ac:parameter>
-<ac:rich-text-body>
 <ac:structured-macro ac:name="code">
 <ac:parameter ac:name="language">bash</ac:parameter>
 <ac:parameter ac:name="collapse">true</ac:parameter>
 <ac:parameter ac:name="title">A b c</ac:parameter>
 <ac:plain-text-body><![CDATA[collapse-and-title]]></ac:plain-text-body>
 </ac:structured-macro>
-</ac:rich-text-body>
-</ac:structured-macro>
-<ac:structured-macro ac:name="expand">
-<ac:rich-text-body>
 <ac:structured-macro ac:name="code">
 <ac:parameter ac:name="language">c</ac:parameter>
 <ac:parameter ac:name="collapse">true</ac:parameter>
 <ac:plain-text-body><![CDATA[collapse-no-title]]></ac:plain-text-body>
-</ac:structured-macro>
-</ac:rich-text-body>
 </ac:structured-macro>
 <ac:structured-macro ac:name="cloudscript-confluence-mermaid">
 <ac:parameter ac:name="showSource">true</ac:parameter>
@@ -63,9 +54,6 @@ text 2</p>
     B-->D;
     C-->D;]]></ac:plain-text-body>
 </ac:structured-macro>
-<ac:structured-macro ac:name="expand">
-<ac:parameter ac:name="title">my mermaid graph</ac:parameter>
-<ac:rich-text-body>
 <ac:structured-macro ac:name="cloudscript-confluence-mermaid">
 <ac:parameter ac:name="showSource">true</ac:parameter>
 <ac:parameter ac:name="collapse">true</ac:parameter>
@@ -75,8 +63,6 @@ text 2</p>
     A-->C;
     B-->D;
     C-->D;]]></ac:plain-text-body>
-</ac:structured-macro>
-</ac:rich-text-body>
 </ac:structured-macro>
 <ac:structured-macro ac:name="cloudscript-confluence-mermaid">
 <ac:parameter ac:name="showSource">true</ac:parameter>


### PR DESCRIPTION
This fixes a bug where if you used the code macro the renderer would create
an additional expand macro if the collapse option was set. This led to
the code section being collapsible twice.

It is unclear why it was there but maybe there was a reason in earlier confluence versions
that is no longer valid?