### PR TITLE
Use markdown-linter

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,14 +7,18 @@ assignees: ''
 
 ---
 
-**What happened?**
+## What happened?
+
 A clear and concise description of what the bug is.
 
-**What did you expect to happen?**
+## What did you expect to happen?
+
 A clear and concise description of what you expected to happen.
 
-**How can we reproduce the behavior you experienced?**
+## How can we reproduce the behavior you experienced?
+
 Steps to reproduce the behavior:
+
 1. Step 1
 2. Step 2
 3. Step 3
@@ -22,17 +26,18 @@ Steps to reproduce the behavior:
 
 In case this is related to specific markdown, please provide a minimal markdown example here.
 
-**Information (please complete the following information)**
+## Further Information (please complete the following information)
 
- - Mark Version (`mark --version`): [e.g. v9.1.4]
- - Mark Parameters: [e.g. `--drop-h1 --title-from-h1`]
- - Confluence Hosting: [e.g. Cloud, Server or Datacenter]
- - Confluence Version: [e.g. v7.13]
- - Environment specific Information: [e.g. running in Github Actions, or on Mac OS X, etc.]
+* Mark Version (`mark --version`): [e.g. v9.1.4]
+* Mark Parameters: [e.g. `--drop-h1 --title-from-h1`]
+* Confluence Hosting: [e.g. Cloud, Server or Datacenter]
+* Confluence Version: [e.g. v7.13]
+* Environment specific Information: [e.g. running in Github Actions, or on Mac OS X, etc.]
 
-**Logs or other output**
+## Logs or other output
+
 Please provide logs, other kind of output here.
 
-**Additional context**
-Add any other context about the problem here.
+## Additional context
 
+Add any other context about the problem here.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,16 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
 
+  # Runs markdown-lint on the markdown files
+  ci-markdown-lint:
+    name: ci-markdown-lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+    - name: markdownlint-cli2-action
+      uses: DavidAnson/markdownlint-cli2-action@v14
+
   # Executes Unit Tests
   ci-unit-tests:
     name: ci-unit-tests

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,12 @@
+{
+  "globs": [
+    "*.md",
+    ".github/**/*.md"
+  ],
+
+  // ToDo: Following rules can't be fixed automatically. They should be enabled when fixed.
+  "config": {
+    "MD013": false, // https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md013---line-length
+    "MD033": false // https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md033---inline-html
+  }
+}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Mark — a tool for syncing your markdown documentation with Atlassian Confluence
 pages.
 
-Read the blog post discussing the tool — https://samizdat.dev/use-markdown-for-confluence/
+Read the blog post discussing the tool — <https://samizdat.dev/use-markdown-for-confluence/>
 
 This is very useful if you store documentation to your software in a Git
 repository and don't want to do an extra job of updating Confluence page using
@@ -23,6 +23,7 @@ contains several HTML-ish metadata headers, which can be used to locate page ins
 Confluence instance and update it accordingly.
 
 File in the extended format should follow the specification:
+
 ```markdown
 <!-- Space: <space key> -->
 <!-- Parent: <parent 1> -->
@@ -170,7 +171,7 @@ The key's value must be a string which defines the template's content.
   </tblbox>
 ```
 
-### Customizing the page layout
+## Customizing the page layout
 
 If you set the Layout to plain, the page layout can be customized using HTML comments inside the markdown:
 
@@ -205,44 +206,44 @@ Please be aware that mark does not validate the layout, so it's your responsibil
 
 If you have long code blocks, you can make them collapsible with the [Code Block Macro]:
 
-    ```bash collapse
-    ...
-    some long bash code block
-    ...
-    ```
+```bash collapse
+...
+some long bash code block
+...
+```
 
 And you can also add a title:
 
-    ```bash collapse title Some long long bash function
-    ...
-    some long bash code block
-    ...
-    ```
+```bash collapse title Some long long bash function
+...
+some long bash code block
+...
+```
 
 Or linenumbers, by giving the first number
 
-    ```bash 1 collapse title Some long long bash function
-    ...
-    some long bash code block
-    ...
-    ```
+```bash 1 collapse title Some long long bash function
+...
+some long bash code block
+...
+```
 
 And even themes
 
-    ```bash 1 collapse midnight title Some long long bash function
-    ...
-    some long bash code block
-    ...
-    ```
+```bash 1 collapse midnight title Some long long bash function
+...
+some long bash code block
+...
+```
 
 Please note that, if you want to have a code block without a language
 use `-` as the first character, if you want to have the other goodies
 
-    ``` - 1 collapse midnight title Some long long code
-    ...
-    some long code block
-    ...
-    ```
+``` - 1 collapse midnight title Some long long code
+...
+some long code block
+...
+```
 
 [Code Block Macro]: https://confluence.atlassian.com/doc/code-block-macro-139390.html
 
@@ -261,209 +262,209 @@ By default, mark provides several built-in templates and macros:
 
 * template `ac:status` to include badge-like text, which accepts following
   parameters:
-  - Title: text to display in the badge
-  - Color: color to use as background/border for badge
-    - Grey
-    - Red
-    - Yellow
-    - Green
-    - Blue
-  - Subtle: specify to fill badge with background or not
-    - true
-    - false
+  * Title: text to display in the badge
+  * Color: color to use as background/border for badge
+    * Grey
+    * Red
+    * Yellow
+    * Green
+    * Blue
+  * Subtle: specify to fill badge with background or not
+    * true
+    * false
 
 * template `ac:box`to include info, tip, note, and warning text boxes. Parameters:
-  - Name: select box style
-    - info
-    - tip
-    - note
-    - warning
-  - Icon: show information/tip/exclamation mark/warning icon
-    - true
-    - false
-  - Title: title text of the box
-  - Body: text to display in the box
+  * Name: select box style
+    * info
+    * tip
+    * note
+    * warning
+  * Icon: show information/tip/exclamation mark/warning icon
+    * true
+    * false
+  * Title: title text of the box
+  * Body: text to display in the box
 
-  See: https://confluence.atlassian.com/conf59/info-tip-note-and-warning-macros-792499127.html
+  See: <https://confluence.atlassian.com/conf59/info-tip-note-and-warning-macros-792499127.html>
 
 * template `ac:jira:ticket` to include JIRA ticket link. Parameters:
-  - Ticket: Jira ticket number like BUGS-123.
+  * Ticket: Jira ticket number like BUGS-123.
 
-  See: https://confluence.atlassian.com/conf59/status-macro-792499207.html
+  See: <https://confluence.atlassian.com/conf59/status-macro-792499207.html>
 
 * template `ac:jira:filter` to include JIRA Filters/Searches. Parameters:
-  - JQL: The "JQL" query of the search
-  - Server (Optional): The Jira server to fetch the query from if its not the default of "System Jira"
+  * JQL: The "JQL" query of the search
+  * Server (Optional): The Jira server to fetch the query from if its not the default of "System Jira"
 
 * template `ac:jiraissues` to include a list of JIRA tickets. Parameters:
-  - URL (Required), The URL of the XML view of your selected issues. (link to the filter)
-  - Anonymous (Optional) If this parameter is set to 'true', your JIRA application will return only the issues which allow unrestricted viewing. That is, the issues which are visible to anonymous viewers. If this parameter is omitted or set to 'false', then the results depend on how your administrator has configured the communication between the JIRA application and Confluence. By default, Confluence will show only the issues which the user is authorised to view.
-  - BaseURL  (Optional) If you specify a 'baseurl', then the link in the header, pointing to your JIRA application, will use this base URL instead of the value of the 'url' parameter. This is useful when Confluence connects to JIRA with a different URL from the one used by other users.
-  - Columns  (Optional) A list of JIRA column names, separated by semi-colons (;). You can include many columns recognized by your JIRA application, including custom columns.
-  - Count  (Optional) If this parameter is set to 'true', the issue list will show the number of issues in JIRA. The count will be linked to your JIRA site.
-  - Cache  (Optional) The macro maintains a cache of the issues which result from the JIRA query. If the 'cache' parameter is set to 'off', the relevant part of the cache is cleared each time the macro is reloaded. (The value 'false' also works and has the same effect as 'off'.)
-  - Height  (Optional) The height in pixels of the table displaying the issues.
-  - RenderMode  (Optional) If the value is 'dynamic', the JIRA Issues macro offers an interactive display.
-  - Title  (Optional) You can customise the title text at the top of the issues table with this parameter. For instance, setting the title to 'Bugs-to-fix' will replace the default 'JIRA Issues' text. This can help provide more context to the list of issues displayed.
-  - Width  (Optional) The width of the table displaying the issues. Can be entered as a percentage (%) or in pixels (px).
+  * URL (Required), The URL of the XML view of your selected issues. (link to the filter)
+  * Anonymous (Optional) If this parameter is set to 'true', your JIRA application will return only the issues which allow unrestricted viewing. That is, the issues which are visible to anonymous viewers. If this parameter is omitted or set to 'false', then the results depend on how your administrator has configured the communication between the JIRA application and Confluence. By default, Confluence will show only the issues which the user is authorised to view.
+  * BaseURL  (Optional) If you specify a 'baseurl', then the link in the header, pointing to your JIRA application, will use this base URL instead of the value of the 'url' parameter. This is useful when Confluence connects to JIRA with a different URL from the one used by other users.
+  * Columns  (Optional) A list of JIRA column names, separated by semi-colons (;). You can include many columns recognized by your JIRA application, including custom columns.
+  * Count  (Optional) If this parameter is set to 'true', the issue list will show the number of issues in JIRA. The count will be linked to your JIRA site.
+  * Cache  (Optional) The macro maintains a cache of the issues which result from the JIRA query. If the 'cache' parameter is set to 'off', the relevant part of the cache is cleared each time the macro is reloaded. (The value 'false' also works and has the same effect as 'off'.)
+  * Height  (Optional) The height in pixels of the table displaying the issues.
+  * RenderMode  (Optional) If the value is 'dynamic', the JIRA Issues macro offers an interactive display.
+  * Title  (Optional) You can customise the title text at the top of the issues table with this parameter. For instance, setting the title to 'Bugs-to-fix' will replace the default 'JIRA Issues' text. This can help provide more context to the list of issues displayed.
+  * Width  (Optional) The width of the table displaying the issues. Can be entered as a percentage (%) or in pixels (px).
 
-  See: https://confluence.atlassian.com/doc/jira-issues-macro-139380.html
+  See: <https://confluence.atlassian.com/doc/jira-issues-macro-139380.html>
 
 * template: `ac:emoticon` to include emoticons. Parameters:
-  - Name: select emoticon
-    - smile
-    - sad
-    - cheeky
-    - laugh
-    - wink
-    - thumbs-up
-    - thumbs-down
-    - information
-    - tick
-    - cross
-    - warning
-    - plus
-    - minus
-    - question
-    - light-on
-    - light-off
-    - yellow-star
-    - red-star
-    - green-star
-    - blue-star
+  * Name: select emoticon
+    * smile
+    * sad
+    * cheeky
+    * laugh
+    * wink
+    * thumbs-up
+    * thumbs-down
+    * information
+    * tick
+    * cross
+    * warning
+    * plus
+    * minus
+    * question
+    * light-on
+    * light-off
+    * yellow-star
+    * red-star
+    * green-star
+    * blue-star
 
-  See: https://confluence.atlassian.com/doc/confluence-storage-format-790796544.html
+  See: <https://confluence.atlassian.com/doc/confluence-storage-format-790796544.html>
 
 * template: `ac:youtube` to include YouTube Widget. Parameters:
-  - URL: YouTube video endpoint
-  - Width: Width in px. Defaults to "640px"
-  - Height: Height in px. Defaults to "360px"
+  * URL: YouTube video endpoint
+  * Width: Width in px. Defaults to "640px"
+  * Height: Height in px. Defaults to "360px"
 
-  See: https://confluence.atlassian.com/doc/widget-connector-macro-171180449.html#WidgetConnectorMacro-YouTube
+  See: <https://confluence.atlassian.com/doc/widget-connector-macro-171180449.html#WidgetConnectorMacro-YouTube>
 
 * template: `ac:children` to include Children Display macro
-	- Reverse (Reverse Sort): Use with the `Sort Children By` parameter. When set, the sort order changes from ascending to descending.
-      - `true`
-      - `false` (Default)
-	- Sort (Sort Children By):
-      - `creation` — to sort by content creation date
-      - `title` — to sort alphabetically on title
-      - `modified` — to sort of last modification date.
-      - If not specified, manual sorting is used if manually ordered, otherwise alphabetical.
-	- Style (Heading Style): Choose the style used to display descendants.
-      - from `h1` to `h6`
-      - If not specified, default style is applied.
-	- Page (Parent Page):
-      - `/` — to list the top-level pages of the current space, i.e. those without parents.
-      - `pagename` — to list the children of the specified page.
-      - `spacekey:pagename` — to list the children of the specified page in the specified space.
-      - If not specified, the current page is used.
-	- Excerpt (Include Excerpts): Allows you to include a short excerpt under each page in the list.
-      - `none` - no excerpt will be displayed. (Default)
-      - `simple` - displays the first line of text contained in an Excerpt macro any of the returned pages. If there is not an Excerpt macro on the page, nothing will be shown.
-      - `rich content` - displays the contents of an Excerpt macro, or if there is not an Excerpt macro on the page, the first part of the page content, including formatted text, images and some macros.
-	- First (Number of Children): Restrict the number of child pages that are displayed at the top level.
-      - If not specified, no limit is applied.
-	- Depth (Depth of Descendants): Enter a number to specify the depth of descendants to display. For example, if the value is 2, the macro will display 2 levels of child pages. This setting has no effect if `Show Descendants` is enabled.
-      - If not specified, no limit is applied.
-	- All (Show Descendants): Choose whether to display all the parent page's descendants.
-      - `true`
-      - `false` (Default)
+  * Reverse (Reverse Sort): Use with the `Sort Children By` parameter. When set, the sort order changes from ascending to descending.
+  * `true`
+  * `false` (Default)
+  * Sort (Sort Children By):
+  * `creation` — to sort by content creation date
+  * `title` — to sort alphabetically on title
+  * `modified` — to sort of last modification date.
+  * If not specified, manual sorting is used if manually ordered, otherwise alphabetical.
+  * Style (Heading Style): Choose the style used to display descendants.
+  * from `h1` to `h6`
+  * If not specified, default style is applied.
+  * Page (Parent Page):
+  * `/` — to list the top-level pages of the current space, i.e. those without parents.
+  * `pagename` — to list the children of the specified page.
+  * `spacekey:pagename` — to list the children of the specified page in the specified space.
+  * If not specified, the current page is used.
+  * Excerpt (Include Excerpts): Allows you to include a short excerpt under each page in the list.
+  * `none` - no excerpt will be displayed. (Default)
+  * `simple` - displays the first line of text contained in an Excerpt macro any of the returned pages. If there is not an Excerpt macro on the page, nothing will be shown.
+  * `rich content` - displays the contents of an Excerpt macro, or if there is not an Excerpt macro on the page, the first part of the page content, including formatted text, images and some macros.
+  * First (Number of Children): Restrict the number of child pages that are displayed at the top level.
+  * If not specified, no limit is applied.
+  * Depth (Depth of Descendants): Enter a number to specify the depth of descendants to display. For example, if the value is 2, the macro will display 2 levels of child pages. This setting has no effect if `Show Descendants` is enabled.
+  * If not specified, no limit is applied.
+  * All (Show Descendants): Choose whether to display all the parent page's descendants.
+  * `true`
+  * `false` (Default)
 
-  See: https://confluence.atlassian.com/doc/children-display-macro-139501.html
+  See: <https://confluence.atlassian.com/doc/children-display-macro-139501.html>
 
 * template: `ac:iframe` to include iframe macro (cloud only)
-  - URL: URL to the iframe.
-  - Frameborder: Choose whether to draw a border around content in the iframe.
-      - `show` (Default)
-      - `hide`
-  - Width: Width in px. Defaults to "640px"
-  - Height: Height in px. Defaults to "360px"
-  - Scrolling: Allow or prevent scrolling in the iframe to see additional content.
-      - `yes`
-      - `no`
-      - `auto` (Default)
-  - Align: Align the iframe to the left or right of the page.
-      - `left` (Default)
-      - `right`
+  * URL: URL to the iframe.
+  * Frameborder: Choose whether to draw a border around content in the iframe.
+    * `show` (Default)
+    * `hide`
+  * Width: Width in px. Defaults to "640px"
+  * Height: Height in px. Defaults to "360px"
+  * Scrolling: Allow or prevent scrolling in the iframe to see additional content.
+    * `yes`
+    * `no`
+    * `auto` (Default)
+  * Align: Align the iframe to the left or right of the page.
+    * `left` (Default)
+    * `right`
 
-  See: https://support.atlassian.com/confluence-cloud/docs/insert-the-iframe-macro
+  See: <https://support.atlassian.com/confluence-cloud/docs/insert-the-iframe-macro>
 
 * template: `ac:blog-posts`to include blog-posts
-  - Content: How much content will be shown
-      - titles (default)
-      - excerpts
-      - entire
-  - Time: Specify how much back in time Confluence should look for blog posts (default: unlimited)
-  - Label: Restrict to blog posts with specific labels
-  - Author: Restrict to blog posts by specific authors
-  - Spaces: Restrict to blog posts in specific spaces
-  - Max: Maximum number of blog posts shown (default: 15)
-  - Sort: Sorting posts by
-      - title
-      - creation (default)
-      - modified
-  - Reverse: Reverses the Sort parameter from oldest to newest (default: false)
+  * Content: How much content will be shown
+    * titles (default)
+    * excerpts
+    * entire
+  * Time: Specify how much back in time Confluence should look for blog posts (default: unlimited)
+  * Label: Restrict to blog posts with specific labels
+  * Author: Restrict to blog posts by specific authors
+  * Spaces: Restrict to blog posts in specific spaces
+  * Max: Maximum number of blog posts shown (default: 15)
+  * Sort: Sorting posts by
+    * title
+    * creation (default)
+    * modified
+  * Reverse: Reverses the Sort parameter from oldest to newest (default: false)
 
-  See: https://confluence.atlassian.com/doc/blog-posts-macro-139470.html
+  See: <https://confluence.atlassian.com/doc/blog-posts-macro-139470.html>
 
 * template: `ac:include` to include a page
-  - Page: the page to be included
-  - Space: the space the page is in (optional, otherwise same space)
+  * Page: the page to be included
+  * Space: the space the page is in (optional, otherwise same space)
 
 * template: `ac:excerpt-include` to include the excerpt from another page
-  - Page: the page the excerpt should be included from
-  - NoPanel: Determines whether Confluence will display a panel around the excerpted content (optional, default: false)
+  * Page: the page the excerpt should be included from
+  * NoPanel: Determines whether Confluence will display a panel around the excerpted content (optional, default: false)
 
 * template: `ac:excerpt` to create an excerpt and include it in the page
-  - Excerpt: The text you want to include
-  - OutputType: Determines whether the content of the Excerpt macro body is displayed on a new line or inline (optional, options: "BLOCK" or "INLINE", default: BLOCK)
-  - Hidden: Hide the excerpt content (optional, default: false)
+  * Excerpt: The text you want to include
+  * OutputType: Determines whether the content of the Excerpt macro body is displayed on a new line or inline (optional, options: "BLOCK" or "INLINE", default: BLOCK)
+  * Hidden: Hide the excerpt content (optional, default: false)
 
 * template: `ac:anchor` to set an anchor inside a page
-  - Anchor: Text for the anchor
+  * Anchor: Text for the anchor
 
-+ template: `ac:expand` to display an expandable/collapsible section of text on your page
-  - Title: Defines the text next to the expand/collapse icon.
-  - Body: The Text that it is expanded to.
+* template: `ac:expand` to display an expandable/collapsible section of text on your page
+  * Title: Defines the text next to the expand/collapse icon.
+  * Body: The Text that it is expanded to.
 
 * template: `ac:profile` to display a short summary of a given Confluence user's profile.
-  - Name: The username of the Confluence user whose profile summary you wish to show.
+  * Name: The username of the Confluence user whose profile summary you wish to show.
 
 * template: `ac:contentbylabel` to display a list of pages, blog posts or attachments that have particular labels
-  - CQL: The CQL query to discover the content
+  * CQL: The CQL query to discover the content
 
 * template: `ac:detailssummary` to show summary information from one page on a another page
-  - Headings: Column headings to show
-  - CQL: The CQL query to discover the pages
-  - SortBy: Sort by a specific column heading
+  * Headings: Column headings to show
+  * CQL: The CQL query to discover the pages
+  * SortBy: Sort by a specific column heading
 
 * template: `ac:details` to create page properties
-  - Body: Must contain a table with two rows, the table headings are used as property key. The table content is the value.
+  * Body: Must contain a table with two rows, the table headings are used as property key. The table content is the value.
 
 * template: `ac:panel` to display a block of text within a customisable panel
-  - Title: Panel title (optional)
-  - Body: Body text of the panel
-  - BGColor: Background Color
-  - TitleBGColor: Background color of the title bar
-  - TitleColor: Text color of the title
-  - BorderStyle: Style of the panel's border
+  * Title: Panel title (optional)
+  * Body: Body text of the panel
+  * BGColor: Background Color
+  * TitleBGColor: Background color of the title bar
+  * TitleColor: Text color of the title
+  * BorderStyle: Style of the panel's border
 
 * template `ac:recently-updated` to display a list of most recently changed content
-  - Spaces: List of Spaces to watch (optional, default is current Space)
-  - ShowProfilePic: Show profile picture of editor
-  - Max: Maximum number of changes
-  - Types: Include these content types only (comments, blogposts, pages)
-  - Theme: Apperance of the macro (concise, social, sidebar)
-  - HideHeading: Determines whether the macro hides or displays the text 'Recently Updated' as a title above the list of content
-  - Labels: Filter the results by label. The macro will display only the pages etc which are tagged with the label(s) you specify here.
+  * Spaces: List of Spaces to watch (optional, default is current Space)
+  * ShowProfilePic: Show profile picture of editor
+  * Max: Maximum number of changes
+  * Types: Include these content types only (comments, blogposts, pages)
+  * Theme: Apperance of the macro (concise, social, sidebar)
+  * HideHeading: Determines whether the macro hides or displays the text 'Recently Updated' as a title above the list of content
+  * Labels: Filter the results by label. The macro will display only the pages etc which are tagged with the label(s) you specify here.
 
 * template: `ac:pagetreesearch` to add a search box to your Confluence page.
-  - Root: Name of the root page whose hierarchy of pages will be searched by this macro. If this not specified, the root page is the current page.
+  * Root: Name of the root page whose hierarchy of pages will be searched by this macro. If this not specified, the root page is the current page.
 
 * template: `ac:column` To be used with the section macro to define the columns in a page.
-  - Width: Width of the column
-  - Body: The content of the column
+  * Width: Width of the column
+  * Body: The content of the column
 
 * macro `@{...}` to mention user by name specified in the braces.
 
@@ -471,13 +472,14 @@ By default, mark provides several built-in templates and macros:
 
 ### Insert Disclaimer
 
-**disclaimer.md**
+This should be in **disclaimer.md**.
 
 ```markdown
 **NOTE**: this document is generated, do not edit manually.
 ```
 
-**article.md**
+Add this to your **article.md**.
+
 ```markdown
 <!-- Space: TEST -->
 <!-- Title: My Article -->
@@ -488,8 +490,6 @@ This is my article.
 ```
 
 ### Insert Status Badge
-
-**article.md**
 
 ```markdown
 <!-- Space: TEST -->
@@ -510,8 +510,6 @@ This is my article.
 ```
 
 ### Insert Colored Text Box
-
-**article.md**
 
 ```markdown
 <!-- Space: TEST -->
@@ -586,6 +584,7 @@ Parameters:
 [Confluence Pagetree Macro]:https://confluence.atlassian.com/conf59/page-tree-macro-792499177.html
 
 E.G.
+
 ```markdown
 <!-- Macro: :pagetree:
      Template: ac:pagetree
@@ -630,9 +629,8 @@ You can use various [parameters](https://confluence.atlassian.com/conf59/childre
 
 :children:
 ```
-### Insert Jira Ticket
 
-**article.md**
+### Insert Jira Ticket
 
 ```markdown
 <!-- Space: TEST -->
@@ -660,6 +658,7 @@ Link to a [page title containing spaces](<ac:With Multiple Words>)
 ```markdown
 ![Example](../images/examples.png)
 ```
+
 will automatically upload the inlined image as an attachment and inline the image using the `ac:image` template.
 
 If the file is not found, it will inline the image using the `ac:image` template and link to the image.
@@ -667,16 +666,20 @@ If the file is not found, it will inline the image using the `ac:image` template
 ### Add width for an image
 
 Use the following macro:
+
 ```markdown
 <!-- Macro: \!\[.*\]\((.+)\)\<\!\-\- width=(.*) \-\-\>
      Template: ac:image
      Attachment: ${1}
      Width: ${2} -->
 ```
+
 And attach any image with the following
+
 ```markdown
 ![Example](../images/example.png)<!-- width=300 -->
 ```
+
 The width will be the commented html after the image (in this case 300px).
 
 Currently this is not compatible with the automated upload of inline images.
@@ -686,10 +689,10 @@ Currently this is not compatible with the automated upload of inline images.
 Confluence doesn't provide [mermaid.js](https://github.com/mermaid-js/mermaid) support natively. Mark provides a convenient way to enable the feature like [Github does](https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/).
 As long as you have a code block and are marked as "mermaid", the mark will automatically render it as a PNG image and insert into before the code block.
 
-    ```mermaid title diagrams_example
-    graph TD;
-    A-->B;
-    ```
+```mermaid title diagrams_example
+graph TD;
+A-->B;
+```
 
 In order to properly render mermaid, you can choose between the following mermaid providers:
 
@@ -724,7 +727,7 @@ go get -v github.com/kovetskiy/mark
 ### Docker
 
 ```bash
-$ docker run --rm -i kovetskiy/mark:latest mark <params>
+docker run --rm -i kovetskiy/mark:latest mark <params>
 ```
 
 ### Compile and install using docker-compose
@@ -740,7 +743,7 @@ $ cp mark /usr/local/bin
 
 ## Usage
 
-```
+```bash
 USAGE:
    mark [global options] [arguments...]
 
@@ -793,13 +796,13 @@ drop-h1 = true
 **NOTE**: Labels aren't supported when using `minor-edit`!
 
 **NOTE**: The system specific locations are described in here:
-https://pkg.go.dev/os#UserConfigDir.
+<https://pkg.go.dev/os#UserConfigDir>.
 Currently these are:
 On Unix systems, it returns $XDG_CONFIG_HOME as specified by https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html if non-empty, else $HOME/.config. On Darwin, it returns $HOME/Library/Application Support. On Windows, it returns %AppData%. On Plan 9, it returns $home/lib.
 
-# Tricks
+## Tricks
 
-## Continuous Integration
+### Continuous Integration
 
 It's quite trivial to integrate Mark into a CI/CD system, here is an example with [Snake CI](https://snake-ci.com/)
 in case of self-hosted Bitbucket Server / Data Center.
@@ -844,18 +847,23 @@ only:
     - main
 ```
 
-## File Globbing
+### File Globbing
 
 Rather than running `mark` multiple times, or looping through a list of files from `find`, you can use file globbing (i.e. wildcard patterns) to match files in subdirectories. For example:
+
 ```bash
 mark -f "helpful_cmds/*.md"
 ```
 
 You can also use `**` to get all files recursively.
+
 ```bash
 mark -f "**/docs/*.md"
 ```
 
+### Linting markdown
+
+We recommend to lint your markdown files with [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) before publishing them to confluence to catch any conversion errors early.
 
 ## Issues, Bugs & Contributions
 
@@ -869,8 +877,8 @@ I try to label all new issues so it's easy to find a bug or a feature request to
 you are willing to help with the project, you can use the following labels to find issues, just make
 sure to reply in the issue to let everyone know you took the issue:
 
-- [label:feature-request](https://github.com/kovetskiy/mark/issues?q=is%3Aissue+is%3Aopen+label%3Afeature-request)
-- [label:bug](https://github.com/kovetskiy/mark/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
+* [label:feature-request](https://github.com/kovetskiy/mark/issues?q=is%3Aissue+is%3Aopen+label%3Afeature-request)
+* [label:bug](https://github.com/kovetskiy/mark/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
 
 ## Contributors ✨
 


### PR DESCRIPTION
This will lint our markdown files and help catching issues earlier (will also be used on testfiles)