### PR TITLE
fix 178: update breaks on more than 50 attachments

### DIFF
--- a/pkg/confluence/api.go
+++ b/pkg/confluence/api.go
@@ -424,6 +424,7 @@ func (api *API) GetAttachments(pageID string) ([]AttachmentInfo, error) {
 
 	payload := map[string]string{
 		"expand": "version,container",
+		"limit":  "1000",
 	}
 
 	request, err := api.rest.Res(


### PR DESCRIPTION
Hi,

This is a quick fix for https://github.com/kovetskiy/mark/issues/178

Obviously the best approach would be to paginate but seemed overkill and unneeded. 1000 attachments is already too many for a confluence page...