### PR TITLE
Change label management to rely on independent rest calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea/
 /mark.test
 /profile.cov
+.vscode

--- a/main.go
+++ b/main.go
@@ -523,7 +523,7 @@ func processFile(
 		log.Fatal(err)
 	}
 
-	updateLabels(err, api, target, meta)
+	updateLabels(api, target, meta)
 
 	if cCtx.Bool("edit-lock") {
 		log.Infof(

--- a/main.go
+++ b/main.go
@@ -583,7 +583,7 @@ func determineLabelsToRemove(labelInfo *confluence.LabelInfo, meta *mark.Meta) [
 	var labels []string
 	for _, label := range labelInfo.Labels {
 		if !slices.ContainsFunc(meta.Labels, func(metaLabel string) bool {
-			return strings.ToLower(metaLabel) == strings.ToLower(label.Name)
+			return strings.EqualFold(metaLabel, label.Name)
 		}) {
 			labels = append(labels, label.Name)
 		}
@@ -596,7 +596,7 @@ func determineLabelsToAdd(meta *mark.Meta, labelInfo *confluence.LabelInfo) []st
 	var labels []string
 	for _, metaLabel := range meta.Labels {
 		if !slices.ContainsFunc(labelInfo.Labels, func(label confluence.Label) bool {
-			return strings.ToLower(label.Name) == strings.ToLower(metaLabel)
+			return strings.EqualFold(label.Name, metaLabel)
 		}) {
 			labels = append(labels, metaLabel)
 		}


### PR DESCRIPTION
Calc delta for labels from metadata and page information, then add/remove labels via independent confluence api calls

Seems to address "Label appear and disappear (PingPong) #226"