### PR TITLE
Allow Title via h1 without any other metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,10 +503,10 @@ mark -h | --help
 - `-c <path>` or `--config <path>` — Specify a path to the configuration file.
 - `-k` — Lock page editing to current user only to prevent accidental
     manual edits over Confluence Web UI.
-- `--space <space>` - Use specified space key. If not specified space ley must be set in a page metadata.
+- `--space <space>` - Use specified space key. If the space key is not specified, it must be set in the page metadata.
 - `--drop-h1` – Don't include H1 headings in Confluence output.
   This option corresponds to the `h1_drop` setting in the configuration file.
-- `--title-from-h1` - Extract page title from a leading H1 heading. If no H1 heading on a page then title must be set in a page metadata.
+- `--title-from-h1` - Extract page title from a leading H1 heading. If no H1 heading on a page exists, then title must be set in the page metadata.
   This option corresponds to the `h1_title` setting in the configuration file.
 - `--dry-run` — Show resulting HTML and don't update Confluence page content.
 - `--minor-edit` — Don't send notifications while updating Confluence page.

--- a/main.go
+++ b/main.go
@@ -66,11 +66,11 @@ Options:
                         Supports file globbing patterns (needs to be quoted).
   -k                   Lock page editing to current user only to prevent accidental
                         manual edits over Confluence Web UI.
-  --space <space>      Use specified space key. If not specified space ley must
-                        be set in a page metadata.
+  --space <space>      Use specified space key. If the space key is not specified, it must
+                        be set in the page metadata.
   --drop-h1            Don't include H1 headings in Confluence output.
   --title-from-h1      Extract page title from a leading H1 heading. If no H1 heading
-                        on a page then title must be set in a page metadata.
+                        on a page exists, then title must be set in the page metadata.
   --dry-run            Resolve page and ancestry, show resulting HTML and exit.
   --compile-only       Show resulting HTML and don't update Confluence page content.
   --minor-edit         Don't send notifications while updating Confluence page.
@@ -197,11 +197,16 @@ func processFile(
 	}
 
 	if pageID == "" && meta == nil {
-		log.Fatal(
-			`specified file doesn't contain metadata ` +
-				`and URL is not specified via command line ` +
-				`or doesn't contain pageId GET-parameter`,
-		)
+		if flags.TitleFromH1 && flags.Space != "" {
+			meta = &mark.Meta{}
+			meta.Type = "page"
+		} else {
+			log.Fatal(
+				`specified file doesn't contain metadata ` +
+					`and URL is not specified via command line ` +
+					`or doesn't contain pageId GET-parameter`,
+			)
+		}
 	}
 
 	switch {


### PR DESCRIPTION
Minimal example:
file.md contains
```
# Test
```

`mark --title-from-h1 -p TOKEN --space "MYSPACE" -l URL  -f file.md`

failed before this change with `FATAL specified file doesn't contain metadata and URL is not specified via command line or doesn't contain pageId GET-parameter`

This does not fail for

file2.md
```
<!-- Title: Test -->
```
`mark -p TOKEN --space "MYSPACE" -l URL  -f file2.md`

With this change,  we can add files even if they don't contain metadata but generate the title from their h1 headings 

