### PR TITLE
Implement Page Deletion Based on 'ToBeDeleted' Label

### DIFF
--- a/main.go
+++ b/main.go
@@ -453,6 +453,14 @@ func processFile(
 		target = page
 	}
 
+	// Iterate over the labels in 'meta' to check if the 'ToBeDeleted' label is present
+	for _, label := range meta.Labels {
+		if label == "ToBeDeleted" {
+			api.DeletePage(target.ID)
+			log.Fatal("Page deleted")
+		}
+	}
+
 	// Resolve attachments created from <!-- Attachment: --> directive
 	localAttachments, err := attachment.ResolveLocalAttachments(vfs.LocalOS, filepath.Dir(file), meta.Attachments)
 	if err != nil {

--- a/pkg/confluence/api.go
+++ b/pkg/confluence/api.go
@@ -455,6 +455,23 @@ func (api *API) GetPageByID(pageID string) (*PageInfo, error) {
 	return request.Response.(*PageInfo), nil
 }
 
+func (api *API) DeletePage(pageID string) (*PageInfo, error) {
+
+	request, err := api.rest.Res(
+		"content/"+pageID, &PageInfo{},
+	).Delete()
+
+	if err != nil {
+		return nil, err
+	}
+
+	if request.Raw.StatusCode != http.StatusOK {
+		return nil, newErrorStatusNotOK(request)
+	}
+
+	return request.Response.(*PageInfo), nil
+}
+
 func (api *API) CreatePage(
 	space string,
 	pageType string,


### PR DESCRIPTION
This PR introduces a new feature that allows for automatic deletion of pages based on the presence of a 'ToBeDeleted' label.

**Changes include:**

1. Added a check for the 'ToBeDeleted' label in the metadata of a page.
2. If the label is present, the page is deleted using the DeletePage API call.
3. A fatal log message is generated upon successful deletion of the page.
4. This feature helps in automating the cleanup of pages that are no longer needed, based on the 'ToBeDeleted' label.


**How to Test:**

1. Apply the 'ToBeDeleted' label to any page.
2. Run the program.
3. The page with the 'ToBeDeleted' label should be deleted and a log message indicating the deletion should be generated.

Any suggestions, improvements are more than welcome since I have 0 experience with GO.