### PR TITLE
Use query param for label deletion

### DIFF
--- a/confluence/api.go
+++ b/confluence/api.go
@@ -599,8 +599,8 @@ func (api *API) AddPageLabels(page *PageInfo, newLabels []string) (*LabelInfo, e
 func (api *API) DeletePageLabel(page *PageInfo, label string) (*LabelInfo, error) {
 
 	request, err := api.rest.Res(
-		"content/"+page.ID+"/label/"+label, &LabelInfo{},
-	).Delete()
+		"content/"+page.ID+"/label", &LabelInfo{},
+    ).SetQuery(map[string]string{"name": label}).Delete()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
(I struggle greatly with Golang, so please assume that if it's possible to do anything wrong, I have done it wrong.)

The Confluence API [is documented](https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-content-labels/#api-wiki-rest-api-content-id-label-label-delete) as preferring this endpoint when the label has slashes in.

I have *not* checked whether it's necessary to URL query-parameter escape this; maybe it is necessary?

(The whitespace change appears to satisfy `go fmt`, but surprised me.)