### PR TITLE
Feature: Support named excerpts (Cloud only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,10 +432,12 @@ By default, mark provides several built-in templates and macros:
 
 * template: `ac:excerpt-include` to include the excerpt from another page
   * Page: the page the excerpt should be included from
+  * Name: The specific identifier for the excerpt, allowing multiple Excerpt macros on one page to be referenced individually. If not provided, the first excerpt from the page will be used (optional, cloud only)
   * NoPanel: Determines whether Confluence will display a panel around the excerpted content (optional, default: false)
 
 * template: `ac:excerpt` to create an excerpt and include it in the page
   * Excerpt: The text you want to include
+  * Name: Allows you to identify this macro so that you can add multiple Excerpt macros to one page and use a specific one on another page using the Excerpt Include macro (optional, cloud only)
   * OutputType: Determines whether the content of the Excerpt macro body is displayed on a new line or inline (optional, options: "BLOCK" or "INLINE", default: BLOCK)
   * Hidden: Hide the excerpt content (optional, default: false)
 

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -296,18 +296,22 @@ func templates(api *confluence.API) (*template.Template, error) {
 		),
 
 		/* https://confluence.atlassian.com/conf59/excerpt-include-macro-792499101.html */
+		/* https://support.atlassian.com/confluence-cloud/docs/insert-the-excerpt-include-macro/ */
 
 		`ac:excerpt-include`: text(
 			`<ac:macro ac:name="excerpt-include">`,
+			`{{ if .Name }}<ac:parameter ac:name="name">{{ .Name }}</ac:parameter>{{ end }}`,
 			`<ac:parameter ac:name="nopanel">{{ if .NoPanel }}{{ .NoPanel }}{{ else }}false{{ end }}</ac:parameter>`,
 			`<ac:default-parameter>{{ .Page }}</ac:default-parameter>`,
 			`</ac:macro>`,
 		),
 
 		/* https://confluence.atlassian.com/conf59/excerpt-macro-792499102.html */
+		/* https://support.atlassian.com/confluence-cloud/docs/insert-the-excerpt-macro/ */
 
 		`ac:excerpt`: text(
 			`<ac:structured-macro ac:name="excerpt">`,
+			`{{ if .Name }}<ac:parameter ac:name="name">{{ .Name }}</ac:parameter>{{ end }}`,
 			`<ac:parameter ac:name="hidden">{{ if .Hidden }}{{ .Hidden }}{{ else }}false{{ end }}</ac:parameter>`,
 			`<ac:parameter ac:name="atlassian-macro-output-type">{{ if .OutputType }}{{ .OutputType }}{{ else }}BLOCK{{ end }}</ac:parameter>`,
 			`<ac:rich-text-body>`,


### PR DESCRIPTION
This pull request adds support for named excerpts (currently available only for Confluence Cloud).

Named excerpts allow users to create multiple excerpts on a single page, each identified by a unique name, making it easier to include specific excerpts from one page to another.

- Resolves feature request #316