### PR TITLE
Disable typographer extension

### DIFF
--- a/pkg/mark/markdown.go
+++ b/pkg/mark/markdown.go
@@ -655,7 +655,6 @@ func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib, path string, mermaidPr
 			extension.GFM,
 			extension.Footnote,
 			extension.DefinitionList,
-			extension.Typographer,
 		),
 		goldmark.WithParserOptions(
 			parser.WithAutoHeadingID(),


### PR DESCRIPTION
This caused issues with confluence macros due to quotes getting replaced.

