### PR TITLE
Fix "<ac:*>" tag rendering

### DIFF
--- a/pkg/mark/markdown.go
+++ b/pkg/mark/markdown.go
@@ -441,9 +441,9 @@ func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib) string {
 
 	tags := regexp.MustCompile(`</?ac:[^>]+>`)
 
-	for _, sm := range tags.FindAll(markdown, -1) {
+	for _, match := range tags.FindAll(markdown, -1) {
 		// Replace the colon in all "<ac:*>" tags with the colon bytes to avoid having Goldmark escape the HTML output.
-		markdown = bytes.ReplaceAll(markdown, sm, bytes.ReplaceAll(sm, []byte(":"), colon))
+		markdown = bytes.ReplaceAll(markdown, match, bytes.ReplaceAll(match, []byte(":"), colon))
 	}
 
 	converter := goldmark.New(

--- a/pkg/mark/testdata/macro-include.html
+++ b/pkg/mark/testdata/macro-include.html
@@ -1,0 +1,6 @@
+<p><foo>bar</foo></p>
+<ac:structured-macro ac:name="info">
+<ac:parameter ac:name="icon">true</ac:parameter>
+<ac:parameter ac:name="title">Attention</ac:parameter>
+<ac:rich-text-body>This is an info!</ac:rich-text-body>
+</ac:structured-macro>

--- a/pkg/mark/testdata/macro-include.md
+++ b/pkg/mark/testdata/macro-include.md
@@ -1,0 +1,7 @@
+<foo>bar</foo>
+
+<ac:structured-macro ac:name="info">
+<ac:parameter ac:name="icon">true</ac:parameter>
+<ac:parameter ac:name="title">Attention</ac:parameter>
+<ac:rich-text-body>This is an info!</ac:rich-text-body>
+</ac:structured-macro>


### PR DESCRIPTION
Extend the existing workaround to avoid HTML element escaping to handle more variants.