### PR TITLE
Replace deprecated io/ioutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,4 @@ RUN make build
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates bash git
 COPY --from=0 /go/src/github.com/kovetskiy/mark/mark /bin/
-RUN mkdir -p /docs
 WORKDIR /docs

--- a/auth.go
+++ b/auth.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"strings"
@@ -36,7 +36,7 @@ func GetCredentials(
 	if password == "" {
 		password = config.Password
 		if password == "" {
-			if ! flags.CompileOnly {
+			if !flags.CompileOnly {
 				return nil, errors.New(
 					"Confluence password should be specified using -p " +
 						"flag or be stored in configuration file",
@@ -47,7 +47,7 @@ func GetCredentials(
 	}
 
 	if password == "-" {
-		stdin, err := ioutil.ReadAll(os.Stdin)
+		stdin, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return nil, karma.Format(
 				err,

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -175,7 +174,7 @@ func processFile(
 	pageID string,
 	username string,
 ) *confluence.PageInfo {
-	markdown, err := ioutil.ReadFile(file)
+	markdown, err := os.ReadFile(file)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/confluence/api.go
+++ b/pkg/confluence/api.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -727,7 +726,7 @@ func newErrorStatusNotOK(request *gopencils.Resource) error {
 		)
 	}
 
-	output, _ := ioutil.ReadAll(request.Raw.Body)
+	output, _ := io.ReadAll(request.Raw.Body)
 	defer request.Raw.Body.Close()
 
 	return fmt.Errorf(

--- a/pkg/mark/attachment.go
+++ b/pkg/mark/attachment.go
@@ -42,7 +42,7 @@ func ResolveAttachments(
 		return nil, err
 	}
 
-	for i, _ := range attaches {
+	for i := range attaches {
 		checksum, err := getChecksum(attaches[i].Path)
 		if err != nil {
 			return nil, karma.Format(
@@ -147,7 +147,7 @@ func ResolveAttachments(
 		updating[i] = attach
 	}
 
-	for i, _ := range existing {
+	for i := range existing {
 		log.Infof(nil, "keeping unmodified attachment: %q", attaches[i].Name)
 	}
 

--- a/pkg/mark/includes/templates.go
+++ b/pkg/mark/includes/templates.go
@@ -3,7 +3,7 @@ package includes
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -16,8 +16,9 @@ import (
 )
 
 // <!-- Include: <template path>
-//      (Delims: (none | "<left>","<right>"))?
-//      <optional yaml data> -->
+//
+//	(Delims: (none | "<left>","<right>"))?
+//	<optional yaml data> -->
 var reIncludeDirective = regexp.MustCompile(
 	`(?s)` +
 		`<!--\s*Include:\s*(?P<template>.+?)\s*` +
@@ -43,7 +44,7 @@ func LoadTemplate(
 
 	var body []byte
 
-	body, err := ioutil.ReadFile(filepath.Join(base, path))
+	body, err := os.ReadFile(filepath.Join(base, path))
 	if err != nil {
 		err = facts.Format(
 			err,

--- a/pkg/mark/link.go
+++ b/pkg/mark/link.go
@@ -3,7 +3,6 @@ package mark
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -80,7 +79,7 @@ func resolveLink(
 			return "", nil
 		}
 
-		linkContents, err := ioutil.ReadFile(filepath)
+		linkContents, err := os.ReadFile(filepath)
 		if err != nil {
 			return "", karma.Format(err, "read file: %s", filepath)
 		}

--- a/pkg/mark/markdown_test.go
+++ b/pkg/mark/markdown_test.go
@@ -1,7 +1,7 @@
 package mark
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -31,11 +31,11 @@ func TestCompileMarkdown(t *testing.T) {
 		testname := strings.TrimSuffix(basename, ".md")
 		htmlname := filepath.Join(filepath.Dir(filename), testname+".html")
 
-		markdown, err := ioutil.ReadFile(filename)
+		markdown, err := os.ReadFile(filename)
 		if err != nil {
 			panic(err)
 		}
-		html, err := ioutil.ReadFile(htmlname)
+		html, err := os.ReadFile(htmlname)
 		if err != nil {
 			panic(err)
 		}
@@ -52,7 +52,7 @@ func TestCompileMarkdown(t *testing.T) {
 func TestExtractDocumentLeadingH1(t *testing.T) {
 	filename := "testdata/header.md"
 
-	markdown, err := ioutil.ReadFile(filename)
+	markdown, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
"Deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. "