### PR TITLE
feat: Add fallback directory to load includes from

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ to the template relative to current working dir, e.g.:
 <!-- Include: <path> -->
 ```
 
+If the template cannot be found relative to the current directory, a fallback directory can be defined via `--include-path`. This way it is possible to have global include files while local ones will still take precedence.
+
 Optionally the delimiters can be defined:
 
 ```markdown
@@ -767,6 +769,7 @@ GLOBAL OPTIONS:
    --parents-delimiter value                     The delimiter used for the nested parent (default: "/") [$MARK_PARENTS_DELIMITER]
    --mermaid-provider value                      defines the mermaid provider to use. Supported options are: cloudscript, mermaid-go. (default: "cloudscript") [$MARK_MERMAID_PROVIDER]
    --mermaid-scale value                         defines the scaling factor for mermaid renderings. (default: 1) [$MARK_MERMAID_SCALE]
+   --include-path value                          Path for shared includes, used as a fallback if the include doesn't exist in the current directory. [$MARK_INCLUDE_PATH]
    --help, -h                                    show help
    --version, -v                                 print the version
 ```

--- a/main.go
+++ b/main.go
@@ -173,6 +173,13 @@ var flags = []cli.Flag{
 		Usage:   "defines the scaling factor for mermaid renderings.",
 		EnvVars: []string{"MARK_MERMAID_SCALE"},
 	}),
+	altsrc.NewStringFlag(&cli.StringFlag{
+		Name:      "include-path",
+		Value:     "",
+		Usage:     "Path for shared includes, used as a fallback if the include doesn't exist in the current directory.",
+		TakesFile: true,
+		EnvVars:   []string{"MARK_INCLUDE_PATH"},
+	}),
 }
 
 func main() {
@@ -339,6 +346,7 @@ func processFile(
 	for {
 		templates, markdown, recurse, err = includes.ProcessIncludes(
 			filepath.Dir(file),
+			cCtx.String("include-path"),
 			markdown,
 			templates,
 		)
@@ -353,6 +361,7 @@ func processFile(
 
 	macros, markdown, err := macro.ExtractMacros(
 		filepath.Dir(file),
+		cCtx.String("include-path"),
 		markdown,
 		templates,
 	)

--- a/pkg/mark/attachment/attachment_test.go
+++ b/pkg/mark/attachment/attachment_test.go
@@ -45,7 +45,7 @@ func TestPrepareAttachmentsWithWorkDirBase(t *testing.T) {
 	}
 
 	attaches, err := prepareAttachments(testingOpener, ".", replacements)
-	t.Logf("attatches: %s", err)
+	t.Logf("attaches: %s", err)
 	if err != nil {
 		println(err.Error())
 		t.Fatal(err)

--- a/pkg/mark/macro/macro.go
+++ b/pkg/mark/macro/macro.go
@@ -106,6 +106,7 @@ func (macro *Macro) configure(node interface{}, groups [][]byte) interface{} {
 
 func ExtractMacros(
 	base string,
+	includePath string,
 	contents []byte,
 	templates *template.Template,
 ) ([]Macro, []byte, error) {
@@ -167,7 +168,7 @@ func ExtractMacros(
 					return nil
 				}
 			} else {
-				macro.Template, err = includes.LoadTemplate(base, template, "{{", "}}", templates)
+				macro.Template, err = includes.LoadTemplate(base, includePath, template, "{{", "}}", templates)
 				if err != nil {
 					err = karma.Format(err, "unable to load template")
 

--- a/pkg/mark/stdlib/stdlib.go
+++ b/pkg/mark/stdlib/stdlib.go
@@ -42,6 +42,7 @@ func macros(templates *template.Template) ([]macro.Macro, error) {
 
 	macros, _, err := macro.ExtractMacros(
 		"",
+		"",
 		text(
 			`<!-- Macro: @\{([^}]+)\}`,
 			`     Template: ac:link:user`,


### PR DESCRIPTION
This is a more flexible solution than https://github.com/kovetskiy/mark/pull/355 and allows users to set custom include paths as a fallback.

@Skeeve please take a look and let me know if this works for you as well. You should be able to use it via `--include-path "~/config/mark.d"` or similar.