### PR TITLE
added update-if-older-than option

### DIFF
--- a/pkg/confluence/api.go
+++ b/pkg/confluence/api.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/kovetskiy/gopencils"
 	"github.com/kovetskiy/lorg"
@@ -48,7 +49,8 @@ type PageInfo struct {
 	Type  string `json:"type"`
 
 	Version struct {
-		Number int64 `json:"number"`
+		Number int64     `json:"number"`
+		When   time.Time `json:"when"`
 	} `json:"version"`
 
 	Ancestors []struct {


### PR DESCRIPTION
This option will skip files where the latest version is have been updated since the date provided on the command line.

For example this could be used to update only if the last commit for a file is newer than the latest version in confluence:

`mark --space "****" -f $file -u "${MARK_USER}" -p "${MARK_PWD}" -b "${MARK_URL}" --ci --update-if-older-than "$(git --no-pager log -1 --pretty="format:%cI" $file)"`