### PR TITLE
Feature/h1 title

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ mark -h | --help
 - `--space <space>` - Use specified space key. If not specified space ley must be set in a page metadata.
 - `--drop-h1` – Don't include H1 headings in Confluence output.
 - `--title-from-h1` - Extract page title from a leading H1 heading. If no H1 heading on a page then title must be set in a page metadata.
+  This option corresponds to the `h1_title` setting in the configuration file.
 - `--dry-run` — Show resulting HTML and don't update Confluence page content.
 - `--minor-edit` — Don't send notifications while updating Confluence page.
 - `--trace` — Enable trace logs.
@@ -455,6 +456,7 @@ username = "your-email"
 password = "password-or-api-key-for-confluence-cloud"
 # If you are using Confluence Cloud add the /wiki suffix to base_url
 base_url = "http://confluence.local"
+h1_title = true
 ```
 
 **NOTE**: Labels aren't supported when using `minor-edit`!
@@ -569,6 +571,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="http://www.devin.com.br/"><img src="https://avatars.githubusercontent.com/u/349457?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Hugo Cisneiros</b></sub></a><br /><a href="https://github.com/kovetskiy/mark/commits?author=eitchugo" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/jevfok"><img src="https://avatars.githubusercontent.com/u/54530686?v=4?s=100" width="100px;" alt=""/><br /><sub><b>jevfok</b></sub></a><br /><a href="https://github.com/kovetskiy/mark/commits?author=jevfok" title="Code">💻</a></td>
     <td align="center"><a href="https://dev.to/mmiranda"><img src="https://avatars.githubusercontent.com/u/16670310?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mateus Miranda</b></sub></a><br /><a href="#maintenance-mmiranda" title="Maintenance">🚧</a></td>
+    <td align="center"><a href="https://github.com/Skeeve"><img src="https://avatars.githubusercontent.com/u/725404?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Skeeve</b></sub></a><br /><a href="https://github.com/kovetskiy/mark/commits?author=Skeeve" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ mark -h | --help
     manual edits over Confluence Web UI.
 - `--space <space>` - Use specified space key. If not specified space ley must be set in a page metadata.
 - `--drop-h1` – Don't include H1 headings in Confluence output.
+  This option corresponds to the `h1_drop` setting in the configuration file.
 - `--title-from-h1` - Extract page title from a leading H1 heading. If no H1 heading on a page then title must be set in a page metadata.
   This option corresponds to the `h1_title` setting in the configuration file.
 - `--dry-run` — Show resulting HTML and don't update Confluence page content.
@@ -457,6 +458,7 @@ password = "password-or-api-key-for-confluence-cloud"
 # If you are using Confluence Cloud add the /wiki suffix to base_url
 base_url = "http://confluence.local"
 h1_title = true
+h1_drop = true
 ```
 
 **NOTE**: Labels aren't supported when using `minor-edit`!

--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	Password string `env:"MARK_PASSWORD" toml:"password"`
 	BaseURL  string `env:"MARK_BASE_URL" toml:"base_url"`
 	H1Title  bool   `env:"MARK_H1_TITLE" toml:"h1_title"`
+	H1Drop   bool   `env:"MARK_H1_DROP"  toml:"h1_drop"`
 }
 
 func LoadConfig(path string) (*Config, error) {

--- a/config.go
+++ b/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	Username string `env:"MARK_USERNAME" toml:"username"`
 	Password string `env:"MARK_PASSWORD" toml:"password"`
 	BaseURL  string `env:"MARK_BASE_URL" toml:"base_url"`
+	H1Title  string `env:"MARK_H1_TITLE" toml:"h1_title"`
 }
 
 func LoadConfig(path string) (*Config, error) {

--- a/config.go
+++ b/config.go
@@ -10,7 +10,7 @@ type Config struct {
 	Username string `env:"MARK_USERNAME" toml:"username"`
 	Password string `env:"MARK_PASSWORD" toml:"password"`
 	BaseURL  string `env:"MARK_BASE_URL" toml:"base_url"`
-	H1Title  string `env:"MARK_H1_TITLE" toml:"h1_title"`
+	H1Title  bool   `env:"MARK_H1_TITLE" toml:"h1_title"`
 }
 
 func LoadConfig(path string) (*Config, error) {

--- a/main.go
+++ b/main.go
@@ -205,14 +205,14 @@ func processFile(
 		meta.Space = flags.Space
 	}
 
-	if meta.Title == "" && flags.TitleFromH1 {
+	if meta.Title == "" && ( flags.TitleFromH1 || config.H1Title ) {
 		meta.Title = mark.ExtractDocumentLeadingH1(markdown)
 	}
 
 	if meta.Title == "" {
 		log.Fatal(
 			`page title is not set ('Title' header is not set ` +
-				`and '--title-from-h1' option is not set or there is no H1 in the file)`,
+				`and '--title-from-h1' option and 'h1_title' config is not set or there is no H1 in the file)`,
 		)
 	}
 

--- a/main.go
+++ b/main.go
@@ -120,6 +120,10 @@ func main() {
 		log.Fatal(err)
 	}
 
+	if ! flags.TitleFromH1 && config.H1Title {
+		flags.TitleFromH1 = true
+	}
+
 	creds, err := GetCredentials(flags, config)
 	if err != nil {
 		log.Fatal(err)
@@ -205,7 +209,7 @@ func processFile(
 		meta.Space = flags.Space
 	}
 
-	if meta.Title == "" && ( flags.TitleFromH1 || config.H1Title ) {
+	if meta.Title == "" && flags.TitleFromH1 {
 		meta.Title = mark.ExtractDocumentLeadingH1(markdown)
 	}
 

--- a/main.go
+++ b/main.go
@@ -124,6 +124,10 @@ func main() {
 		flags.TitleFromH1 = true
 	}
 
+	if ! flags.DropH1 && config.H1Drop {
+		flags.DropH1 = true
+	}
+
 	creds, err := GetCredentials(flags, config)
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -283,7 +283,14 @@ func processFile(
 	}
 
 	if flags.CompileOnly {
-		fmt.Println(mark.CompileMarkdown(markdown, stdlib))
+		if flags.DropH1 {
+			log.Info(
+				"the leading H1 heading will be excluded from the Confluence output",
+			)
+			markdown = mark.DropDocumentLeadingH1(markdown)
+		}
+	
+			fmt.Println(mark.CompileMarkdown(markdown, stdlib))
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
This extends #153 in that there is a new config setting `h1_title` of type bool which will be used when neither a meta Title is set nor `--title-from-h1`  was given.

Same goes for `--drop-h1` which can be set with the bool setting `h1_drop`.

Additionally I added dropping of `h1` when `--compile-only` as this was not done yet.