### PR TITLE
feat: support ac:jiraissues macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,20 @@ By default, mark provides several built-in templates and macros:
 
   See: https://confluence.atlassian.com/conf59/status-macro-792499207.html
 
+* template `ac:jiraissues` to include a list of JIRA tickets. Parameters:
+  - URL (Required), The URL of the XML view of your selected issues. (link to the filter)
+  - Anonymous (Optional) If this parameter is set to 'true', your JIRA application will return only the issues which allow unrestricted viewing. That is, the issues which are visible to anonymous viewers. If this parameter is omitted or set to 'false', then the results depend on how your administrator has configured the communication between the JIRA application and Confluence. By default, Confluence will show only the issues which the user is authorised to view.
+  - BaseURL  (Optional) If you specify a 'baseurl', then the link in the header, pointing to your JIRA application, will use this base URL instead of the value of the 'url' parameter. This is useful when Confluence connects to JIRA with a different URL from the one used by other users.
+  - Columns  (Optional) A list of JIRA column names, separated by semi-colons (;). You can include many columns recognized by your JIRA application, including custom columns.
+  - Count  (Optional) If this parameter is set to 'true', the issue list will show the number of issues in JIRA. The count will be linked to your JIRA site.
+  - Cache  (Optional) The macro maintains a cache of the issues which result from the JIRA query. If the 'cache' parameter is set to 'off', the relevant part of the cache is cleared each time the macro is reloaded. (The value 'false' also works and has the same effect as 'off'.)
+  - Height  (Optional) The height in pixels of the table displaying the issues.
+  - RenderMode  (Optional) If the value is 'dynamic', the JIRA Issues macro offers an interactive display.
+  - Title  (Optional) You can customise the title text at the top of the issues table with this parameter. For instance, setting the title to 'Bugs-to-fix' will replace the default 'JIRA Issues' text. This can help provide more context to the list of issues displayed.
+  - Width  (Optional) The width of the table displaying the issues. Can be entered as a percentage (%) or in pixels (px).
+
+  See: https://confluence.atlassian.com/doc/jira-issues-macro-139380.html
+
 * template: `ac:emoticon` to include emoticons. Parameters:
   - Name: select emoticon
     - smile

--- a/pkg/mark/stdlib/stdlib.go
+++ b/pkg/mark/stdlib/stdlib.go
@@ -139,6 +139,22 @@ func templates(api *confluence.API) (*template.Template, error) {
 			`</ac:structured-macro>`,
 		),
 
+		/* https://confluence.atlassian.com/doc/jira-issues-macro-139380.html */
+		`ac:jiraissues`: text(
+			`<ac:structured-macro ac:name="jiraissues">`,
+			`<ac:parameter ac:name="anonymous">{{ or .Anonymous false }}</ac:parameter>`,
+			`<ac:parameter ac:name="baseurl">{{ or .BaseURL .URL }}</ac:parameter>`,
+			`<ac:parameter ac:name="columns">{{ or .Columns "type;key;summary;assignee;reporter;priority;status;resolution;created;updated;due" }}</ac:parameter>`,
+			`<ac:parameter ac:name="count">{{ or .Count false }}</ac:parameter>`,
+			`<ac:parameter ac:name="cache">{{ or .Cache "on" }}</ac:parameter>`,
+			`<ac:parameter ac:name="height">{{ or .Height 480 }}</ac:parameter>`,
+			`<ac:parameter ac:name="renderMode">{{ or RenderMode "static" }}</ac:parameter>`,
+			`<ac:parameter ac:name="title">{{ or .Title "Jira Issues" }}</ac:parameter>`,
+			`<ac:parameter ac:name="url">{{ .URL }}</ac:parameter>`,
+			`<ac:parameter ac:name="width">{{ or .Width "100%" }}</ac:parameter>`,
+			`</ac:structured-macro>`,
+		),
+
 		/* https://confluence.atlassian.com/conf59/info-tip-note-and-warning-macros-792499127.html */
 
 		`ac:box`: text(


### PR DESCRIPTION
Add support for the `ac:jiraissues` macro. By adding the template to the stdlib. Not sure if there are other places where you need to add stuff for macros. Or how I could test this locally.