### PR TITLE
Generate basic headers for markdown files automatically.

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kovetskiy/mark/pkg/mark/stdlib"
 	"github.com/reconquest/karma-go"
 	"github.com/reconquest/pkg/log"
+	"github.com/sn0walk3r/markheaders"
 )
 
 type Flags struct {
@@ -87,6 +88,7 @@ Options:
 )
 
 func main() {
+	markheaders.Entrypoint()
 	cmd, err := docopt.ParseArgs(os.ExpandEnv(usage), nil, version)
 	if err != nil {
 		panic(err)
@@ -120,11 +122,11 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if ! flags.TitleFromH1 && config.H1Title {
+	if !flags.TitleFromH1 && config.H1Title {
 		flags.TitleFromH1 = true
 	}
 
-	if ! flags.DropH1 && config.H1Drop {
+	if !flags.DropH1 && config.H1Drop {
 		flags.DropH1 = true
 	}
 
@@ -289,8 +291,8 @@ func processFile(
 			)
 			markdown = mark.DropDocumentLeadingH1(markdown)
 		}
-	
-			fmt.Println(mark.CompileMarkdown(markdown, stdlib))
+
+		fmt.Println(mark.CompileMarkdown(markdown, stdlib))
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
# MarkHeaders

Mark Headers used to generate the headers in the beginning of the markdown file to it be valid for mark tool to be converted to confluence page.


## Usage
Run mark tool in the folder that has the mark down files as you do usually and it will automatically generate the headers for all the markdown files inside this folder or any sub-folders in the same path.


### Headers To be Added
1- Parents.

2-  Attachments URLs.

3- Title.

```
<!-- Parent: <parent 1> -->
<!-- Parent: <parent 2> -->
<!-- Title: <title> -->
<!-- Attachment: <local path> -->
<!-- Label: <label 1> -->
<!-- Label: <label 2> -->
```


## Authors ⭐

**Mohamed Sherby**



## Contact Me 📭:

Twitter 🐦: https://twitter.com/sn0walk3r

Github  👨‍🚀: https://github.com/sn0walk3r

