### PR TITLE
Add option to pass a version message

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,6 +85,12 @@ var flags = []cli.Flag{
 		EnvVars: []string{"MARK_MINOR_EDIT"},
 	}),
 	altsrc.NewStringFlag(&cli.StringFlag{
+		Name:    "version-message",
+		Value:   "",
+        Usage:   "add a message to the page version, to explain the edit (default: \"\")",
+		EnvVars: []string{"MARK_VERSION_MESSAGE"},
+	}),
+	altsrc.NewStringFlag(&cli.StringFlag{
 		Name:    "color",
 		Value:   "auto",
 		Usage:   "display logs in color. Possible values: auto, never.",
@@ -511,7 +517,7 @@ func processFile(
 		html = buffer.String()
 	}
 
-	err = api.UpdatePage(target, html, cCtx.Bool("minor-edit"), meta.Labels, meta.ContentAppearance)
+	err = api.UpdatePage(target, html, cCtx.Bool("minor-edit"), cCtx.String("version-message"), meta.Labels, meta.ContentAppearance)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/confluence/api.go
+++ b/pkg/confluence/api.go
@@ -503,7 +503,7 @@ func (api *API) CreatePage(
 	return request.Response.(*PageInfo), nil
 }
 
-func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, newLabels []string, appearance string) error {
+func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, versionMessage string, newLabels []string, appearance string) error {
 	nextPageVersion := page.Version.Number + 1
 	oldAncestors := []map[string]interface{}{}
 
@@ -532,6 +532,7 @@ func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, ne
 		"version": map[string]interface{}{
 			"number":    nextPageVersion,
 			"minorEdit": minorEdit,
+			"message":   versionMessage,
 		},
 		"ancestors": oldAncestors,
 		"body": map[string]interface{}{


### PR DESCRIPTION
Adds a new option to mark that allows the edit message to be set.

```
   --version-message value         add a message to the page version, to explain the edit (default: "") [$MARK_VERSION_MESSAGE]
```

This value can be passed to mark with the new argument `--version-message` or by setting the environment variable `MARK_VERSION_MESSAGE`.

My use case for this feature is allowing the version information for a collection of confluence pages to be added to the page history in confluence.