### PR TITLE
Adding linebreak stripping

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,6 +750,7 @@ GLOBAL OPTIONS:
    --dry-run                                     resolve page and ancestry, show resulting HTML and exit. (default: false) [$MARK_DRY_RUN]
    --edit-lock, -k                               lock page editing to current user only to prevent accidental manual edits over Confluence Web UI. (default: false) [$MARK_EDIT_LOCK]
    --drop-h1, --h1_drop                          don't include the first H1 heading in Confluence output. (default: false) [$MARK_H1_DROP]
+   --strip-linebreak                             remove linebreaks inside of tags, to accomodate Confluence non-standard behavior (default: false)
    --title-from-h1, --h1_title                   extract page title from a leading H1 heading. If no H1 heading on a page exists, then title must be set in the page metadata. (default: false) [$MARK_H1_TITLE]
    --minor-edit                                  don't send notifications while updating Confluence page. (default: false) [$MARK_MINOR_EDIT]
    --color value                                 display logs in color. Possible values: auto, never. (default: "auto") [$MARK_COLOR]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       # Linux 32-bit
       # - GOOS=linux
       # - GOARCH=386
-      
+
       # Windows 64-bit
       # - GOOS=windows
       # - GOARCH=amd64

--- a/main.go
+++ b/main.go
@@ -64,6 +64,13 @@ var flags = []cli.Flag{
 		EnvVars: []string{"MARK_H1_DROP"},
 	}),
 	altsrc.NewBoolFlag(&cli.BoolFlag{
+		Name:    "strip-linebreaks",
+		Value:   false,
+		Aliases: []string{"L"},
+		Usage:   "remove linebreaks inside of tags, to accomodate non-standard Confluence behavior",
+		EnvVars: []string{"MARK_STRIP_LINEBREAK"},
+	}),
+	altsrc.NewBoolFlag(&cli.BoolFlag{
 		Name:    "title-from-h1",
 		Value:   false,
 		Aliases: []string{"h1_title"},
@@ -383,7 +390,7 @@ func processFile(
 			)
 		}
 
-		html, _ := mark.CompileMarkdown(markdown, stdlib, file, cCtx.String("mermaid-provider"), cCtx.Float64("mermaid-scale"), cCtx.Bool("drop-h1"))
+		html, _ := mark.CompileMarkdown(markdown, stdlib, file, cCtx.String("mermaid-provider"), cCtx.Float64("mermaid-scale"), cCtx.Bool("drop-h1"), cCtx.Bool("strip-linebreaks"))
 		fmt.Println(html)
 		os.Exit(0)
 	}
@@ -459,7 +466,7 @@ func processFile(
 		)
 	}
 
-	html, inlineAttachments := mark.CompileMarkdown(markdown, stdlib, file, cCtx.String("mermaid-provider"), cCtx.Float64("mermaid-scale"), cCtx.Bool("drop-h1"))
+	html, inlineAttachments := mark.CompileMarkdown(markdown, stdlib, file, cCtx.String("mermaid-provider"), cCtx.Float64("mermaid-scale"), cCtx.Bool("drop-h1"), cCtx.Bool("strip-linebreaks"))
 
 	// Resolve attachements detected from markdown
 	_, err = attachment.ResolveAttachments(

--- a/pkg/mark/markdown_test.go
+++ b/pkg/mark/markdown_test.go
@@ -10,6 +10,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func loadData(t *testing.T, filename, variant string) ([]byte, string, []byte) {
+	t.Helper()
+	basename := filepath.Base(filename)
+	testname := strings.TrimSuffix(basename, ".md")
+	htmlname := filepath.Join(filepath.Dir(filename), testname+variant+".html")
+
+	markdown, err := os.ReadFile(filename)
+	if err != nil {
+		panic(err)
+	}
+	html, err := os.ReadFile(htmlname)
+	if err != nil {
+		panic(err)
+	}
+
+	return markdown, htmlname, html
+}
+
 func TestCompileMarkdown(t *testing.T) {
 	test := assert.New(t)
 
@@ -19,24 +37,50 @@ func TestCompileMarkdown(t *testing.T) {
 	}
 
 	for _, filename := range testcases {
-		basename := filepath.Base(filename)
-		testname := strings.TrimSuffix(basename, ".md")
-		htmlname := filepath.Join(filepath.Dir(filename), testname+".html")
-
-		markdown, err := os.ReadFile(filename)
-		if err != nil {
-			panic(err)
-		}
-		html, err := os.ReadFile(htmlname)
-		if err != nil {
-			panic(err)
-		}
-
 		lib, err := stdlib.New(nil)
 		if err != nil {
 			panic(err)
 		}
-		actual, _ := CompileMarkdown(markdown, lib, filename, "", 1.0, false)
+		markdown, htmlname, html := loadData(t, filename, "")
+		actual, _ := CompileMarkdown(markdown, lib, filename, "", 1.0, false, false)
+		test.EqualValues(string(html), actual, filename+" vs "+htmlname)
+	}
+}
+
+func TestCompileMarkdownDropH1(t *testing.T) {
+	test := assert.New(t)
+
+	testcases, err := filepath.Glob("testdata/*.md")
+	if err != nil {
+		panic(err)
+	}
+
+	for _, filename := range testcases {
+		lib, err := stdlib.New(nil)
+		if err != nil {
+			panic(err)
+		}
+		markdown, htmlname, html := loadData(t, filename, "-droph1")
+		actual, _ := CompileMarkdown(markdown, lib, filename, "", 1.0, true, false)
+		test.EqualValues(string(html), actual, filename+" vs "+htmlname)
+	}
+}
+
+func TestCompileMarkdownStripNewlines(t *testing.T) {
+	test := assert.New(t)
+
+	testcases, err := filepath.Glob("testdata/*.md")
+	if err != nil {
+		panic(err)
+	}
+
+	for _, filename := range testcases {
+		lib, err := stdlib.New(nil)
+		if err != nil {
+			panic(err)
+		}
+		markdown, htmlname, html := loadData(t, filename, "-stripnewlines")
+		actual, _ := CompileMarkdown(markdown, lib, filename, "", 1.0, false, true)
 		test.EqualValues(string(html), actual, filename+" vs "+htmlname)
 	}
 }

--- a/pkg/mark/renderer/text.go
+++ b/pkg/mark/renderer/text.go
@@ -3,19 +3,26 @@ package renderer
 import (
 	"unicode/utf8"
 
-	//"github.com/kovetskiy/mark/pkg/mark/stdlib"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/util"
 )
 
+// ConfluenceTextRenderer slightly alters the default goldmark behavior for
+// inline text block. It allows for soft breaks
+// (c.f. https://spec.commonmark.org/0.30/#softbreak)
+// to be rendered into HTML as either '\n' (the goldmark default)
+// or as ' '.
+// This latter option is useful for Confluence,
+// which inserts <br> tags into uploaded HTML where it sees '\n'.
+// See also https://sembr.org/ for partial motivation.
 type ConfluenceTextRenderer struct {
 	html.Config
 	softBreak rune
 }
 
-// NewConfluenceRenderer creates a new instance of the ConfluenceRenderer
+// NewConfluenceTextRenderer creates a new instance of the ConfluenceTextRenderer
 func NewConfluenceTextRenderer(stripNL bool, opts ...html.Option) renderer.NodeRenderer {
 	sb := '\n'
 	if stripNL {
@@ -32,6 +39,8 @@ func (r *ConfluenceTextRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegi
 	reg.Register(ast.KindText, r.renderText)
 }
 
+// This is taken from https://github.com/yuin/goldmark/blob/v1.5.6/renderer/html/html.go#L648
+// with the hardcoded '\n' for soft breaks swapped for the configurable r.softBreak
 func (r *ConfluenceTextRenderer) renderText(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if !entering {
 		return ast.WalkContinue, nil

--- a/pkg/mark/renderer/text.go
+++ b/pkg/mark/renderer/text.go
@@ -1,0 +1,71 @@
+package renderer
+
+import (
+	"unicode/utf8"
+
+	//"github.com/kovetskiy/mark/pkg/mark/stdlib"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/util"
+)
+
+type ConfluenceTextRenderer struct {
+	html.Config
+	softBreak rune
+}
+
+// NewConfluenceRenderer creates a new instance of the ConfluenceRenderer
+func NewConfluenceTextRenderer(stripNL bool, opts ...html.Option) renderer.NodeRenderer {
+	sb := '\n'
+	if stripNL {
+		sb = ' '
+	}
+	return &ConfluenceTextRenderer{
+		Config:    html.NewConfig(),
+		softBreak: sb,
+	}
+}
+
+// RegisterFuncs implements NodeRenderer.RegisterFuncs .
+func (r *ConfluenceTextRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(ast.KindText, r.renderText)
+}
+
+func (r *ConfluenceTextRenderer) renderText(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	n := node.(*ast.Text)
+	segment := n.Segment
+	if n.IsRaw() {
+		r.Writer.RawWrite(w, segment.Value(source))
+	} else {
+		value := segment.Value(source)
+		r.Writer.Write(w, value)
+		if n.HardLineBreak() || (n.SoftLineBreak() && r.HardWraps) {
+			if r.XHTML {
+				_, _ = w.WriteString("<br />\n")
+			} else {
+				_, _ = w.WriteString("<br>\n")
+			}
+		} else if n.SoftLineBreak() {
+			if r.EastAsianLineBreaks && len(value) != 0 {
+				sibling := node.NextSibling()
+				if sibling != nil && sibling.Kind() == ast.KindText {
+					if siblingText := sibling.(*ast.Text).Text(source); len(siblingText) != 0 {
+						thisLastRune := util.ToRune(value, len(value)-1)
+						siblingFirstRune, _ := utf8.DecodeRune(siblingText)
+						if !(util.IsEastAsianWideRune(thisLastRune) &&
+							util.IsEastAsianWideRune(siblingFirstRune)) {
+							_ = w.WriteByte(byte(r.softBreak))
+						}
+					}
+				}
+			} else {
+				_ = w.WriteByte(byte(r.softBreak))
+			}
+		}
+	}
+	return ast.WalkContinue, nil
+}

--- a/pkg/mark/testdata/codes-droph1.html
+++ b/pkg/mark/testdata/codes-droph1.html
@@ -1,0 +1,20 @@
+<p><code>inline</code></p>
+<ac:structured-macro ac:name="code"><ac:parameter ac:name="language"></ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[some code]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">bash</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[code bash]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">bash</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[with a newline
+]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">unknown</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[unknown code]]></ac:plain-text-body></ac:structured-macro><p>text
+text 2</p>
+<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">unknown</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[unknown code 2]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">sh</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:parameter ac:name="title">A b c</ac:parameter><ac:plain-text-body><![CDATA[no-collapse-title]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">bash</ac:parameter><ac:parameter ac:name="collapse">true</ac:parameter><ac:parameter ac:name="title">A b c</ac:parameter><ac:plain-text-body><![CDATA[collapse-and-title]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">c</ac:parameter><ac:parameter ac:name="collapse">true</ac:parameter><ac:plain-text-body><![CDATA[collapse-no-title]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">nested</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[code
+``` more code ```
+even more code]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language"></ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[indented code block
+with multiple lines]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="cloudscript-confluence-mermaid"><ac:parameter ac:name="showSource">true</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="cloudscript-confluence-mermaid"><ac:parameter ac:name="showSource">true</ac:parameter><ac:parameter ac:name="collapse">true</ac:parameter><ac:parameter ac:name="title">my mermaid graph</ac:parameter><ac:plain-text-body><![CDATA[graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="cloudscript-confluence-mermaid"><ac:parameter ac:name="showSource">true</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:parameter ac:name="title">my mermaid graph</ac:parameter><ac:plain-text-body><![CDATA[graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;]]></ac:plain-text-body></ac:structured-macro>

--- a/pkg/mark/testdata/codes-stripnewlines.html
+++ b/pkg/mark/testdata/codes-stripnewlines.html
@@ -1,0 +1,19 @@
+<p><code>inline</code></p>
+<ac:structured-macro ac:name="code"><ac:parameter ac:name="language"></ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[some code]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">bash</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[code bash]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">bash</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[with a newline
+]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">unknown</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[unknown code]]></ac:plain-text-body></ac:structured-macro><p>text text 2</p>
+<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">unknown</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[unknown code 2]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">sh</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:parameter ac:name="title">A b c</ac:parameter><ac:plain-text-body><![CDATA[no-collapse-title]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">bash</ac:parameter><ac:parameter ac:name="collapse">true</ac:parameter><ac:parameter ac:name="title">A b c</ac:parameter><ac:plain-text-body><![CDATA[collapse-and-title]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">c</ac:parameter><ac:parameter ac:name="collapse">true</ac:parameter><ac:plain-text-body><![CDATA[collapse-no-title]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">nested</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[code
+``` more code ```
+even more code]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="code"><ac:parameter ac:name="language"></ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[indented code block
+with multiple lines]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="cloudscript-confluence-mermaid"><ac:parameter ac:name="showSource">true</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="cloudscript-confluence-mermaid"><ac:parameter ac:name="showSource">true</ac:parameter><ac:parameter ac:name="collapse">true</ac:parameter><ac:parameter ac:name="title">my mermaid graph</ac:parameter><ac:plain-text-body><![CDATA[graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name="cloudscript-confluence-mermaid"><ac:parameter ac:name="showSource">true</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:parameter ac:name="title">my mermaid graph</ac:parameter><ac:plain-text-body><![CDATA[graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;]]></ac:plain-text-body></ac:structured-macro>

--- a/pkg/mark/testdata/header-droph1.html
+++ b/pkg/mark/testdata/header-droph1.html
@@ -1,0 +1,6 @@
+<h2 id="b">b</h2>
+<h3 id="c">c</h3>
+<h4 id="d">d</h4>
+<h5 id="e">e</h5>
+<h1 id="f">f</h1>
+<h2 id="g">g</h2>

--- a/pkg/mark/testdata/header-stripnewlines.html
+++ b/pkg/mark/testdata/header-stripnewlines.html
@@ -1,0 +1,7 @@
+<h1 id="a">a</h1>
+<h2 id="b">b</h2>
+<h3 id="c">c</h3>
+<h4 id="d">d</h4>
+<h5 id="e">e</h5>
+<h1 id="f">f</h1>
+<h2 id="g">g</h2>

--- a/pkg/mark/testdata/issue-64-broken-link-droph1.html
+++ b/pkg/mark/testdata/issue-64-broken-link-droph1.html
@@ -1,0 +1,1 @@
+<p><a href="Page2#Page2-Releasev71-22-Feb-2018(intern)">v71</a></p>

--- a/pkg/mark/testdata/issue-64-broken-link-stripnewlines.html
+++ b/pkg/mark/testdata/issue-64-broken-link-stripnewlines.html
@@ -1,0 +1,1 @@
+<p><a href="Page2#Page2-Releasev71-22-Feb-2018(intern)">v71</a></p>

--- a/pkg/mark/testdata/links-droph1.html
+++ b/pkg/mark/testdata/links-droph1.html
@@ -1,0 +1,17 @@
+<p>Use <a href="https://example.com">https://example.com</a></p>
+<p>Use <ac:rich-text-body>aaa</ac:rich-text-body></p>
+<p>Use <ac:link><ri:page ri:content-title="Page"/><ac:plain-text-link-body><![CDATA[page link]]></ac:plain-text-link-body></ac:link></p>
+<p>Use <ac:link><ri:page ri:content-title="AnotherPage"/><ac:plain-text-link-body><![CDATA[AnotherPage]]></ac:plain-text-link-body></ac:link></p>
+<p>Use <ac:link><ri:page ri:content-title="Another Page"/><ac:plain-text-link-body><![CDATA[Another Page]]></ac:plain-text-link-body></ac:link></p>
+<p>Use <ac:link><ri:page ri:content-title="Page With Space"/><ac:plain-text-link-body><![CDATA[page link with spaces]]></ac:plain-text-link-body></ac:link></p>
+<p><ac:image ac:alt="My Image"><ri:attachment ri:filename="test.png"/></ac:image></p>
+<p><ac:image ac:alt="My External Image"><ri:url ri:value="http://confluence.atlassian.com/images/logo/confluence_48_trans.png?key1=value1&amp;key2=value2"/></ac:image></p>
+<p>Use footnotes link <sup id="fnref:1"><a href="#fn:1" class="footnote-ref" role="doc-noteref">1</a></sup></p>
+<div class="footnotes" role="doc-endnotes">
+<hr />
+<ol>
+<li id="fn:1">
+<p>a footnote link&#160;<a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+</li>
+</ol>
+</div>

--- a/pkg/mark/testdata/links-stripnewlines.html
+++ b/pkg/mark/testdata/links-stripnewlines.html
@@ -1,0 +1,17 @@
+<p>Use <a href="https://example.com">https://example.com</a></p>
+<p>Use <ac:rich-text-body>aaa</ac:rich-text-body></p>
+<p>Use <ac:link><ri:page ri:content-title="Page"/><ac:plain-text-link-body><![CDATA[page link]]></ac:plain-text-link-body></ac:link></p>
+<p>Use <ac:link><ri:page ri:content-title="AnotherPage"/><ac:plain-text-link-body><![CDATA[AnotherPage]]></ac:plain-text-link-body></ac:link></p>
+<p>Use <ac:link><ri:page ri:content-title="Another Page"/><ac:plain-text-link-body><![CDATA[Another Page]]></ac:plain-text-link-body></ac:link></p>
+<p>Use <ac:link><ri:page ri:content-title="Page With Space"/><ac:plain-text-link-body><![CDATA[page link with spaces]]></ac:plain-text-link-body></ac:link></p>
+<p><ac:image ac:alt="My Image"><ri:attachment ri:filename="test.png"/></ac:image></p>
+<p><ac:image ac:alt="My External Image"><ri:url ri:value="http://confluence.atlassian.com/images/logo/confluence_48_trans.png?key1=value1&amp;key2=value2"/></ac:image></p>
+<p>Use footnotes link <sup id="fnref:1"><a href="#fn:1" class="footnote-ref" role="doc-noteref">1</a></sup></p>
+<div class="footnotes" role="doc-endnotes">
+<hr />
+<ol>
+<li id="fn:1">
+<p>a footnote link&#160;<a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+</li>
+</ol>
+</div>

--- a/pkg/mark/testdata/lists-droph1.html
+++ b/pkg/mark/testdata/lists-droph1.html
@@ -1,0 +1,21 @@
+<ul>
+<li>dash 1-1</li>
+<li>dash 1-2</li>
+<li>dash 1-3
+<ul>
+<li>dash 1-3-1</li>
+<li>dash 1-3-2</li>
+<li>dash 1-3-3
+<ul>
+<li>dash 1-3-3-1</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<p>text</p>
+<ul>
+<li>a</li>
+<li>b</li>
+<li>c</li>
+</ul>

--- a/pkg/mark/testdata/lists-stripnewlines.html
+++ b/pkg/mark/testdata/lists-stripnewlines.html
@@ -1,0 +1,21 @@
+<ul>
+<li>dash 1-1</li>
+<li>dash 1-2</li>
+<li>dash 1-3
+<ul>
+<li>dash 1-3-1</li>
+<li>dash 1-3-2</li>
+<li>dash 1-3-3
+<ul>
+<li>dash 1-3-3-1</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<p>text</p>
+<ul>
+<li>a</li>
+<li>b</li>
+<li>c</li>
+</ul>

--- a/pkg/mark/testdata/macro-include-droph1.html
+++ b/pkg/mark/testdata/macro-include-droph1.html
@@ -1,0 +1,6 @@
+<p><foo>bar</foo></p>
+<p><ac:structured-macro ac:name="info">
+<ac:parameter ac:name="icon">true</ac:parameter>
+<ac:parameter ac:name="title">Attention</ac:parameter>
+<ac:rich-text-body>This is an info!</ac:rich-text-body>
+</ac:structured-macro></p>

--- a/pkg/mark/testdata/macro-include-stripnewlines.html
+++ b/pkg/mark/testdata/macro-include-stripnewlines.html
@@ -1,0 +1,2 @@
+<p><foo>bar</foo></p>
+<p><ac:structured-macro ac:name="info"> <ac:parameter ac:name="icon">true</ac:parameter> <ac:parameter ac:name="title">Attention</ac:parameter> <ac:rich-text-body>This is an info!</ac:rich-text-body> </ac:structured-macro></p>

--- a/pkg/mark/testdata/newlines-droph1.html
+++ b/pkg/mark/testdata/newlines-droph1.html
@@ -1,0 +1,10 @@
+<p>one-1
+one-2</p>
+<p>two-1</p>
+<p>two-2</p>
+<p>three-1</p>
+<p>three-2</p>
+<p>space-1
+space-2</p>
+<p>2space-1<br />
+2space-2</p>

--- a/pkg/mark/testdata/newlines-stripnewlines.html
+++ b/pkg/mark/testdata/newlines-stripnewlines.html
@@ -1,0 +1,8 @@
+<p>one-1 one-2</p>
+<p>two-1</p>
+<p>two-2</p>
+<p>three-1</p>
+<p>three-2</p>
+<p>space-1 space-2</p>
+<p>2space-1<br />
+2space-2</p>

--- a/pkg/mark/testdata/pagelayout-droph1.html
+++ b/pkg/mark/testdata/pagelayout-droph1.html
@@ -1,0 +1,18 @@
+<ac:layout>
+<ac:layout-section type="three_with_sidebars">
+<ac:layout-cell>
+<p>More Content</p>
+</ac:layout-cell>
+<ac:layout-cell>
+<p>More Content</p>
+</ac:layout-cell>
+<ac:layout-cell>
+<p>Even More Content</p>
+</ac:layout-cell>
+</ac:layout-section>
+<ac:layout-section type="single">
+<ac:layout-cell>
+<p>Still More Content</p>
+</ac:layout-cell>
+</ac:layout-section>
+</ac:layout>

--- a/pkg/mark/testdata/pagelayout-stripnewlines.html
+++ b/pkg/mark/testdata/pagelayout-stripnewlines.html
@@ -1,0 +1,18 @@
+<ac:layout>
+<ac:layout-section type="three_with_sidebars">
+<ac:layout-cell>
+<p>More Content</p>
+</ac:layout-cell>
+<ac:layout-cell>
+<p>More Content</p>
+</ac:layout-cell>
+<ac:layout-cell>
+<p>Even More Content</p>
+</ac:layout-cell>
+</ac:layout-section>
+<ac:layout-section type="single">
+<ac:layout-cell>
+<p>Still More Content</p>
+</ac:layout-cell>
+</ac:layout-section>
+</ac:layout>

--- a/pkg/mark/testdata/quotes-droph1.html
+++ b/pkg/mark/testdata/quotes-droph1.html
@@ -1,4 +1,3 @@
-<h1 id="main-heading">Main Heading</h1>
 <h2 id="first-heading">First Heading</h2>
 <ac:structured-macro ac:name="note"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
 <p><strong>NOTES:</strong></p>

--- a/pkg/mark/testdata/quotes-stripnewlines.html
+++ b/pkg/mark/testdata/quotes-stripnewlines.html
@@ -7,8 +7,7 @@
 <li>Note number two</li>
 </ol>
 <blockquote>
-<p>a
-b</p>
+<p>a b</p>
 </blockquote>
 <p><strong>Warn (Should not be picked as blockquote type)</strong></p>
 </ac:rich-text-body></ac:structured-macro>
@@ -21,8 +20,7 @@ b</p>
 </ul>
 </ac:rich-text-body></ac:structured-macro>
 <ul>
-<li>Regular list
-that runs long</li>
+<li>Regular list that runs long</li>
 </ul>
 <h2 id="third-heading">Third Heading</h2>
 <ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>

--- a/pkg/mark/testdata/quotes.md
+++ b/pkg/mark/testdata/quotes.md
@@ -19,6 +19,8 @@
 > * Warn bullet 1
 > * Warn bullet 2
 
+* Regular list
+  that runs long
 
 ## Third Heading
 > <!-- Info -->

--- a/pkg/mark/testdata/table-droph1.html
+++ b/pkg/mark/testdata/table-droph1.html
@@ -1,0 +1,14 @@
+<table>
+<thead>
+<tr>
+<th>HEADER1</th>
+<th>HEADER2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>row1</td>
+<td>row2</td>
+</tr>
+</tbody>
+</table>

--- a/pkg/mark/testdata/table-stripnewlines.html
+++ b/pkg/mark/testdata/table-stripnewlines.html
@@ -1,0 +1,14 @@
+<table>
+<thead>
+<tr>
+<th>HEADER1</th>
+<th>HEADER2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>row1</td>
+<td>row2</td>
+</tr>
+</tbody>
+</table>

--- a/pkg/mark/testdata/tags-droph1.html
+++ b/pkg/mark/testdata/tags-droph1.html
@@ -1,0 +1,6 @@
+<p><b>bold</b>
+<strong>bold</strong></p>
+<p><i>vitalik</i>
+<em>vitalik</em></p>
+<p><s>strikethrough</s>
+<del>strikethrough</del></p>

--- a/pkg/mark/testdata/tags-stripnewlines.html
+++ b/pkg/mark/testdata/tags-stripnewlines.html
@@ -1,0 +1,3 @@
+<p><b>bold</b> <strong>bold</strong></p>
+<p><i>vitalik</i> <em>vitalik</em></p>
+<p><s>strikethrough</s> <del>strikethrough</del></p>


### PR DESCRIPTION
Adds `--strip-newlines` which collapses single newlines into a space - effectively what would happen during normal HTML rendering.  This is to address Confluence's behavior, which is to insert a `<br>`.

Closes #92
