### PR TITLE
Fixes #253 Can't build with Go versions > 17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ build:
 	CGO_ENABLED=0 go build \
 		-ldflags "-X main.version=$(VERSION)" \
 		-gcflags "-trimpath $(GOPATH)/src"
+		-buildvcs=false
 
 test:
 	go test -race -coverprofile=profile.cov ./...


### PR DESCRIPTION
Fixes the build for go versions >= 18.