### PR TITLE
Fix for jira.com hosted sites

### DIFF
--- a/pkg/confluence/api.go
+++ b/pkg/confluence/api.go
@@ -705,7 +705,7 @@ func (api *API) RestrictPageUpdates(
 ) error {
 	var err error
 
-	if strings.HasSuffix(api.rest.Api.BaseUrl.Host, "atlassian.net") {
+	if strings.HasSuffix(api.rest.Api.BaseUrl.Host, "jira.com") || strings.HasSuffix(api.rest.Api.BaseUrl.Host, "atlassian.net") {
 		err = api.RestrictPageUpdatesCloud(page, allowedUser)
 	} else {
 		err = api.RestrictPageUpdatesServer(page, allowedUser)


### PR DESCRIPTION
This CLI works great thank you for creating it!

However for our Confluence site we are on Confluence **cloud** but a `jira.com` address.

I added the flex for jira.com to where it was checked for atlassian.net