### PR TITLE
add archive link for blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Mark — a tool for syncing your markdown documentation with Atlassian Confluence
 pages.
 
-Read the blog post discussing the tool — <https://samizdat.dev/use-markdown-for-confluence/>
+Read the blog post discussing the tool — <https://samizdat.dev/use-markdown-for-confluence/> ([archive](https://web.archive.org/web/20231210204843/https://samizdat.dev/use-markdown-for-confluence/))
 
 This is very useful if you store documentation to your software in a Git
 repository and don't want to do an extra job of updating Confluence page using


### PR DESCRIPTION
Responding to issue #424 "Reference article is no more accessible"

Adding a link to archive.org copy of the inaccessible blog post.