### PR TITLE
Fix error on delete label

### DIFF
--- a/pkg/confluence/api.go
+++ b/pkg/confluence/api.go
@@ -605,7 +605,7 @@ func (api *API) DeletePageLabel(page *PageInfo, label string) (*LabelInfo, error
 		return nil, err
 	}
 
-	if request.Raw.StatusCode != http.StatusOK {
+	if request.Raw.StatusCode != http.StatusOK && request.Raw.StatusCode != http.StatusNoContent {
 		return nil, newErrorStatusNotOK(request)
 	}
 


### PR DESCRIPTION
Fixes #495 

PR to alllow http status 204 as valid when deleting labels. 

Note: This depends on PR https://github.com/kovetskiy/gopencils/pull/3 and go.mod/go.sum must be updated once merged