### PR TITLE
Add option to remove linebreaks within pagragraph tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ mark -h | --help
     manual edits over Confluence Web UI.
 - `--space <space>` - Use specified space key. If not specified space ley must be set in a page metadata.
 - `--drop-h1` – Don't include H1 headings in Confluence output.
+- `--drop-single-linebreak` – Don't break the line in Confluence for single Markdown linebreaks.
 - `--title-from-h1` - Extract page title from a leading H1 heading. If no H1 heading on a page then title must be set in a page metadata.
 - `--dry-run` — Show resulting HTML and don't update Confluence page content.
 - `--minor-edit` — Don't send notifications while updating Confluence page.

--- a/main.go
+++ b/main.go
@@ -20,23 +20,24 @@ import (
 )
 
 type Flags struct {
-	FileGlobPatten string `docopt:"-f"`
-	CompileOnly    bool   `docopt:"--compile-only"`
-	DryRun         bool   `docopt:"--dry-run"`
-	EditLock       bool   `docopt:"-k"`
-	DropH1         bool   `docopt:"--drop-h1"`
-	TitleFromH1    bool   `docopt:"--title-from-h1"`
-	MinorEdit      bool   `docopt:"--minor-edit"`
-	Color          string `docopt:"--color"`
-	Debug          bool   `docopt:"--debug"`
-	Trace          bool   `docopt:"--trace"`
-	Username       string `docopt:"-u"`
-	Password       string `docopt:"-p"`
-	TargetURL      string `docopt:"-l"`
-	BaseURL        string `docopt:"--base-url"`
-	Config         string `docopt:"--config"`
-	Ci             bool   `docopt:"--ci"`
-	Space          string `docopt:"--space"`
+	FileGlobPatten      string `docopt:"-f"`
+	CompileOnly         bool   `docopt:"--compile-only"`
+	DryRun              bool   `docopt:"--dry-run"`
+	EditLock            bool   `docopt:"-k"`
+	DropH1              bool   `docopt:"--drop-h1"`
+	DropSingleLinebreak bool   `docopt:"--drop-single-linebreak"`
+	TitleFromH1         bool   `docopt:"--title-from-h1"`
+	MinorEdit           bool   `docopt:"--minor-edit"`
+	Color               string `docopt:"--color"`
+	Debug               bool   `docopt:"--debug"`
+	Trace               bool   `docopt:"--trace"`
+	Username            string `docopt:"-u"`
+	Password            string `docopt:"-p"`
+	TargetURL           string `docopt:"-l"`
+	BaseURL             string `docopt:"--base-url"`
+	Config              string `docopt:"--config"`
+	Ci                  bool   `docopt:"--ci"`
+	Space               string `docopt:"--space"`
 }
 
 const (
@@ -52,37 +53,38 @@ Usage:
   mark -h | --help
 
 Options:
-  -u <username>        Use specified username for updating Confluence page.
-  -p <token>           Use specified token for updating Confluence page.
-                        Specify - as password to read password from stdin, or your Personal access token.
-                        Username is not mandatory if personal access token is provided.
-                        For more info please see: https://developer.atlassian.com/server/confluence/confluence-server-rest-api/#authentication.
-  -l <url>             Edit specified Confluence page.
-                        If -l is not specified, file should contain metadata (see
-                        above).
-  -b --base-url <url>  Base URL for Confluence.
-                        Alternative option for base_url config field.
-  -f <file>            Use specified markdown file(s) for converting to html.
-                        Supports file globbing patterns (needs to be quoted).
-  -k                   Lock page editing to current user only to prevent accidental
-                        manual edits over Confluence Web UI.
-  --space <space>      Use specified space key. If not specified space ley must
-                        be set in a page metadata.
-  --drop-h1            Don't include H1 headings in Confluence output.
-  --title-from-h1      Extract page title from a leading H1 heading. If no H1 heading
-                        on a page then title must be set in a page metadata.
-  --dry-run            Resolve page and ancestry, show resulting HTML and exit.
-  --compile-only       Show resulting HTML and don't update Confluence page content.
-  --minor-edit         Don't send notifications while updating Confluence page.
-  --debug              Enable debug logs.
-  --trace              Enable trace logs.
-  --color <when>       Display logs in color. Possible values: auto, never.
-                        [default: auto]
-  -c --config <path>   Use the specified configuration file.
-                        [default: $HOME/.config/mark]
-  --ci                 Runs on CI mode. It won't fail if files are not found.
-  -h --help            Show this message.
-  -v --version         Show version.
+  -u <username>            Use specified username for updating Confluence page.
+  -p <token>               Use specified token for updating Confluence page.
+                            Specify - as password to read password from stdin, or your Personal access token.
+                            Username is not mandatory if personal access token is provided.
+                            For more info please see: https://developer.atlassian.com/server/confluence/confluence-server-rest-api/#authentication.
+  -l <url>                 Edit specified Confluence page.
+                            If -l is not specified, file should contain metadata (see
+                            above).
+  -b --base-url <url>      Base URL for Confluence.
+                            Alternative option for base_url config field.
+  -f <file>                Use specified markdown file(s) for converting to html.
+                            Supports file globbing patterns (needs to be quoted).
+  -k                       Lock page editing to current user only to prevent accidental
+                            manual edits over Confluence Web UI.
+  --space <space>          Use specified space key. If not specified space ley must
+                            be set in a page metadata.
+  --drop-h1                Don't include H1 headings in Confluence output.
+  --drop-single-linebreak  Don't break the line in Confluence for single Markdown linebreaks
+  --title-from-h1          Extract page title from a leading H1 heading. If no H1 heading
+                            on a page then title must be set in a page metadata.
+  --dry-run                Resolve page and ancestry, show resulting HTML and exit.
+  --compile-only           Show resulting HTML and don't update Confluence page content.
+  --minor-edit             Don't send notifications while updating Confluence page.
+  --debug                  Enable debug logs.
+  --trace                  Enable trace logs.
+  --color <when>           Display logs in color. Possible values: auto, never.
+                            [default: auto]
+  -c --config <path>       Use the specified configuration file.
+                            [default: $HOME/.config/mark]
+  --ci                     Runs on CI mode. It won't fail if files are not found.
+  -h --help                Show this message.
+  -v --version             Show version.
 `
 )
 
@@ -347,6 +349,14 @@ func processFile(
 	}
 
 	html := mark.CompileMarkdown(markdown, stdlib)
+
+	if flags.DropSingleLinebreak {
+		log.Info(
+			"the line breaks inside <p> tags will be excluded from the Confluence output",
+		)
+
+		html = mark.RemoveNewlinesWithinParagraphTags(html)
+	}
 
 	{
 		var buffer bytes.Buffer

--- a/pkg/mark/markdown.go
+++ b/pkg/mark/markdown.go
@@ -159,3 +159,16 @@ func ExtractDocumentLeadingH1(markdown []byte) string {
 		return string(groups[1])
 	}
 }
+
+// RemoveNewlinesWithinParagraphTags will remove any newline within <p> tags to force Confluence
+// to break lines only for double line breaks in Markdown
+func RemoveNewlinesWithinParagraphTags(
+	html string,
+) string {
+	paragraphRegex := regexp.MustCompile(`<p>[\s\S]*?</p>`)
+	newlineRegex := regexp.MustCompile(`\s+`)
+
+	return paragraphRegex.ReplaceAllStringFunc(html, func(text string) string {
+		return newlineRegex.ReplaceAllLiteralString(text, " ")
+	})
+}

--- a/pkg/mark/markdown_test.go
+++ b/pkg/mark/markdown_test.go
@@ -61,3 +61,18 @@ func TestExtractDocumentLeadingH1(t *testing.T) {
 
 	assert.Equal(t, "a", actual)
 }
+
+func TestRemoveNewlinesWithinParagraphTags(t *testing.T) {
+	html := `<p>This newline
+	should be ignored</p>
+	<span>And this one
+	shouldn't</span>`
+
+	expected := `<p>This newline should be ignored</p>
+	<span>And this one
+	shouldn't</span>`
+
+	actual := RemoveNewlinesWithinParagraphTags(html)
+
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
This merge request addresses #92 by adding the flag `--drop-single-linebreak` which when enabled will strip all `\n` characters within `<p></p>` tags.

Suggestions or changes to the flag name are welcome.