### PR TITLE
feat: Support page include, excerpt and excerpt-include macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,10 @@ By default, mark provides several built-in templates and macros:
 
   See: https://confluence.atlassian.com/doc/blog-posts-macro-139470.html
 
+* template: `ac:include` to include a page
+  - Page: the page to be included
+  - Space: the space the page is in (optional, otherwise same space)
+
 * macro `@{...}` to mention user by name specified in the braces.
 
 ## Template & Macros Usecases

--- a/README.md
+++ b/README.md
@@ -375,6 +375,15 @@ By default, mark provides several built-in templates and macros:
   - Page: the page to be included
   - Space: the space the page is in (optional, otherwise same space)
 
+* template: `ac:excerpt-include` to include the excerpt from another page
+  - Page: the page the excerpt should be included from
+  - NoPanel: Determines whether Confluence will display a panel around the excerpted content (optional, default: false)
+
+* template: `ac:excerpt` to create an excerpt and include it in the page
+  - Excerpt: The text you want to include
+  - OutputType: Determines whether the content of the Excerpt macro body is displayed on a new line or inline (optional, options: "BLOCK" or "INLINE", default: BLOCK)
+  - Hidden: Hide the excerpt content (optional, default: false)
+
 * macro `@{...}` to mention user by name specified in the braces.
 
 ## Template & Macros Usecases

--- a/pkg/mark/markdown.go
+++ b/pkg/mark/markdown.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	cparser "github.com/kovetskiy/mark/pkg/mark/parser"
 	"github.com/kovetskiy/mark/pkg/mark/stdlib"
 	"github.com/reconquest/pkg/log"
 	"github.com/yuin/goldmark"
@@ -450,7 +451,7 @@ func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib) string {
 	converter.Parser().AddOptions(parser.WithInlineParsers(
 		// Must be registered with a higher priority than goldmark's linkParser to make sure goldmark doesn't parse
 		// the <ac:*/> tags.
-		util.Prioritized(NewACTagParser(), 199),
+		util.Prioritized(cparser.NewConfluenceTagParser(), 199),
 	))
 
 	converter.Renderer().AddOptions(renderer.WithNodeRenderers(

--- a/pkg/mark/stdlib/stdlib.go
+++ b/pkg/mark/stdlib/stdlib.go
@@ -261,6 +261,18 @@ func templates(api *confluence.API) (*template.Template, error) {
 			`</ac:structured-macro>{{printf "\n"}}`,
 		),
 
+		/* https://confluence.atlassian.com/conf59/include-page-macro-792499125.html */
+
+		`ac:include`: text(
+			`<ac:structured-macro ac:name="include">{{printf "\n"}}`,
+			`<ac:parameter ac:name="">{{printf "\n"}}`,
+			`<ac:link>{{printf "\n"}}`,
+			`<ri:page ri:content-title="{{ .Page }}" {{if .Space }}ri:space-key="{{ .Space }}"{{end}}/>{{printf "\n"}}`,
+			`</ac:link>{{printf "\n"}}`,
+			`</ac:parameter>{{printf "\n"}}`,
+			`</ac:structured-macro>{{printf "\n"}}`,
+		),
+
 		// TODO(seletskiy): more templates here
 	} {
 		templates, err = templates.New(name).Parse(body)

--- a/pkg/mark/stdlib/stdlib.go
+++ b/pkg/mark/stdlib/stdlib.go
@@ -273,6 +273,27 @@ func templates(api *confluence.API) (*template.Template, error) {
 			`</ac:structured-macro>{{printf "\n"}}`,
 		),
 
+		/* https://confluence.atlassian.com/conf59/excerpt-include-macro-792499101.html */
+
+		`ac:excerpt-include`: text(
+			`<ac:macro ac:name="excerpt-include">{{printf "\n"}}`,
+			`<ac:parameter ac:name="nopanel">{{ if .NoPanel }}{{ .NoPanel }}{{ else }}false{{ end }}</ac:parameter>{{printf "\n"}}`,
+			`<ac:default-parameter>{{ .Page }}</ac:default-parameter>{{printf "\n"}}`,
+			`</ac:macro>{{printf "\n"}}`,
+		),
+
+		/* https://confluence.atlassian.com/conf59/excerpt-macro-792499102.html */
+
+		`ac:excerpt`: text(
+			`<ac:structured-macro ac:name="excerpt">{{printf "\n"}}`,
+			`<ac:parameter ac:name="hidden">{{ if .Hidden }}{{ .Hidden }}{{ else }}false{{ end }}</ac:parameter>{{printf "\n"}}`,
+			`<ac:parameter ac:name="atlassian-macro-output-type">{{ if .OutputType }}{{ .OutputType }}{{ else }}BLOCK{{ end }}</ac:parameter>{{printf "\n"}}`,
+			`<ac:rich-text-body>{{printf "\n"}}`,
+			`{{ .Excerpt }}{{printf "\n"}}`,
+			`</ac:rich-text-body>{{printf "\n"}}`,
+			`</ac:structured-macro>{{printf "\n"}}`,
+		),
+
 		// TODO(seletskiy): more templates here
 	} {
 		templates, err = templates.New(name).Parse(body)


### PR DESCRIPTION
Also generalize the ac_tag_parser a bit and support <ri:* /> tags as well

@bernd @kovetskiy 