### PR TITLE
Fix mermaid-go rendering

### DIFF
--- a/pkg/mark/markdown.go
+++ b/pkg/mark/markdown.go
@@ -378,12 +378,14 @@ func (r *ConfluenceRenderer) renderFencedCodeBlock(writer util.BufWriter, source
 				Title      string
 				Alt        string
 				Attachment string
+				Url        string
 			}{
 				attachment.Width,
 				attachment.Height,
 				attachment.Name,
 				"",
 				attachment.Filename,
+				"",
 			},
 		)
 


### PR DESCRIPTION
This broke as the template added an .Url field.