### PR TITLE
Fix layout section attribute tags

### DIFF
--- a/pkg/mark/renderer/htmlblock.go
+++ b/pkg/mark/renderer/htmlblock.go
@@ -45,22 +45,22 @@ func (r *ConfluenceHTMLBlockRenderer) renderHTMLBlock(w util.BufWriter, source [
 			_, _ = w.WriteString("</ac:layout>\n")
 			return ast.WalkContinue, nil
 		case "<!-- ac:layout-section type:single -->":
-			_, _ = w.WriteString("<ac:layout-section type=\"single\">\n")
+			_, _ = w.WriteString("<ac:layout-section ac:type=\"single\">\n")
 			return ast.WalkContinue, nil
 		case "<!-- ac:layout-section type:two_equal -->":
-			_, _ = w.WriteString("<ac:layout-section type=\"two_equal\">\n")
+			_, _ = w.WriteString("<ac:layout-section ac:type=\"two_equal\">\n")
 			return ast.WalkContinue, nil
 		case "<!-- ac:layout-section type:two_left_sidebar -->":
-			_, _ = w.WriteString("<ac:layout-section type=\"two_left_sidebar\">\n")
+			_, _ = w.WriteString("<ac:layout-section ac:type=\"two_left_sidebar\">\n")
 			return ast.WalkContinue, nil
 		case "<!-- ac:layout-section type:two_right_sidebar -->":
-			_, _ = w.WriteString("<ac:layout-section type=\"two_right_sidebar\">\n")
+			_, _ = w.WriteString("<ac:layout-section ac:type=\"two_right_sidebar\">\n")
 			return ast.WalkContinue, nil
 		case "<!-- ac:layout-section type:three -->":
-			_, _ = w.WriteString("<ac:layout-section type=\"three\">\n")
+			_, _ = w.WriteString("<ac:layout-section ac:type=\"three\">\n")
 			return ast.WalkContinue, nil
 		case "<!-- ac:layout-section type:three_with_sidebars -->":
-			_, _ = w.WriteString("<ac:layout-section type=\"three_with_sidebars\">\n")
+			_, _ = w.WriteString("<ac:layout-section ac:type=\"three_with_sidebars\">\n")
 			return ast.WalkContinue, nil
 		case "<!-- ac:layout-section end -->":
 			_, _ = w.WriteString("</ac:layout-section>\n")

--- a/pkg/mark/testdata/pagelayout-droph1.html
+++ b/pkg/mark/testdata/pagelayout-droph1.html
@@ -1,5 +1,5 @@
 <ac:layout>
-<ac:layout-section type="three_with_sidebars">
+<ac:layout-section ac:type="three_with_sidebars">
 <ac:layout-cell>
 <p>More Content</p>
 </ac:layout-cell>
@@ -10,7 +10,7 @@
 <p>Even More Content</p>
 </ac:layout-cell>
 </ac:layout-section>
-<ac:layout-section type="single">
+<ac:layout-section ac:type="single">
 <ac:layout-cell>
 <p>Still More Content</p>
 </ac:layout-cell>

--- a/pkg/mark/testdata/pagelayout-stripnewlines.html
+++ b/pkg/mark/testdata/pagelayout-stripnewlines.html
@@ -1,5 +1,5 @@
 <ac:layout>
-<ac:layout-section type="three_with_sidebars">
+<ac:layout-section ac:type="three_with_sidebars">
 <ac:layout-cell>
 <p>More Content</p>
 </ac:layout-cell>
@@ -10,7 +10,7 @@
 <p>Even More Content</p>
 </ac:layout-cell>
 </ac:layout-section>
-<ac:layout-section type="single">
+<ac:layout-section ac:type="single">
 <ac:layout-cell>
 <p>Still More Content</p>
 </ac:layout-cell>

--- a/pkg/mark/testdata/pagelayout.html
+++ b/pkg/mark/testdata/pagelayout.html
@@ -1,5 +1,5 @@
 <ac:layout>
-<ac:layout-section type="three_with_sidebars">
+<ac:layout-section ac:type="three_with_sidebars">
 <ac:layout-cell>
 <p>More Content</p>
 </ac:layout-cell>
@@ -10,7 +10,7 @@
 <p>Even More Content</p>
 </ac:layout-cell>
 </ac:layout-section>
-<ac:layout-section type="single">
+<ac:layout-section ac:type="single">
 <ac:layout-cell>
 <p>Still More Content</p>
 </ac:layout-cell>


### PR DESCRIPTION
I was finding that without `ac:` prefix on the `type` attribute that the attribute was being ignored.

I wondered if the attribute had been expected without the prefix in other versions of confluence but is appears this is correct in all the versions currently documented.

- [8.7](https://confluence.atlassian.com/doc/confluence-storage-format-790796544.html#ConfluenceStorageFormat-Pagelayouts)
- [8.0](https://confluence.atlassian.com/conf80/confluence-storage-format-1188407674.html#ConfluenceStorageFormat-Pagelayouts)
- [7.16](https://confluence.atlassian.com/conf716/confluence-storage-format-1108682045.html#ConfluenceStorageFormat-Pagelayouts)

Elsewhere in the mark codebase the `ac:` prefix used too. I've only tested this on a single confluence version but it seems like it should be correct for other versions.