### PR TITLE
Fix Attachment Recording in New Renderers

### DIFF
--- a/pkg/mark/attachment/attachment.go
+++ b/pkg/mark/attachment/attachment.go
@@ -33,6 +33,10 @@ type Attachment struct {
 	Replace   string
 }
 
+type Attacher interface {
+	Attach(Attachment)
+}
+
 func ResolveAttachments(
 	api *confluence.API,
 	page *confluence.PageInfo,

--- a/pkg/mark/markdown.go
+++ b/pkg/mark/markdown.go
@@ -44,16 +44,20 @@ func NewConfluenceExtension(stdlib *stdlib.Lib, path string, mermaidProvider str
 	}
 }
 
+func (c *ConfluenceExtension) Attach(a attachment.Attachment) {
+	c.Attachments = append(c.Attachments, a)
+}
+
 func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 
 	m.Renderer().AddOptions(renderer.WithNodeRenderers(
 		util.Prioritized(crenderer.NewConfluenceTextRenderer(c.StripNewlines), 100),
 		util.Prioritized(crenderer.NewConfluenceBlockQuoteRenderer(), 100),
 		util.Prioritized(crenderer.NewConfluenceCodeBlockRenderer(c.Stdlib, c.Path), 100),
-		util.Prioritized(crenderer.NewConfluenceFencedCodeBlockRenderer(c.Stdlib, &c.Attachments, c.MermaidProvider, c.MermaidScale), 100),
+		util.Prioritized(crenderer.NewConfluenceFencedCodeBlockRenderer(c.Stdlib, c, c.MermaidProvider, c.MermaidScale), 100),
 		util.Prioritized(crenderer.NewConfluenceHTMLBlockRenderer(c.Stdlib), 100),
 		util.Prioritized(crenderer.NewConfluenceHeadingRenderer(c.DropFirstH1), 100),
-		util.Prioritized(crenderer.NewConfluenceImageRenderer(c.Stdlib, &c.Attachments, c.Path), 100),
+		util.Prioritized(crenderer.NewConfluenceImageRenderer(c.Stdlib, c, c.Path), 100),
 		util.Prioritized(crenderer.NewConfluenceLinkRenderer(), 100),
 	))
 

--- a/pkg/mark/mermaid/mermaid.go
+++ b/pkg/mark/mermaid/mermaid.go
@@ -8,26 +8,30 @@ import (
 
 	mermaid "github.com/dreampuf/mermaid.go"
 	"github.com/kovetskiy/mark/pkg/mark/attachment"
+	"github.com/reconquest/pkg/log"
 )
 
 var renderTimeout = 60 * time.Second
 
-func ProcessMermaidLocally(title string, mermaidDiagram []byte, scale float64) (attachement attachment.Attachment, err error) {
+func ProcessMermaidLocally(title string, mermaidDiagram []byte, scale float64) (attachment.Attachment, error) {
 	ctx, cancel := context.WithTimeout(context.TODO(), renderTimeout)
 	defer cancel()
 
+	log.Debugf(nil, "Setting up Mermaid renderer: %q", title)
 	renderer, err := mermaid.NewRenderEngine(ctx)
 
 	if err != nil {
 		return attachment.Attachment{}, err
 	}
 
+	log.Debugf(nil, "Rendering: %q", title)
 	pngBytes, boxModel, err := renderer.RenderAsScaledPng(string(mermaidDiagram), scale)
 	if err != nil {
 		return attachment.Attachment{}, err
 	}
 
 	checkSum, err := attachment.GetChecksum(bytes.NewReader(mermaidDiagram))
+	log.Debugf(nil, "Checksum: %q -> %s", title, checkSum)
 
 	if err != nil {
 		return attachment.Attachment{}, err

--- a/pkg/mark/renderer/image.go
+++ b/pkg/mark/renderer/image.go
@@ -19,16 +19,16 @@ type ConfluenceImageRenderer struct {
 	html.Config
 	Stdlib      *stdlib.Lib
 	Path        string
-	Attachments []attachment.Attachment
+	Attachments attachment.Attacher
 }
 
 // NewConfluenceRenderer creates a new instance of the ConfluenceRenderer
-func NewConfluenceImageRenderer(stdlib *stdlib.Lib, attachments *[]attachment.Attachment, path string, opts ...html.Option) renderer.NodeRenderer {
+func NewConfluenceImageRenderer(stdlib *stdlib.Lib, attachments attachment.Attacher, path string, opts ...html.Option) renderer.NodeRenderer {
 	return &ConfluenceImageRenderer{
 		Config:      html.NewConfig(),
 		Stdlib:      stdlib,
 		Path:        path,
-		Attachments: *attachments,
+		Attachments: attachments,
 	}
 }
 
@@ -72,7 +72,7 @@ func (r *ConfluenceImageRenderer) renderImage(writer util.BufWriter, source []by
 		)
 	} else {
 
-		r.Attachments = append(r.Attachments, attachments[0])
+		r.Attachments.Attach(attachments[0])
 
 		err = r.Stdlib.Templates.ExecuteTemplate(
 			writer,

--- a/pkg/mark/renderer/text.go
+++ b/pkg/mark/renderer/text.go
@@ -1,4 +1,3 @@
-package renderer
 
 import (
 	"unicode/utf8"

--- a/pkg/mark/renderer/text.go
+++ b/pkg/mark/renderer/text.go
@@ -1,3 +1,4 @@
+package renderer
 
 import (
 	"unicode/utf8"


### PR DESCRIPTION
During the process of migrating to individual sub-renderers,
it looks like the process of adding attachments got broken.

The initial version of the code broke out using the ConfluenceExtension
Attachments slice in a way analogous to: https://go.dev/play/p/oA91ElVhL8i
One of Go's fun gotchas!

Closes #356
