### PR TITLE
allow templates and macros to include blanks in path

### DIFF
--- a/pkg/mark/includes/templates.go
+++ b/pkg/mark/includes/templates.go
@@ -18,7 +18,7 @@ import (
 // <!-- Include: <template path>
 //      <optional yaml data> -->
 var reIncludeDirective = regexp.MustCompile(
-	`(?s)<!--\s*Include:\s*(?P<template>\S+)\s*(\n(?P<config>.*?))?-->`)
+	`(?s)<!--\s*Include:\s*(?P<template>.+?)\s*(\n(?P<config>.*?))?-->`)
 
 func LoadTemplate(
 	base string,

--- a/pkg/mark/macro/macro.go
+++ b/pkg/mark/macro/macro.go
@@ -21,7 +21,7 @@ var reMacroDirective = regexp.MustCompile(
 
 	`(?s)` + // dot capture newlines
 		/**/ `<!--\s*Macro:\s*(?P<expr>[^\n]+)\n` +
-		/*    */ `\s*Template:\s*(?P<template>\S+)\s*` +
+		/*    */ `\s*Template:\s*(?P<template>.+?)\s*` +
 		/*   */ `(?P<config>\n.*?)?-->`,
 )
 


### PR DESCRIPTION
This small change will allow you to use template files containing blanks.