### PR TITLE
Lint: Disable staticcheck for strings.Title

### DIFF
--- a/pkg/mark/meta.go
+++ b/pkg/mark/meta.go
@@ -74,6 +74,7 @@ func ExtractMeta(data []byte) (*Meta, []byte, error) {
 			meta.Type = "page" //Default if not specified
 		}
 
+		//nolint:staticcheck
 		header := strings.Title(matches[1])
 
 		var value string


### PR DESCRIPTION
strings.Title is deprecated, but we need to keep using it since there is no 1:1 replacement and otherwise this might change page names on confluence.


@kovetskiy 