### PR TITLE
Added a command line option that reduces attachment filenames to thei…

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ mark -h | --help
 - `--dry-run` — Show resulting HTML and don't update Confluence page content.
 - `--minor-edit` — Don't send notifications while updating Confluence page.
 - `--trace` — Enable trace logs.
+- `--attachment-basename` — Don't include attachment paths in attachment names.
 - `-v | --version` — Show version.
 - `-h | --help` — Show help screen and call 911.
 

--- a/main.go
+++ b/main.go
@@ -20,23 +20,24 @@ import (
 )
 
 type Flags struct {
-	FileGlobPatten string `docopt:"-f"`
-	CompileOnly    bool   `docopt:"--compile-only"`
-	DryRun         bool   `docopt:"--dry-run"`
-	EditLock       bool   `docopt:"-k"`
-	DropH1         bool   `docopt:"--drop-h1"`
-	TitleFromH1    bool   `docopt:"--title-from-h1"`
-	MinorEdit      bool   `docopt:"--minor-edit"`
-	Color          string `docopt:"--color"`
-	Debug          bool   `docopt:"--debug"`
-	Trace          bool   `docopt:"--trace"`
-	Username       string `docopt:"-u"`
-	Password       string `docopt:"-p"`
-	TargetURL      string `docopt:"-l"`
-	BaseURL        string `docopt:"--base-url"`
-	Config         string `docopt:"--config"`
-	Ci             bool   `docopt:"--ci"`
-	Space          string `docopt:"--space"`
+	FileGlobPatten     string `docopt:"-f"`
+	CompileOnly        bool   `docopt:"--compile-only"`
+	DryRun             bool   `docopt:"--dry-run"`
+	EditLock           bool   `docopt:"-k"`
+	DropH1             bool   `docopt:"--drop-h1"`
+	TitleFromH1        bool   `docopt:"--title-from-h1"`
+	MinorEdit          bool   `docopt:"--minor-edit"`
+	Color              string `docopt:"--color"`
+	Debug              bool   `docopt:"--debug"`
+	Trace              bool   `docopt:"--trace"`
+	Username           string `docopt:"-u"`
+	Password           string `docopt:"-p"`
+	TargetURL          string `docopt:"-l"`
+	BaseURL            string `docopt:"--base-url"`
+	Config             string `docopt:"--config"`
+	Ci                 bool   `docopt:"--ci"`
+	Space          	   string `docopt:"--space"`
+	AttachmentBasename bool   `docopt:"--attachment-basename"`
 }
 
 const (
@@ -52,37 +53,38 @@ Usage:
   mark -h | --help
 
 Options:
-  -u <username>        Use specified username for updating Confluence page.
-  -p <token>           Use specified token for updating Confluence page.
-                        Specify - as password to read password from stdin, or your Personal access token.
-                        Username is not mandatory if personal access token is provided.
-                        For more info please see: https://developer.atlassian.com/server/confluence/confluence-server-rest-api/#authentication.
-  -l <url>             Edit specified Confluence page.
-                        If -l is not specified, file should contain metadata (see
-                        above).
-  -b --base-url <url>  Base URL for Confluence.
-                        Alternative option for base_url config field.
-  -f <file>            Use specified markdown file(s) for converting to html.
-                        Supports file globbing patterns (needs to be quoted).
-  -k                   Lock page editing to current user only to prevent accidental
-                        manual edits over Confluence Web UI.
-  --space <space>      Use specified space key. If not specified space ley must
-                        be set in a page metadata.
-  --drop-h1            Don't include H1 headings in Confluence output.
-  --title-from-h1      Extract page title from a leading H1 heading. If no H1 heading
-                        on a page then title must be set in a page metadata.
-  --dry-run            Resolve page and ancestry, show resulting HTML and exit.
-  --compile-only       Show resulting HTML and don't update Confluence page content.
-  --minor-edit         Don't send notifications while updating Confluence page.
-  --debug              Enable debug logs.
-  --trace              Enable trace logs.
-  --color <when>       Display logs in color. Possible values: auto, never.
-                        [default: auto]
-  -c --config <path>   Use the specified configuration file.
-                        [default: $HOME/.config/mark]
-  --ci                 Runs on CI mode. It won't fail if files are not found.
-  -h --help            Show this message.
-  -v --version         Show version.
+  -u <username>          Use specified username for updating Confluence page.
+  -p <token>             Use specified token for updating Confluence page.
+                          Specify - as password to read password from stdin, or your Personal access token.
+                          Username is not mandatory if personal access token is provided.
+                          For more info please see: https://developer.atlassian.com/server/confluence/confluence-server-rest-api/#authentication.
+  -l <url>               Edit specified Confluence page.
+                          If -l is not specified, file should contain metadata (see
+                          above).
+  -b --base-url <url>    Base URL for Confluence.
+                          Alternative option for base_url config field.
+  -f <file>              Use specified markdown file(s) for converting to html.
+                          Supports file globbing patterns (needs to be quoted).
+  -k                     Lock page editing to current user only to prevent accidental
+                          manual edits over Confluence Web UI.
+  --space <space>        Use specified space key. If not specified space ley must
+                          be set in a page metadata.
+  --drop-h1              Don't include H1 headings in Confluence output.
+  --title-from-h1        Extract page title from a leading H1 heading. If no H1 heading
+                          on a page then title must be set in a page metadata.
+  --dry-run              Resolve page and ancestry, show resulting HTML and exit.
+  --compile-only         Show resulting HTML and don't update Confluence page content.
+  --minor-edit           Don't send notifications while updating Confluence page.
+  --debug                Enable debug logs.
+  --trace                Enable trace logs.
+  --color <when>         Display logs in color. Possible values: auto, never.
+                          [default: auto]
+  -c --config <path>     Use the specified configuration file.
+                          [default: $HOME/.config/mark]
+  --ci                   Runs on CI mode. It won't fail if files are not found.
+  --attachment-basename  Don't include attachment paths in attachment names.
+  -h --help              Show this message.
+  -v --version           Show version.
 `
 )
 
@@ -329,6 +331,7 @@ func processFile(
 
 	attaches, err := mark.ResolveAttachments(
 		api,
+		flags.AttachmentBasename,
 		target,
 		filepath.Dir(file),
 		meta.Attachments,

--- a/pkg/mark/attachment.go
+++ b/pkg/mark/attachment.go
@@ -33,11 +33,12 @@ type Attachment struct {
 
 func ResolveAttachments(
 	api *confluence.API,
+	attachmentBasename bool,
 	page *confluence.PageInfo,
 	base string,
 	replacements []string,
 ) ([]Attachment, error) {
-	attaches, err := prepareAttachments(base, replacements)
+	attaches, err := prepareAttachments(base, replacements, attachmentBasename)
 	if err != nil {
 		return nil, err
 	}
@@ -155,12 +156,18 @@ func ResolveAttachments(
 	return attaches, nil
 }
 
-func prepareAttachments(base string, replacements []string) ([]Attachment, error) {
+func prepareAttachments(base string, replacements []string, attachmentBasename bool) ([]Attachment, error) {
 	attaches := []Attachment{}
 	for _, name := range replacements {
+		var filename string
+		if attachmentBasename {
+			filename = filepath.Base(name)
+		} else {
+			filename = strings.ReplaceAll(name, "/", "_")
+		}
 		attach := Attachment{
 			Name:     name,
-			Filename: strings.ReplaceAll(name, "/", "_"),
+			Filename: filename,
 			Path:     filepath.Join(base, name),
 			Replace:  name,
 		}


### PR DESCRIPTION
…r basename only instead of containing the whole local path as a prefix, which can be ugly especially if the local path uses upwards directory movement resulting in something like ".._.._.._dir_Attachment.txt" instead of "Attachment.txt". The command line option is opt-in, which means this addition does not break anything.