### PR TITLE
.github: Reorder steps to use module caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
     - master
 
 env:
-  GO_VERSION: "~1.20.4"
+  GO_VERSION: "~1.20.5"
 
 jobs:
   # Runs Golangci-lint on the source code
@@ -19,14 +19,14 @@ jobs:
     name: ci-go-lint
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
@@ -36,14 +36,14 @@ jobs:
     name: ci-unit-tests
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Run unit tests
       run: |
@@ -54,14 +54,14 @@ jobs:
     name: ci-build
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Build mark
       run: |


### PR DESCRIPTION
This allows to use go.mod caching 