### PR TITLE
Do not require password and url when compileonly

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -36,10 +36,13 @@ func GetCredentials(
 	if password == "" {
 		password = config.Password
 		if password == "" {
-			return nil, errors.New(
-				"Confluence password should be specified using -p " +
-					"flag or be stored in configuration file",
-			)
+			if ! flags.CompileOnly {
+				return nil, errors.New(
+					"Confluence password should be specified using -p " +
+						"flag or be stored in configuration file",
+				)
+			}
+			password = "none"
 		}
 	}
 
@@ -53,6 +56,10 @@ func GetCredentials(
 		}
 
 		password = string(stdin)
+	}
+
+	if flags.CompileOnly && targetURL == "" {
+		targetURL = "http://localhost"
 	}
 
 	url, err := url.Parse(targetURL)


### PR DESCRIPTION
When trying to use `--compile-only`, mark complained about missing password and URL. So this PR will set a password of "none" and a URL of "http://localhost" if they are not given but `--compile-only` was requested.