### PR TITLE
Revert "Make references to pages within the same Confluence relative"

### DIFF
--- a/pkg/mark/link.go
+++ b/pkg/mark/link.go
@@ -203,9 +203,9 @@ func getConfluenceLink(
 	}
 
 	if page != nil {
-		// Confluence supports relative links to reference other pages:
-		// https://confluence.atlassian.com/doc/links-776656293.html
-		link = page.Links.Full
+		// Needs baseURL, as REST api response URL doesn't contain subpath ir
+		// confluence is server from that
+		link = api.BaseURL + page.Links.Full
 	}
 
 	return link, nil


### PR DESCRIPTION
This reverts commit ecd563e0957c23573bc8b37ba398396b8144c0d0.

@monti-python it looks like #457 broke some cloud instances of confluence.

See also #468 