### PR TITLE
Add "/wiki" segment when relative confluence link is resolved

### DIFF
--- a/pkg/mark/link.go
+++ b/pkg/mark/link.go
@@ -205,7 +205,11 @@ func getConfluenceLink(
 	if page != nil {
 		// Confluence supports relative links to reference other pages:
 		// https://confluence.atlassian.com/doc/links-776656293.html
-		link = page.Links.Full
+		// Without /wiki prefix confluence renders broken links when page already exists.
+		link = fmt.Sprintf(
+			"/wiki%s",
+			page.Links.Full,
+		)
 	}
 
 	return link, nil


### PR DESCRIPTION
1. There are two pages documented: `page1.md (title Title1)` and `page2.md (title Title2)`. 
2. page2.md links to page1.md by `[link text](page1.md)`

We've noticed that when relative link is used, because the linked page already exists on confluence, relative link rendered in confluence has the following form: `/spaces/~spaceId/pages/number/Title1`. That results in the following html representation `<a data-testid="link-with-safety" href="/spaces/~spaceId/pages/number/Title1" title="/spaces/~spaceId/pages/number/Title1" data-renderer-mark="true" class="cc-1rn59kg">link text</a>`. 

In our case base url is `https://[company-name].atlassian.net/wiki/`. Once page2 with Title2 is rendered in the browser, link points to `https://[company-name].atlassian.net/spaces/~spaceId/pages/number/Title1` instead of `https://[company-name].atlassian.net/wiki/spaces/~spaceId/pages/number/Title1`

This PR makes fixes the situation. It would be great if you could have a look and merge it if that is a behaviour across all confluence relative linking. 