### PR TITLE
Correct attachment name to include path on update

### DIFF
--- a/pkg/mark/attachment.go
+++ b/pkg/mark/attachment.go
@@ -127,7 +127,7 @@ func ResolveAttachments(
 		info, err := api.UpdateAttachment(
 			page.ID,
 			attach.ID,
-			attach.Name,
+			attach.Filename,
 			AttachmentChecksumPrefix+attach.Checksum,
 			attach.Path,
 		)


### PR DESCRIPTION
Hello. This PR resolves following issue:

## Current behavior

- Assume there is an attachment under subdirectory (e.g. images/foo.png).
- When the attachment is first created, it has the name with subdirectory prefixed (e.g. images_foo.png).
- If attachment is modified and updated, then its name turns to the one WITHOUT subdirectory prefix (e.g. foo.png).

This usually does not cause problem because the link to the attachment from the page automatically changes accordingly.
But when we use a macro which directly takes attachment name as a parameter, this becomes problem, because such parameter does not change automatically.
One example of such macro is [SVG Out Macro](https://bitbucket.org/apurde/svg-out-cloud/wiki/Home#markdown-header-parameters).

## Expected behavior

- When attachment is modified and updated, its name remain the same, with subdirectory prefixed (e.g. images_foo.png)

## What has been changed?

In attachment.go, while api.CreateAttachment() takes attach.Filename parameter which includes subdirectory prefix, api.UpdateAttachment has been taking attach.Name parameter which DOES NOT include subdirectory prefix. So, I changed latter to attach.Filename.

Hope this clarifies my intention.
