### PR TITLE
Build multi-arch image for amd64 and arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
       if: ${{ github.ref_type == 'tag' }}
       with:
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: |
            kovetskiy/mark:${{ github.ref_name }}
            kovetskiy/mark:latest


### PR DESCRIPTION
I have been building my own multi-arch image locally and that works for me but with this modification the docker image built by the CI and pushed to [docker hub](https://hub.docker.com/r/kovetskiy/mark) will start supporting amd64 and arm64.

If you want to try this locally it is equivalent to building with

```
docker build --platform=linux/amd64,linux/arm64 -t kovetskiy/mark:$tag .
```