### PR TITLE
Add Content-Appearance header

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Also, optional following headers are supported:
 * blogpost: [Blog post](https://confluence.atlassian.com/doc/blog-posts-834222533.html) in `Space`.  Cannot have `Parent`(s)
 
 ```markdown
+<!-- Content-Appearance: (full-width|fixed) -->
+```
+
+* (default) full-width: content will fill the full page width
+* fixed: content will be rendered in a fixed narrow view
+
+```markdown
 <!-- Sidebar: <h2>Test</h2> -->
 ```
 

--- a/main.go
+++ b/main.go
@@ -390,7 +390,7 @@ func processFile(
 		html = buffer.String()
 	}
 
-	err = api.UpdatePage(target, html, flags.MinorEdit, meta.Labels)
+	err = api.UpdatePage(target, html, flags.MinorEdit, meta.Labels, meta.ContentAppearance)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/confluence/api.go
+++ b/pkg/confluence/api.go
@@ -514,9 +514,7 @@ func (api *API) CreatePage(
 	return request.Response.(*PageInfo), nil
 }
 
-func (api *API) UpdatePage(
-	page *PageInfo, newContent string, minorEdit bool, newLabels []string,
-) error {
+func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, newLabels []string, appearance string) error {
 	nextPageVersion := page.Version.Number + 1
 	oldAncestors := []map[string]interface{}{}
 
@@ -560,7 +558,7 @@ func (api *API) UpdatePage(
 			// 
 			"properties": map[string]interface{}{
 				"content-appearance-published": map[string]interface{}{
-					"value": "full-width",
+					"value": appearance,
 				},
 			},
 			// content-appearance-draft should not be set as this is impacted by

--- a/pkg/mark/meta.go
+++ b/pkg/mark/meta.go
@@ -11,27 +11,34 @@ import (
 )
 
 const (
-	HeaderParent     = `Parent`
-	HeaderSpace      = `Space`
-	HeaderType       = `Type`
-	HeaderTitle      = `Title`
-	HeaderLayout     = `Layout`
-	HeaderAttachment = `Attachment`
-	HeaderLabel      = `Label`
-	HeaderInclude    = `Include`
-	HeaderSidebar    = `Sidebar`
+	HeaderParent      = `Parent`
+	HeaderSpace       = `Space`
+	HeaderType        = `Type`
+	HeaderTitle       = `Title`
+	HeaderLayout      = `Layout`
+	HeaderAttachment  = `Attachment`
+	HeaderLabel       = `Label`
+	HeaderInclude     = `Include`
+	HeaderSidebar     = `Sidebar`
+	ContentAppearance = `Content-Appearance`
 )
 
 type Meta struct {
-	Parents     []string
-	Space       string
-	Type        string
-	Title       string
-	Layout      string
-	Sidebar     string
-	Attachments []string
-	Labels      []string
+	Parents           []string
+	Space             string
+	Type              string
+	Title             string
+	Layout            string
+	Sidebar           string
+	Attachments       []string
+	Labels            []string
+	ContentAppearance string
 }
+
+const (
+	FullWidthContentAppearance = "full-width"
+	FixedContentAppearance     = "fixed"
+)
 
 var (
 	reHeaderPatternV1    = regexp.MustCompile(`\[\]:\s*#\s*\(([^:]+):\s*(.*)\)`)
@@ -78,7 +85,8 @@ func ExtractMeta(data []byte) (*Meta, []byte, error) {
 
 		if meta == nil {
 			meta = &Meta{}
-			meta.Type = "page" //Default if not specified
+			meta.Type = "page"                                  // Default if not specified
+			meta.ContentAppearance = FullWidthContentAppearance // Default to full-width for backwards compatibility
 		}
 
 		//nolint:staticcheck
@@ -118,6 +126,13 @@ func ExtractMeta(data []byte) (*Meta, []byte, error) {
 		case HeaderInclude:
 			// Includes are parsed by a different func
 			continue
+
+		case ContentAppearance:
+			if strings.TrimSpace(value) == FixedContentAppearance {
+				meta.ContentAppearance = FixedContentAppearance
+			} else {
+				meta.ContentAppearance = FullWidthContentAppearance
+			}
 
 		default:
 			log.Errorf(


### PR DESCRIPTION
Allows switching between the "full-width" and "fixed" page layouts.

The "fixed" layout renders the page in a narrow column. (Confluence default)

If not configured, it defaults to "full-width".