### PR TITLE
Move drop-h1 to the renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ GLOBAL OPTIONS:
    --compile-only                                show resulting HTML and don't update Confluence page content. (default: false) [$MARK_COMPILE_ONLY]
    --dry-run                                     resolve page and ancestry, show resulting HTML and exit. (default: false) [$MARK_DRY_RUN]
    --edit-lock, -k                               lock page editing to current user only to prevent accidental manual edits over Confluence Web UI. (default: false) [$MARK_EDIT_LOCK]
-   --drop-h1, --h1_drop                          don't include H1 headings in Confluence output. (default: false) [$MARK_H1_DROP]
+   --drop-h1, --h1_drop                          don't include the first H1 heading in Confluence output. (default: false) [$MARK_H1_DROP]
    --title-from-h1, --h1_title                   extract page title from a leading H1 heading. If no H1 heading on a page exists, then title must be set in the page metadata. (default: false) [$MARK_H1_TITLE]
    --minor-edit                                  don't send notifications while updating Confluence page. (default: false) [$MARK_MINOR_EDIT]
    --color value                                 display logs in color. Possible values: auto, never. (default: "auto") [$MARK_COLOR]

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ var flags = []cli.Flag{
 		Name:    "drop-h1",
 		Value:   false,
 		Aliases: []string{"h1_drop"},
-		Usage:   "don't include H1 headings in Confluence output.",
+		Usage:   "don't include the first H1 heading in Confluence output.",
 		EnvVars: []string{"MARK_H1_DROP"},
 	}),
 	altsrc.NewBoolFlag(&cli.BoolFlag{
@@ -361,10 +361,9 @@ func processFile(
 			log.Info(
 				"the leading H1 heading will be excluded from the Confluence output",
 			)
-			markdown = mark.DropDocumentLeadingH1(markdown)
 		}
 
-		html, _ := mark.CompileMarkdown(markdown, stdlib, file, cCtx.String("mermaid-provider"))
+		html, _ := mark.CompileMarkdown(markdown, stdlib, file, cCtx.String("mermaid-provider"), cCtx.Bool("drop-h1"))
 		fmt.Println(html)
 		os.Exit(0)
 	}
@@ -438,10 +437,9 @@ func processFile(
 		log.Info(
 			"the leading H1 heading will be excluded from the Confluence output",
 		)
-		markdown = mark.DropDocumentLeadingH1(markdown)
 	}
 
-	html, inlineAttachments := mark.CompileMarkdown(markdown, stdlib, file, cCtx.String("mermaid-provider"))
+	html, inlineAttachments := mark.CompileMarkdown(markdown, stdlib, file, cCtx.String("mermaid-provider"), cCtx.Bool("drop-h1"))
 
 	// Resolve attachements detected from markdown
 	_, err = mark.ResolveAttachments(

--- a/pkg/mark/markdown_test.go
+++ b/pkg/mark/markdown_test.go
@@ -36,7 +36,7 @@ func TestCompileMarkdown(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		actual, _ := CompileMarkdown(markdown, lib, filename, "")
+		actual, _ := CompileMarkdown(markdown, lib, filename, "", false)
 		test.EqualValues(string(html), actual, filename+" vs "+htmlname)
 	}
 }


### PR DESCRIPTION
This is more reliable than a regular expression.


@kovetskiy do you know if we want to drop *ALL* h1 or just the first one with this?