### PR TITLE
Fix for relative links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /testdata
 .idea/
 /mark.test
+.vscode/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM golang:latest
 ENV GOPATH="/go"
-WORKDIR /go/src/github.com/jack-fireworkhq/mark
+WORKDIR /go/src/github.com/kovetskiy/mark
 COPY / .
 RUN make get
 RUN make build
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates bash git
-COPY --from=0 /go/src/github.com/jack-fireworkhq/mark /bin/
+COPY --from=0 /go/src/github.com/kovetskiy/mark/mark /bin/
 RUN mkdir -p /docs
 WORKDIR /docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM golang:latest
 ENV GOPATH="/go"
-WORKDIR /go/src/github.com/kovetskiy/mark
+WORKDIR /go/src/github.com/jack-fireworkhq/mark
 COPY / .
 RUN make get
 RUN make build
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates bash git
-COPY --from=0 /go/src/github.com/kovetskiy/mark/mark /bin/
+COPY --from=0 /go/src/github.com/jack-fireworkhq/mark /bin/
 RUN mkdir -p /docs
 WORKDIR /docs

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ type Flags struct {
 	Username       string `docopt:"-u"`
 	Password       string `docopt:"-p"`
 	TargetURL      string `docopt:"-l"`
+	FilesList 	   []string `docopt:"-L"`
 	BaseURL        string `docopt:"--base-url"`
 	Config         string `docopt:"--config"`
 	Ci             bool   `docopt:"--ci"`
@@ -47,6 +48,7 @@ Docs: https://github.com/kovetskiy/mark
 Usage:
   mark [options] [-u <username>] [-p <token>] [-k] [-l <url>] -f <file>
   mark [options] [-u <username>] [-p <password>] [-k] [-b <url>] -f <file>
+  mark [options] [-u <username>] [-p <password>] [-k] [-b <url>] [-L <file>...]
   mark -v | --version
   mark -h | --help
 
@@ -59,6 +61,7 @@ Options:
   -l <url>             Edit specified Confluence page.
                         If -l is not specified, file should contain metadata (see
                         above).
+  -L <fileslist>       List of files. Use this option multiple times to pass files to Confluence.
   -b --base-url <url>  Base URL for Confluence.
                         Alternative option for base_url config field.
   -f <file>            Use specified markdown file(s) for converting to html.
@@ -86,6 +89,12 @@ Options:
 )
 
 func main() {
+	// args := []string{"-u","", 
+	// "-p", "", 
+	// "-k",
+	// "-b", "",
+	// "-L", "/home/xxxxx/file",
+	// "-L", "/home/xxxxx/file"}
 	cmd, err := docopt.ParseArgs(os.ExpandEnv(usage), nil, version)
 	if err != nil {
 		panic(err)
@@ -126,7 +135,14 @@ func main() {
 
 	api := confluence.NewAPI(creds.BaseURL, creds.Username, creds.Password)
 
-	files, err := filepath.Glob(flags.FileGlobPatten)
+	var files []string
+	if len(flags.FilesList) != 0 {
+		files = flags.FilesList
+		err = nil
+	} else {
+		files, err = filepath.Glob(flags.FileGlobPatten)
+	}
+
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -140,6 +156,7 @@ func main() {
 	}
 
 	// Loop through files matched by glob pattern
+	var fails []string
 	for _, file := range files {
 		log.Infof(
 			nil,
@@ -147,7 +164,8 @@ func main() {
 			file,
 		)
 
-		target := processFile(file, api, flags, creds.PageID, creds.Username)
+		target, relative_falis := processFile(file, api, flags, creds.PageID, creds.Username)
+		fails = append(fails, relative_falis...)
 
 		log.Infof(
 			nil,
@@ -157,6 +175,27 @@ func main() {
 
 		fmt.Println(creds.BaseURL + target.Links.Full)
 	}
+
+	// Try again with relative resolved fails
+	if len(fails) > 0 {
+		for _, file := range fails {
+			log.Infof(
+				nil,
+				"try again to resolve relative links of %s",
+				file,
+			)
+			target, _ := processFile(file, api, flags, creds.PageID, creds.Username)
+
+			log.Infof(
+				nil,
+				"done retry relative resolve for: %s",
+				creds.BaseURL+target.Links.Full,
+			)
+
+			fmt.Println(creds.BaseURL + target.Links.Full)
+
+		}
+	}
 }
 
 func processFile(
@@ -165,7 +204,8 @@ func processFile(
 	flags Flags,
 	pageID string,
 	username string,
-) *confluence.PageInfo {
+) (*confluence.PageInfo, []string) {
+	var rfails []string
 	markdown, err := ioutil.ReadFile(file)
 	if err != nil {
 		log.Fatal(err)
@@ -240,9 +280,11 @@ func processFile(
 		}
 	}
 
-	links, err := mark.ResolveRelativeLinks(api, meta, markdown, ".")
+	base, _ := filepath.Split(file)
+	links, err := mark.ResolveRelativeLinks(api, meta, markdown, base)
 	if err != nil {
-		log.Fatalf(err, "unable to resolve relative links")
+		log.Warningf(err, "unable to resolve relative links in %s", file)
+		rfails = append(rfails, file)
 	}
 
 	markdown = mark.SubstituteLinks(markdown, links)
@@ -385,5 +427,5 @@ func processFile(
 		}
 	}
 
-	return target
+	return target, rfails
 }


### PR DESCRIPTION
Hi Kovetskiy, First of all, thank you for creating this great repo. 

I have done some effort to resolve kovetskiy/mark#55, I think the main cause for this is [here](https://github.com/kovetskiy/mark/blob/5428cc683302a7679901e23d4e97fc83838a788b/main.go#L261) which makes Mark failed to find relative links. 
I fixed it with [code here](https://github.com/jack-fireworkhq/mark/blob/67d7b490f39166455a13abc74a7e53d41ef313c5/main.go#L301).

Besides that, I add a "-L" option so that Mark can take many files at the same time as input. 
I did that to let users be able to synchronize files references with relative links to each other. 
I add a loop [here](https://github.com/jack-fireworkhq/mark/blob/67d7b490f39166455a13abc74a7e53d41ef313c5/main.go#L181) to retry resolve relative links after everything was synchronized to Confluence once.

I tested this with the [Github action](https://github.com/jack-fireworkhq/action-confluence-sync/blob/develop/action.yml) I forked and modified it, and Mark works as my expectation.
Leave some comments if you feel some code needs to be changed.