### PR TITLE
allow change of delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,9 @@ mark -h | --help
     manual edits over Confluence Web UI.
 - `--space <space>` - Use specified space key. If not specified space ley must be set in a page metadata.
 - `--drop-h1` – Don't include H1 headings in Confluence output.
+  This option corresponds to the `h1_drop` setting in the configuration file.
 - `--title-from-h1` - Extract page title from a leading H1 heading. If no H1 heading on a page then title must be set in a page metadata.
+  This option corresponds to the `h1_title` setting in the configuration file.
 - `--dry-run` — Show resulting HTML and don't update Confluence page content.
 - `--minor-edit` — Don't send notifications while updating Confluence page.
 - `--trace` — Enable trace logs.
@@ -455,6 +457,8 @@ username = "your-email"
 password = "password-or-api-key-for-confluence-cloud"
 # If you are using Confluence Cloud add the /wiki suffix to base_url
 base_url = "http://confluence.local"
+h1_title = true
+h1_drop = true
 ```
 
 **NOTE**: Labels aren't supported when using `minor-edit`!
@@ -569,6 +573,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="http://www.devin.com.br/"><img src="https://avatars.githubusercontent.com/u/349457?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Hugo Cisneiros</b></sub></a><br /><a href="https://github.com/kovetskiy/mark/commits?author=eitchugo" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/jevfok"><img src="https://avatars.githubusercontent.com/u/54530686?v=4?s=100" width="100px;" alt=""/><br /><sub><b>jevfok</b></sub></a><br /><a href="https://github.com/kovetskiy/mark/commits?author=jevfok" title="Code">💻</a></td>
     <td align="center"><a href="https://dev.to/mmiranda"><img src="https://avatars.githubusercontent.com/u/16670310?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mateus Miranda</b></sub></a><br /><a href="#maintenance-mmiranda" title="Maintenance">🚧</a></td>
+    <td align="center"><a href="https://github.com/Skeeve"><img src="https://avatars.githubusercontent.com/u/725404?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Skeeve</b></sub></a><br /><a href="https://github.com/kovetskiy/mark/commits?author=Skeeve" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,26 @@ to the template relative to current working dir, e.g.:
 <!-- Include: <path> -->
 ```
 
+Optionally the delimiters can be defined:
+
+```markdown
+<!-- Include: <path>
+     Delims: "<<", ">>"
+     -->
+```
+
+Or they can be switched off to disable processing:
+
+```markdown
+<!-- Include: <path>
+     Delims: none
+     -->
+```
+
+**Note:** Switching delimiters off really simply changes
+them to ASCII characters "\x00" and "\x01" which, usually
+should not occure in a template.
+
 Templates can accept configuration data in YAML format which immediately
 follows the `Include` tag:
 

--- a/config.go
+++ b/config.go
@@ -10,6 +10,8 @@ type Config struct {
 	Username string `env:"MARK_USERNAME" toml:"username"`
 	Password string `env:"MARK_PASSWORD" toml:"password"`
 	BaseURL  string `env:"MARK_BASE_URL" toml:"base_url"`
+	H1Title  bool   `env:"MARK_H1_TITLE" toml:"h1_title"`
+	H1Drop   bool   `env:"MARK_H1_DROP"  toml:"h1_drop"`
 }
 
 func LoadConfig(path string) (*Config, error) {

--- a/main.go
+++ b/main.go
@@ -120,6 +120,14 @@ func main() {
 		log.Fatal(err)
 	}
 
+	if ! flags.TitleFromH1 && config.H1Title {
+		flags.TitleFromH1 = true
+	}
+
+	if ! flags.DropH1 && config.H1Drop {
+		flags.DropH1 = true
+	}
+
 	creds, err := GetCredentials(flags, config)
 	if err != nil {
 		log.Fatal(err)
@@ -212,7 +220,7 @@ func processFile(
 	if meta.Title == "" {
 		log.Fatal(
 			`page title is not set ('Title' header is not set ` +
-				`and '--title-from-h1' option is not set or there is no H1 in the file)`,
+				`and '--title-from-h1' option and 'h1_title' config is not set or there is no H1 in the file)`,
 		)
 	}
 
@@ -275,7 +283,14 @@ func processFile(
 	}
 
 	if flags.CompileOnly {
-		fmt.Println(mark.CompileMarkdown(markdown, stdlib))
+		if flags.DropH1 {
+			log.Info(
+				"the leading H1 heading will be excluded from the Confluence output",
+			)
+			markdown = mark.DropDocumentLeadingH1(markdown)
+		}
+	
+			fmt.Println(mark.CompileMarkdown(markdown, stdlib))
 		os.Exit(0)
 	}
 

--- a/pkg/mark/includes/templates.go
+++ b/pkg/mark/includes/templates.go
@@ -18,7 +18,7 @@ import (
 // <!-- Include: <template path>
 //      <optional yaml data> -->
 var reIncludeDirective = regexp.MustCompile(
-	`(?s)<!--\s*Include:\s*(?P<template>\S+)\s*(\n(?P<config>.*?))?-->`)
+	`(?s)<!--\s*Include:\s*(?P<template>.+?)\s*(\n(?P<config>.*?))?-->`)
 
 func LoadTemplate(
 	base string,

--- a/pkg/mark/includes/templates.go
+++ b/pkg/mark/includes/templates.go
@@ -16,13 +16,20 @@ import (
 )
 
 // <!-- Include: <template path>
+//      (Delims: (none | "<left>","<right>"))?
 //      <optional yaml data> -->
 var reIncludeDirective = regexp.MustCompile(
-	`(?s)<!--\s*Include:\s*(?P<template>.+?)\s*(\n(?P<config>.*?))?-->`)
+	`(?s)` +
+	`<!--\s*Include:\s*(?P<template>.+?)\s*` +
+	`(?:\n\s*Delims:\s*(?:(none|"(?P<left>.*?)"\s*,\s*"(?P<right>.*?)")))?\s*`+
+	`(?:\n(?P<config>.*?))?-->`,
+)
 
 func LoadTemplate(
 	base string,
 	path string,
+	left string,
+	right string,
 	templates *template.Template,
 ) (*template.Template, error) {
 	var (
@@ -52,7 +59,7 @@ func LoadTemplate(
 		[]byte("\n"),
 	)
 
-	templates, err = templates.New(name).Parse(string(body))
+	templates, err = templates.New(name).Delims(left, right).Parse(string(body))
 	if err != nil {
 		err = facts.Format(
 			err,
@@ -104,12 +111,15 @@ func ProcessIncludes(
 			groups := reIncludeDirective.FindSubmatch(spec)
 
 			var (
-				path, config = string(groups[1]), groups[2]
-				data         = map[string]interface{}{}
+				path, none, left, right, config = string(groups[1]), string(groups[2]), string(groups[3]), string(groups[4]), groups[5]
+				data = map[string]interface{}{}
 
 				facts = karma.Describe("path", path)
 			)
-
+			if none == "none" {
+				left = "\x00"
+				right = "\x01"
+			}
 			err = yaml.Unmarshal(config, &data)
 			if err != nil {
 				err = facts.
@@ -124,7 +134,7 @@ func ProcessIncludes(
 
 			log.Tracef(vardump(facts, data), "including template %q", path)
 
-			templates, err = LoadTemplate(base, path, templates)
+			templates, err = LoadTemplate(base, path, left, right, templates)
 			if err != nil {
 				err = facts.Format(err, "unable to load template")
 

--- a/pkg/mark/macro/macro.go
+++ b/pkg/mark/macro/macro.go
@@ -21,7 +21,7 @@ var reMacroDirective = regexp.MustCompile(
 
 	`(?s)` + // dot capture newlines
 		/**/ `<!--\s*Macro:\s*(?P<expr>[^\n]+)\n` +
-		/*    */ `\s*Template:\s*(?P<template>\S+)\s*` +
+		/*    */ `\s*Template:\s*(?P<template>.+?)\s*` +
 		/*   */ `(?P<config>\n.*?)?-->`,
 )
 

--- a/pkg/mark/macro/macro.go
+++ b/pkg/mark/macro/macro.go
@@ -134,7 +134,7 @@ func ExtractMacros(
 				macro Macro
 			)
 
-			macro.Template, err = includes.LoadTemplate(base, template, templates)
+			macro.Template, err = includes.LoadTemplate(base, template, "{{", "}}", templates)
 			if err != nil {
 				err = karma.Format(err, "unable to load template")
 

--- a/pkg/mark/macro/macro.go
+++ b/pkg/mark/macro/macro.go
@@ -134,12 +134,35 @@ func ExtractMacros(
 				macro Macro
 			)
 
-			macro.Template, err = includes.LoadTemplate(base, template, "{{", "}}", templates)
-			if err != nil {
-				err = karma.Format(err, "unable to load template")
+			if strings.HasPrefix(template, "#") {
+				cfg := map[string]interface{}{}
 
-				return nil
+				err = yaml.Unmarshal([]byte(config), &cfg)
+				if err != nil {
+					err = karma.Format(
+						err,
+						"unable to unmarshal macros config template",
+					)
+					return nil
+				}
+				body, _ := cfg[template[1:]].(string)
+				macro.Template, err = templates.New(template).Parse(body)
+				if err != nil {
+					err = karma.Format(
+						err,
+						"unable to parse template",
+					)
+					return nil
+				}
+			} else {
+				macro.Template, err = includes.LoadTemplate(base, template, "{{", "}}", templates)
+				if err != nil {
+					err = karma.Format(err, "unable to load template")
+	
+					return nil
+				}
 			}
+
 
 			facts := karma.
 				Describe("template", template).


### PR DESCRIPTION
This PR will allow you to change the template delimiters as well as switching off delimiters at all, resulting in an "unparsed" template. See README.md for details.

This also includes PR #191 