### PR TITLE
Revert "fix: Support relative links with titleFromH1"

### DIFF
--- a/pkg/mark/link.go
+++ b/pkg/mark/link.go
@@ -29,8 +29,6 @@ func ResolveRelativeLinks(
 	meta *Meta,
 	markdown []byte,
 	base string,
-	spaceFromCli string,
-	titleFromH1 bool,
 ) ([]LinkSubstitution, error) {
 	matches := parseLinks(string(markdown))
 
@@ -44,7 +42,7 @@ func ResolveRelativeLinks(
 			match.hash,
 		)
 
-		resolved, err := resolveLink(api, base, match, spaceFromCli, titleFromH1)
+		resolved, err := resolveLink(api, base, match)
 		if err != nil {
 			return nil, karma.Format(err, "resolve link: %q", match.full)
 		}
@@ -66,15 +64,12 @@ func resolveLink(
 	api *confluence.API,
 	base string,
 	link markdownLink,
-	spaceFromCli string,
-	titleFromH1 bool,
 ) (string, error) {
 	var result string
 
 	if len(link.filename) > 0 {
 		filepath := filepath.Join(base, link.filename)
 
-		log.Tracef(nil, "filepath: %s", filepath)
 		stat, err := os.Stat(filepath)
 		if err != nil {
 			return "", nil
@@ -97,7 +92,7 @@ func resolveLink(
 
 		// This helps to determine if found link points to file that's
 		// not markdown or have mark required metadata
-		linkMeta, _, err := ExtractMeta(linkContents, spaceFromCli, titleFromH1)
+		linkMeta, _, err := ExtractMeta(linkContents)
 		if err != nil {
 			log.Errorf(
 				err,
@@ -111,13 +106,6 @@ func resolveLink(
 		if linkMeta == nil {
 			return "", nil
 		}
-
-		log.Tracef(
-			nil,
-			"extracted metadata: space=%s title=%s",
-			linkMeta.Space,
-			linkMeta.Title,
-		)
 
 		result, err = getConfluenceLink(api, linkMeta.Space, linkMeta.Title)
 		if err != nil {

--- a/pkg/mark/meta.go
+++ b/pkg/mark/meta.go
@@ -46,7 +46,7 @@ var (
 	reHeaderPatternMacro = regexp.MustCompile(`<!-- Macro: .*`)
 )
 
-func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool) (*Meta, []byte, error) {
+func ExtractMeta(data []byte) (*Meta, []byte, error) {
 	var (
 		meta   *Meta
 		offset int
@@ -143,27 +143,6 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool) (*Meta, []b
 			)
 
 			continue
-		}
-	}
-
-	if titleFromH1 || spaceFromCli != "" {
-		if meta == nil {
-			meta = &Meta{}
-		}
-
-		if meta.Type == "" {
-			meta.Type = "page"
-		}
-
-		if meta.ContentAppearance == "" {
-			meta.ContentAppearance = FullWidthContentAppearance // Default to full-width for backwards compatibility
-		}
-
-		if titleFromH1 && meta.Title == "" {
-			meta.Title = ExtractDocumentLeadingH1(data)
-		}
-		if spaceFromCli != "" && meta.Space == "" {
-			meta.Space = spaceFromCli
 		}
 	}
 


### PR DESCRIPTION
This PR broke relative attachments for the marktool in version 8.9.   Would like to revert until there is a fix - see issue https://github.com/kovetskiy/mark/issues/263