### PR TITLE
fix: Remove double interpolation for attachments (BREAKING)

### DIFF
--- a/pkg/mark/attachment.go
+++ b/pkg/mark/attachment.go
@@ -207,20 +207,6 @@ func CompileAttachmentLinks(markdown []byte, attaches []Attachment) []byte {
 		if bytes.Contains(markdown, []byte("attachment://"+replace)) {
 			from := "attachment://" + replace
 
-			log.Debugf(nil, "replacing legacy link: %q -> %q", from, to)
-
-			markdown = bytes.ReplaceAll(
-				markdown,
-				[]byte(from),
-				[]byte(to),
-			)
-
-			found = true
-		}
-
-		if bytes.Contains(markdown, []byte(replace)) {
-			from := replace
-
 			log.Debugf(nil, "replacing link: %q -> %q", from, to)
 
 			markdown = bytes.ReplaceAll(


### PR DESCRIPTION
The use case was that when using the "attachment://", it would replace the link twice, once on the "attachment://" and after that on the replace all as well as the string will be present in the replacement. This ensures that the keyword only get replcaed once.

Furthermore, put "attachment://" in as a identifier for a replacement is better then nothing since you effectively create a ban word in the name of the attachement file.

if you have an `attachement://foo`, currently it get transformed into `/wiki/<path>/foo?query` which get transformed into `/wiki/<path>/wiki/<path>/foo?query?query`

this PR changes it to only have a single interpolation.

Note that this is a breaking change as simple text references to files will break. But it seems better to prefix it with `attachement://` anyways to avoid creating ban words in your text.