### PR TITLE
This should fix #171 by allowing a markdown link to start with ac:

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,14 @@ You can use various [parameters](https://confluence.atlassian.com/conf59/childre
 See task MYJIRA-123.
 ```
 
+### Insert link to existing confluence page by title
+
+```markdown
+This is a [link to an existing confluence page](ac:Pagetitle)
+
+And this is how to link when the linktext is the same as the [Pagetitle](ac:)
+```
+
 ## Installation
 
 ### Homebrew

--- a/pkg/mark/markdown.go
+++ b/pkg/mark/markdown.go
@@ -73,6 +73,21 @@ func (renderer ConfluenceRenderer) RenderNode(
 
 		return bf.GoToNext
 	}
+	if node.Type == bf.Link && string(node.Destination[0:3]) == "ac:" {
+		if entering {
+			writer.Write([]byte("<ac:link><ri:page ri:content-title=\""))
+			if len(node.Destination) < 4 {
+				writer.Write(node.FirstChild.Literal)
+			} else {
+				writer.Write(node.Destination[3:])
+			}
+			writer.Write([]byte("\"/><ac:plain-text-link-body><![CDATA["))
+			writer.Write(node.FirstChild.Literal)
+			writer.Write([]byte("]]></ac:plain-text-link-body></ac:link>"))
+			return bf.SkipChildren
+		}
+		return bf.GoToNext
+	}
 	return renderer.Renderer.RenderNode(writer, node, entering)
 }
 


### PR DESCRIPTION
With this pr you can add links to already existing confluence pages or pages of which you know the title.

```markdown
This is a [link to an existing confluence page](ac:Pagetitle)

And this is how to link when the linktext is the same as the [Pagetitle](ac:)
```
