### PR TITLE
Revert to XHTML (except for tables)

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,7 +741,7 @@ USAGE:
    mark [global options] [arguments...]
 
 VERSION:
-   9.10.0
+   9.10.1
 
 DESCRIPTION:
    Mark is a tool to update Atlassian Confluence pages from markdown. Documentation is available here: https://github.com/kovetskiy/mark

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	version     = "9.10.0"
+	version     = "9.10.1"
 	usage       = "A tool for updating Atlassian Confluence pages from markdown."
 	description = `Mark is a tool to update Atlassian Confluence pages from markdown. Documentation is available here: https://github.com/kovetskiy/mark`
 )

--- a/pkg/mark/markdown.go
+++ b/pkg/mark/markdown.go
@@ -78,6 +78,9 @@ func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib, path string, mermaidPr
 			extension.GFM,
 			extension.Footnote,
 			extension.DefinitionList,
+			extension.NewTable(
+				extension.WithTableCellAlignMethod(extension.TableCellAlignStyle),
+			),
 			confluenceExtension,
 		),
 		goldmark.WithParserOptions(
@@ -85,6 +88,7 @@ func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib, path string, mermaidPr
 		),
 		goldmark.WithRendererOptions(
 			html.WithUnsafe(),
+			html.WithXHTML(),
 		))
 
 	var buf bytes.Buffer

--- a/pkg/mark/mermaid/mermaid.go
+++ b/pkg/mark/mermaid/mermaid.go
@@ -11,7 +11,7 @@ import (
 	"github.com/reconquest/pkg/log"
 )
 
-var renderTimeout = 60 * time.Second
+var renderTimeout = 90 * time.Second
 
 func ProcessMermaidLocally(title string, mermaidDiagram []byte, scale float64) (attachment.Attachment, error) {
 	ctx, cancel := context.WithTimeout(context.TODO(), renderTimeout)

--- a/pkg/mark/testdata/links-droph1.html
+++ b/pkg/mark/testdata/links-droph1.html
@@ -8,7 +8,7 @@
 <p><ac:image ac:alt="My External Image"><ri:url ri:value="http://confluence.atlassian.com/images/logo/confluence_48_trans.png?key1=value1&amp;key2=value2"/></ac:image></p>
 <p>Use footnotes link <sup id="fnref:1"><a href="#fn:1" class="footnote-ref" role="doc-noteref">1</a></sup></p>
 <div class="footnotes" role="doc-endnotes">
-<hr>
+<hr />
 <ol>
 <li id="fn:1">
 <p>a footnote link&#160;<a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>

--- a/pkg/mark/testdata/links-stripnewlines.html
+++ b/pkg/mark/testdata/links-stripnewlines.html
@@ -8,7 +8,7 @@
 <p><ac:image ac:alt="My External Image"><ri:url ri:value="http://confluence.atlassian.com/images/logo/confluence_48_trans.png?key1=value1&amp;key2=value2"/></ac:image></p>
 <p>Use footnotes link <sup id="fnref:1"><a href="#fn:1" class="footnote-ref" role="doc-noteref">1</a></sup></p>
 <div class="footnotes" role="doc-endnotes">
-<hr>
+<hr />
 <ol>
 <li id="fn:1">
 <p>a footnote link&#160;<a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>

--- a/pkg/mark/testdata/links.html
+++ b/pkg/mark/testdata/links.html
@@ -8,7 +8,7 @@
 <p><ac:image ac:alt="My External Image"><ri:url ri:value="http://confluence.atlassian.com/images/logo/confluence_48_trans.png?key1=value1&amp;key2=value2"/></ac:image></p>
 <p>Use footnotes link <sup id="fnref:1"><a href="#fn:1" class="footnote-ref" role="doc-noteref">1</a></sup></p>
 <div class="footnotes" role="doc-endnotes">
-<hr>
+<hr />
 <ol>
 <li id="fn:1">
 <p>a footnote link&#160;<a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>

--- a/pkg/mark/testdata/newlines-droph1.html
+++ b/pkg/mark/testdata/newlines-droph1.html
@@ -6,5 +6,5 @@ one-2</p>
 <p>three-2</p>
 <p>space-1
 space-2</p>
-<p>2space-1<br>
+<p>2space-1<br />
 2space-2</p>

--- a/pkg/mark/testdata/newlines-stripnewlines.html
+++ b/pkg/mark/testdata/newlines-stripnewlines.html
@@ -4,5 +4,5 @@
 <p>three-1</p>
 <p>three-2</p>
 <p>space-1 space-2</p>
-<p>2space-1<br>
+<p>2space-1<br />
 2space-2</p>

--- a/pkg/mark/testdata/newlines.html
+++ b/pkg/mark/testdata/newlines.html
@@ -6,5 +6,5 @@ one-2</p>
 <p>three-2</p>
 <p>space-1
 space-2</p>
-<p>2space-1<br>
+<p>2space-1<br />
 2space-2</p>


### PR DESCRIPTION
This should fix https://github.com/kovetskiy/mark/issues/380 as confluence uses an XHTML based storage format.