### PR TITLE
feat: Add template for the confluence mermaid-cloud plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,32 @@ And attach any image with the following
 The width will be the commented html after the image (in this case 300px).
 
 
+### Usage with the mermaid-cloud plugin
+
+> Note: The mermaid-cloud plugin needs to be added to your Confluence instance
+
+This plugin uses attachments to provide and place the graph in your confluence page, so don't forget to add the attachment.
+
+```mardown
+<!-- Attachment: graph.mermaid -->
+<!-- Macro: :mermaid:(.+):(.*):(.*)
+     Template: ac:mermaidcloud
+     Filename: ${1}
+     Revision: ${2}
+     Layout: ${3}
+-->
+
+```
+
+> Note: This is a complete example, but Revision and Layout can be ommited from the Template as they are optional.
+
+And now you only need to add the following to add the mermaid diagram:
+
+```
+:mermaid:graph.mermaid:1:default:
+```
+
+
 ## Installation
 
 ### Homebrew

--- a/pkg/mark/stdlib/stdlib.go
+++ b/pkg/mark/stdlib/stdlib.go
@@ -299,6 +299,15 @@ func templates(api *confluence.API) (*template.Template, error) {
 		`ac:anchor`: text(
 			`<ac:structured-macro ac:name="anchor">{{printf "\n"}}`,
 			`<ac:parameter ac:name="">{{ .Anchor }}</ac:parameter>{{printf "\n"}}`,
+		`</ac:structured-macro>{{printf "\n"}}`,
+		),
+
+		/* https://stratus-addons.atlassian.net/wiki/spaces/MDFC/overview?homepageId=1650262147 */
+
+		`ac:mermaidcloud`: text(
+			`<ac:structured-macro ac:name="mermaid-cloud" ac:schema-version="1" data-layout="{{ if .Layout }}{{ .Layout }}{{ else }}default{{ end }}">{{printf "\n"}}`,
+			`{{ if .Filename }}<ac:parameter ac:name="filename">{{ .Filename }}</ac:parameter>{{printf "\n"}}{{end}}`,
+			`{{ if .Revision }}<ac:parameter ac:name="revision">{{ .Revision }}</ac:parameter>{{printf "\n"}}{{end}}`,
 			`</ac:structured-macro>{{printf "\n"}}`,
 		),
 


### PR DESCRIPTION
While mark already support other mermaid plugins. This is using the free plugin from the mermaid community.

IMPORTANT NOTE: This PR is dependant on #284 as the bug was discovered while developing this feature.