### PR TITLE
.goreleaser.yml: Support arm64 builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,9 @@ builds:
   - linux
   # windows fails with an error https://github.com/kovetskiy/mark/runs/5034726426?check_suite_focus=true
   # - windows
+  goarch:
+  - amd64
+  - arm64
 archives:
 - replacements:
     darwin: Darwin


### PR DESCRIPTION
This should provide executables for OS X with m1/m2 chipsets as well as Linux arm64 machines.