### PR TITLE
Fixed video name handling in 'ac:multimedia' macro

### DIFF
--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -444,7 +444,7 @@ func templates(api *confluence.API) (*template.Template, error) {
 			`<ac:structured-macro ac:name="multimedia">`,
 			`<ac:parameter ac:name="width">{{ or .Width 500 }}</ac:parameter>`,
 			`<ac:parameter ac:name="name">`,
-			`<ri:attachment ri:filename="{{ .Name }}/>`,
+			`<ri:attachment ri:filename="{{ .Name | convertAttachment }}"/>`,
 			`</ac:parameter>`,
 			`<ac:parameter ac:name="autoplay">{{ or .AutoPlay "false"}}</ac:parameter>`,
 			`</ac:structured-macro>`,


### PR DESCRIPTION
This merge request addresses an issue with inconsistent handling of video file names in the `ac:multimedia macro`. 
Previously, video file paths containing slashes ("/") were not converted to match the format of attachments, causing issues in file references.

- Related #500