### PR TITLE
container file: only install git-core in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN make get \
 
 FROM chromedp/headless-shell:latest
 RUN apt-get update \
-&& apt-get install --no-install-recommends -qq ca-certificates bash sed git dumb-init \
+&& apt-get install --no-install-recommends -qq ca-certificates bash sed git-core dumb-init \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
This PR helps to only install the minimal git client without X11 dependencies which reduces the size of the Container Image and lowers the number of security CVE reported.