### PR TITLE
Support for converting Material for MkDocs' Admonitions to Confluence Info Panels (#40)

### DIFF
--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -59,7 +59,14 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 		util.Prioritized(crenderer.NewConfluenceImageRenderer(c.Stdlib, c, c.Path), 100),
 		util.Prioritized(crenderer.NewConfluenceParagraphRenderer(), 100),
 		util.Prioritized(crenderer.NewConfluenceLinkRenderer(), 100),
+		util.Prioritized(crenderer.NewConfluenceAdmonitionRenderer(), 100),
 	))
+
+	m.Parser().AddOptions(
+		parser.WithBlockParsers(
+			util.Prioritized(cparser.NewAdmonitionParser(), 100),
+		),
+	)
 
 	m.Parser().AddOptions(parser.WithInlineParsers(
 		// Must be registered with a higher priority than goldmark's linkParser to make sure goldmark doesn't parse

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -66,7 +66,7 @@ func TestCompileMarkdownDropH1(t *testing.T) {
 
 	test := assert.New(t)
 
-        testcases, err := filepath.Glob("testdata/*.md")
+	testcases, err := filepath.Glob("testdata/*.md")
 	if err != nil {
 		panic(err)
 	}
@@ -78,7 +78,7 @@ func TestCompileMarkdownDropH1(t *testing.T) {
 		}
 		var variant string
 		switch filename {
-		case "testdata/quotes.md", "testdata/header.md":
+		case "testdata/quotes.md", "testdata/header.md", "testdata/admonitions.md":
 			variant = "-droph1"
 		default:
 			variant = ""
@@ -99,7 +99,7 @@ func TestCompileMarkdownStripNewlines(t *testing.T) {
 
 	test := assert.New(t)
 
-        testcases, err := filepath.Glob("testdata/*.md")
+	testcases, err := filepath.Glob("testdata/*.md")
 	if err != nil {
 		panic(err)
 	}
@@ -110,12 +110,12 @@ func TestCompileMarkdownStripNewlines(t *testing.T) {
 			panic(err)
 		}
 		var variant string
-                switch filename {
-                case "testdata/quotes.md", "testdata/codes.md", "testdata/newlines.md", "testdata/macro-include.md":
-                        variant = "-stripnewlines"
-                default:
-                        variant = ""
-                }
+		switch filename {
+		case "testdata/quotes.md", "testdata/codes.md", "testdata/newlines.md", "testdata/macro-include.md", "testdata/admonitions.md":
+			variant = "-stripnewlines"
+		default:
+			variant = ""
+		}
 
 		markdown, htmlname, html := loadData(t, filename, variant)
 		actual, _ := CompileMarkdown(markdown, lib, filename, "", 1.0, false, true)

--- a/parser/admonition.go
+++ b/parser/admonition.go
@@ -1,0 +1,341 @@
+package parser
+
+import (
+	"bytes"
+	"fmt"
+
+	"math/rand"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+// A Admonition struct represents a fenced code block of Markdown text.
+type Admonition struct {
+	ast.BaseBlock
+	AdmonitionClass []byte
+	Title           []byte
+}
+
+// Dump implements Node.Dump .
+func (n *Admonition) Dump(source []byte, level int) {
+	ast.DumpHelper(n, source, level, nil, nil)
+}
+
+// KindAdmonition is a NodeKind of the Admonition node.
+var KindAdmonition = ast.NewNodeKind("Admonition")
+
+// Kind implements Node.Kind.
+func (n *Admonition) Kind() ast.NodeKind {
+	return KindAdmonition
+}
+
+// NewAdmonition return a new Admonition node.
+func NewAdmonition() *Admonition {
+	return &Admonition{
+		BaseBlock: ast.BaseBlock{},
+	}
+}
+
+type admonitionParser struct {
+}
+
+var defaultAdmonitionParser = &admonitionParser{}
+
+// NewAdmonitionParser returns a new BlockParser that
+// parses admonition blocks.
+func NewAdmonitionParser() parser.BlockParser {
+	return defaultAdmonitionParser
+}
+
+type admonitionData struct {
+	ID                string   // The ID of the admonition. This enables nested admonitions with indentation
+	char              byte     // Currently, this is always "!"
+	indent            int      // The indentation of the opening (and closing) tags (!!!{})
+	length            int      // The length of the admonition, e.g. is it !!! or !!!!?
+	node              ast.Node // The node of the admonition
+	contentIndent     int      // The indentation of the content relative to the previous admonition block. The first line of the content is taken as its indentation. If you want an admonition with just a code block you need to use backticks
+	contentHasStarted bool     // Only used as an indicator if contentIndent has been set already
+}
+
+var admonitionInfoKey = parser.NewContextKey()
+
+func (b *admonitionParser) Trigger() []byte {
+	return []byte{'!'}
+}
+
+func (b *admonitionParser) Open(parent ast.Node, reader text.Reader, pc parser.Context) (ast.Node, parser.State) {
+	line, _ := reader.PeekLine()
+	pos := pc.BlockOffset()
+	if pos < 0 || line[pos] != '!' {
+		return nil, parser.NoChildren
+	}
+	findent := pos
+
+	// currently useless
+	admonitionChar := line[pos]
+	i := pos
+	for ; i < len(line) && line[i] == admonitionChar; i++ {
+	}
+	oAdmonitionLength := i - pos
+	if oAdmonitionLength < 3 {
+		return nil, parser.NoChildren
+	}
+
+	// ========================================================================== //
+	// 	Without attributes we return
+
+	if i >= len(line)-1 {
+		// If there are no attributes we can't create a div because we won't know
+		// if a "!!!" ends the last admonition or opens a new one
+		return nil, parser.NoChildren
+	}
+
+	rest := line[i:]
+	left := i + util.TrimLeftSpaceLength(rest)
+	right := len(line) - 1 - util.TrimRightSpaceLength(rest)
+
+	if left >= right {
+		// As above:
+		// If there are no attributes we can't create a div because we won't know
+		// if a "!!!" ends the last admonition or opens a new one
+		return nil, parser.NoChildren
+	}
+
+	// ========================================================================== //
+	// 	With attributes we construct the node
+	node := parseOpeningLine(reader, left)
+	admonitionID := genRandomString(24)
+	node.SetAttributeString("data-admonition", []byte(admonitionID))
+
+	fdata := &admonitionData{
+		ID:                admonitionID,
+		char:              admonitionChar,
+		indent:            findent,
+		length:            oAdmonitionLength,
+		node:              node,
+		contentIndent:     0,
+		contentHasStarted: false,
+	}
+	var fdataMap []*admonitionData
+
+	if oldData := pc.Get(admonitionInfoKey); oldData != nil {
+		fdataMap = oldData.([]*admonitionData)
+		fdataMap = append(fdataMap, fdata)
+	} else {
+		fdataMap = []*admonitionData{fdata}
+	}
+	pc.Set(admonitionInfoKey, fdataMap)
+
+	// ========================================================================== //
+	// 	 check if it's an empty block
+
+	line, _ = reader.PeekLine()
+	w, pos := util.IndentWidth(line, reader.LineOffset())
+
+	if close, _ := hasClosingTag(line, w, pos, fdata); w < fdata.indent || close {
+		return node, parser.NoChildren
+	}
+
+	return node, parser.HasChildren
+}
+
+// Parse the opening line for
+// * admonition class
+// * admonition title
+// * attributes
+func parseOpeningLine(reader text.Reader, left int) *Admonition {
+	node := NewAdmonition()
+	reader.Advance(left)
+
+	remainingLine, _ := reader.PeekLine()
+	remainingLength := len(remainingLine) - 1
+
+	// ========================================================================== //
+	// 	find class
+	endClass := 0
+	for ; endClass < remainingLength && remainingLine[endClass] != ' ' && remainingLine[endClass] != '{'; endClass++ {
+	}
+	if endClass > 0 {
+		node.AdmonitionClass = remainingLine[0:endClass]
+	}
+
+	// ========================================================================== //
+	// 	find title
+	startTitle := endClass + util.TrimLeftSpaceLength(remainingLine[endClass:])
+	endTitle := startTitle
+	for ; endTitle < remainingLength && remainingLine[endTitle] != '{'; endTitle++ {
+	}
+	if endTitle > startTitle {
+		endTitle = endTitle - util.TrimRightSpaceLength(remainingLine[startTitle:endTitle])
+		if endTitle > startTitle {
+			node.Title = remainingLine[startTitle:endTitle]
+		}
+	}
+
+	if endTitle < remainingLength {
+		reader.Advance(endTitle)
+	} else {
+		reader.Advance(remainingLength)
+	}
+
+	// ========================================================================== //
+	// 	find attributes
+	hasClass := false
+	admClass := bytes.Join([][]byte{[]byte("admonition adm-"), node.AdmonitionClass}, []byte(""))
+
+	attrs, ok := parser.ParseAttributes(reader)
+
+	if ok {
+		for _, attr := range attrs {
+			oldVal := attr.Value.([]byte)
+			var val []byte
+
+			if bytes.Equal(attr.Name, []byte("class")) {
+				hasClass = true
+				val = bytes.Join([][]byte{admClass, oldVal}, []byte(" "))
+			} else {
+				val = oldVal
+			}
+
+			node.SetAttribute(attr.Name, val)
+		}
+	}
+
+	if !hasClass {
+		node.SetAttribute([]byte("class"), admClass)
+	}
+
+	return node
+}
+
+func (b *admonitionParser) Continue(node ast.Node, reader text.Reader, pc parser.Context) parser.State {
+	// ========================================================================== //
+	// Get admonitionID from node
+
+	rawAdmonitionID, ok := node.AttributeString("data-admonition")
+	if !ok {
+		fmt.Println("Admonition ID is missing")
+	}
+	admonitionID := string(rawAdmonitionID.([]byte))
+
+	// ========================================================================== //
+	// 	Get admonition for current admonition
+	rawdata := pc.Get(admonitionInfoKey)
+	fdataMap := rawdata.([]*admonitionData)
+
+	// This should not happen
+	if len(fdataMap) == 0 {
+		fmt.Printf("we're in an admonition block but have no state data. This should not happen")
+		return parser.Close
+	}
+
+	var fdata *admonitionData
+	var flevel int
+	for flevel = 0; flevel < len(fdataMap); flevel++ {
+		fdata = fdataMap[flevel]
+		if fdata.ID == admonitionID {
+			break
+		}
+	}
+
+	// ========================================================================== //
+	// 	Set indentation level if it hasn't been set yet
+
+	line, segment := reader.PeekLine()
+	w, pos := util.IndentWidth(line, reader.LineOffset())
+
+	if !fdata.contentHasStarted && !util.IsBlank(line[pos:]) {
+		fdata.contentHasStarted = true
+		fdata.contentIndent = w
+
+		fdataMap[flevel] = fdata
+		pc.Set(admonitionInfoKey, fdataMap)
+	}
+
+	// ========================================================================== //
+	// Are we closing the node?
+	// * Either the indentation is below the indentation of the opening tags
+	// * or it is at the level of the opening tags but the content was indented
+	// * or there is a closing tag and we're in the deepest admonition block
+	close, newline := hasClosingTag(line, w, pos, fdata)
+	if close && flevel == len(fdataMap)-1 {
+		reader.Advance(segment.Stop - segment.Start - newline + segment.Padding)
+
+		node.SetAttributeString("data-admonition", []byte(fmt.Sprint(flevel)))
+
+		fdataMap = fdataMap[:flevel]
+		pc.Set(admonitionInfoKey, fdataMap)
+
+		return parser.Close
+	}
+
+	indentClose :=
+		!util.IsBlank(line) &&
+			(w < fdata.indent || (w == fdata.indent && w < fdata.contentIndent))
+
+	if indentClose {
+		node.SetAttributeString("data-admonition", []byte(fmt.Sprint(flevel)))
+
+		fdataMap = fdataMap[:flevel]
+		pc.Set(admonitionInfoKey, fdataMap)
+
+		return parser.Close
+	}
+
+	if fdata.contentIndent > 0 {
+		dontJumpLineEnd := segment.Stop - segment.Start - 1
+		if fdata.contentIndent < dontJumpLineEnd {
+			dontJumpLineEnd = fdata.contentIndent
+		}
+
+		reader.Advance(dontJumpLineEnd)
+	}
+
+	return parser.Continue | parser.HasChildren
+}
+
+func (b *admonitionParser) Close(node ast.Node, reader text.Reader, pc parser.Context) {
+}
+
+func (b *admonitionParser) CanInterruptParagraph() bool {
+	return true
+}
+
+func (b *admonitionParser) CanAcceptIndentedLine() bool {
+	return false
+}
+
+func hasClosingTag(line []byte, w int, pos int, fdata *admonitionData) (bool, int) {
+	// else, check for the correct number of closing chars and provide the info
+	// necessary to advance the reader
+	if w == fdata.indent {
+		i := pos
+		for ; i < len(line) && line[i] == fdata.char; i++ {
+		}
+		length := i - pos
+
+		if length >= fdata.length && util.IsBlank(line[i:]) {
+			newline := 1
+			if line[len(line)-1] != '\n' {
+				newline = 0
+			}
+
+			return true, newline
+		}
+	}
+
+	return false, 0
+}
+
+const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func genRandomString(n int) string {
+	bytes := make([]byte, n)
+	for i := range bytes {
+		bytes[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(bytes)
+}

--- a/renderer/admonition.go
+++ b/renderer/admonition.go
@@ -1,0 +1,150 @@
+package renderer
+
+import (
+	"fmt"
+
+	"github.com/kovetskiy/mark/parser"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/util"
+)
+
+// HeadingAttributeFilter defines attribute names which heading elements can have
+var AdmonitionAttributeFilter = html.GlobalAttributeFilter
+
+// A Renderer struct is an implementation of renderer.NodeRenderer that renders
+// nodes as (X)HTML.
+type ConfluenceAdmonitionRenderer struct {
+	html.Config
+	LevelMap AdmonitionLevelMap
+}
+
+// NewConfluenceRenderer creates a new instance of the ConfluenceRenderer
+func NewConfluenceAdmonitionRenderer(opts ...html.Option) renderer.NodeRenderer {
+	return &ConfluenceAdmonitionRenderer{
+		Config:   html.NewConfig(),
+		LevelMap: nil,
+	}
+}
+
+// RegisterFuncs implements NodeRenderer.RegisterFuncs .
+func (r *ConfluenceAdmonitionRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(parser.KindAdmonition, r.renderAdmon)
+}
+
+// Define AdmonitionType enum
+type AdmonitionType int
+
+const (
+	AInfo AdmonitionType = iota
+	ANote
+	AWarn
+	ATip
+	ANone
+)
+
+func (t AdmonitionType) String() string {
+	return []string{"info", "note", "warning", "tip", "none"}[t]
+}
+
+type AdmonitionLevelMap map[ast.Node]int
+
+func (m AdmonitionLevelMap) Level(node ast.Node) int {
+	return m[node]
+}
+
+func ParseAdmonitionType(node ast.Node) AdmonitionType {
+	n, ok := node.(*parser.Admonition)
+	if !ok {
+		return ANone
+	}
+
+	switch string(n.AdmonitionClass) {
+	case "info":
+		return AInfo
+	case "note":
+		return ANote
+	case "warning":
+		return AWarn
+	case "tip":
+		return ATip
+	default:
+		return ANone
+	}
+}
+
+// GenerateAdmonitionLevel walks a given node and returns a map of blockquote levels
+func GenerateAdmonitionLevel(someNode ast.Node) AdmonitionLevelMap {
+
+	// We define state variable that track BlockQuote level while we walk the tree
+	admonitionLevel := 0
+	AdmonitionLevelMap := make(map[ast.Node]int)
+
+	rootNode := someNode
+	for rootNode.Parent() != nil {
+		rootNode = rootNode.Parent()
+	}
+	_ = ast.Walk(rootNode, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if node.Kind() == ast.KindBlockquote && entering {
+			AdmonitionLevelMap[node] = admonitionLevel
+			admonitionLevel += 1
+		}
+		if node.Kind() == ast.KindBlockquote && !entering {
+			admonitionLevel -= 1
+		}
+		return ast.WalkContinue, nil
+	})
+	return AdmonitionLevelMap
+}
+
+// renderBlockQuote will render a BlockQuote
+func (r *ConfluenceAdmonitionRenderer) renderAdmon(writer util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	//	Initialize BlockQuote level map
+	n := node.(*parser.Admonition)
+	if r.LevelMap == nil {
+		r.LevelMap = GenerateAdmonitionLevel(node)
+	}
+
+	admonitionType := ParseAdmonitionType(node)
+	admonitionLevel := r.LevelMap.Level(node)
+
+	if admonitionLevel == 0 && entering && admonitionType != ANone {
+		prefix := fmt.Sprintf("<ac:structured-macro ac:name=\"%s\"><ac:parameter ac:name=\"icon\">true</ac:parameter><ac:rich-text-body>\n", admonitionType)
+		if _, err := writer.Write([]byte(prefix)); err != nil {
+			return ast.WalkStop, err
+		}
+		if string(n.Title) != "" {
+			titleHTML := fmt.Sprintf("<p><strong>%s</strong></p>\n", string(n.Title))
+			if _, err := writer.Write([]byte(titleHTML)); err != nil {
+				return ast.WalkStop, err
+			}
+		}
+
+		return ast.WalkContinue, nil
+	}
+	if admonitionLevel == 0 && !entering && admonitionType != ANone {
+		suffix := "</ac:rich-text-body></ac:structured-macro>\n"
+		if _, err := writer.Write([]byte(suffix)); err != nil {
+			return ast.WalkStop, err
+		}
+		return ast.WalkContinue, nil
+	}
+	return r.renderAdmonition(writer, source, node, entering)
+}
+
+func (r *ConfluenceAdmonitionRenderer) renderAdmonition(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	n := node.(*parser.Admonition)
+	if entering {
+		if n.Attributes() != nil {
+			_, _ = w.WriteString("<blockquote")
+			html.RenderAttributes(w, n, AdmonitionAttributeFilter)
+			_ = w.WriteByte('>')
+		} else {
+			_, _ = w.WriteString("<blockquote>\n")
+		}
+	} else {
+		_, _ = w.WriteString("</blockquote>\n")
+	}
+	return ast.WalkContinue, nil
+}

--- a/testdata/admonitions-droph1.html
+++ b/testdata/admonitions-droph1.html
@@ -1,4 +1,3 @@
-<h1 id="Main-Heading">Main Heading</h1>
 <h2 id="First-Heading">First Heading</h2>
 <ac:structured-macro ac:name="note"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
 <p><strong>"NOTES:"</strong></p>

--- a/testdata/admonitions-stripnewlines.html
+++ b/testdata/admonitions-stripnewlines.html
@@ -21,8 +21,7 @@ b</p>
 </ul>
 </ac:rich-text-body></ac:structured-macro>
 <ul>
-<li>Regular list
-that runs long</li>
+<li>Regular list that runs long</li>
 </ul>
 <h2 id="Third-Heading">Third Heading</h2>
 <ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>

--- a/testdata/admonitions.html
+++ b/testdata/admonitions.html
@@ -1,0 +1,102 @@
+<h1 id="Main-Heading">Main Heading</h1>
+<h2 id="First-Heading">First Heading</h2>
+<ac:structured-macro ac:name="note"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
+<p><strong>"NOTES:"</strong></p>
+<ol>
+<li>Note number one</li>
+<li>Note number two</li>
+</ol>
+<ac:structured-macro ac:name="note"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
+<p>a<br />
+b</p>
+</ac:rich-text-body></ac:structured-macro>
+<p><strong>Warn (Should not be picked as blockquote type)</strong></p>
+</ac:rich-text-body></ac:structured-macro>
+<h2 id="Second-Heading">Second Heading</h2>
+<ac:structured-macro ac:name="warning"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
+<p><strong>"Warn"</strong></p>
+<ul>
+<li>Warn bullet 1</li>
+<li>Warn bullet 2</li>
+</ul>
+</ac:rich-text-body></ac:structured-macro>
+<ul>
+<li>Regular list
+that runs long</li>
+</ul>
+<h2 id="Third-Heading">Third Heading</h2>
+<ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
+<p>Test</p>
+</ac:rich-text-body></ac:structured-macro>
+<h2 id="Fourth-Heading---Warn-should-not-get-picked-as-block-quote">Fourth Heading - Warn should not get picked as block quote</h2>
+<ac:structured-macro ac:name="tip"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
+<p><strong>"TIP:"</strong></p>
+<ol>
+<li>Note number one</li>
+<li>Note number two</li>
+</ol>
+<ac:structured-macro ac:name="tip"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
+<p>a<br />
+b</p>
+</ac:rich-text-body></ac:structured-macro>
+<p><strong>Warn (Should not be picked as blockquote type)</strong></p>
+</ac:rich-text-body></ac:structured-macro>
+<h2 id="Simple-Blockquote">Simple Blockquote</h2>
+<blockquote>
+<p>This paragraph is a simple blockquote</p>
+</blockquote>
+<h2 id="GH-Alerts-Heading">GH Alerts Heading</h2>
+<h3 id="Note-Type-Alert-Heading">Note Type Alert Heading</h3>
+<ac:structured-macro ac:name="note"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
+<ul>
+<li>Note bullet 1</li>
+<li>Note bullet 2</li>
+</ul>
+</ac:rich-text-body></ac:structured-macro>
+<h3 id="Tip-Type-Alert-Heading">Tip Type Alert Heading</h3>
+<ac:structured-macro ac:name="tip"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
+<ul>
+<li>Tip bullet 1</li>
+<li>Tip bullet 2</li>
+</ul>
+</ac:rich-text-body></ac:structured-macro>
+<h3 id="Warning-Type-Alert-Heading">Warning Type Alert Heading</h3>
+<ac:structured-macro ac:name="warning"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
+<ul>
+<li>Warning bullet 1</li>
+<li>Warning bullet 2</li>
+</ul>
+</ac:rich-text-body></ac:structured-macro>
+<h3 id="Important/Caution-Type-Alert-Heading">Important/Caution Type Alert Heading</h3>
+<ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
+<p><strong>"[!IMPORTANT]"</strong></p>
+<ul>
+<li>Important bullet 1</li>
+<li>Important bullet 2</li>
+</ul>
+</ac:rich-text-body></ac:structured-macro>
+<ac:structured-macro ac:name="warning"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
+<p><strong>"[!CAUTION]"</strong></p>
+<ul>
+<li>Important bullet 1</li>
+<li>Important bullet 2</li>
+</ul>
+</ac:rich-text-body></ac:structured-macro>
+<h3 id="Should-not-be-picked-up-and-converted-into-blockquote-macro">Should not be picked up and converted into blockquote macro</h3>
+<blockquote>
+<p>[[!NOTE]</p>
+</blockquote>
+<blockquote>
+<p>[!NOTE</p>
+</blockquote>
+<blockquote>
+<p>[Hey !NOTE]</p>
+</blockquote>
+<blockquote>
+<p>[NOTE]</p>
+</blockquote>
+<blockquote>
+<p><strong>TL;DR:</strong> Thingy!
+More stuff</p>
+</blockquote>
+

--- a/testdata/admonitions.md
+++ b/testdata/admonitions.md
@@ -1,0 +1,90 @@
+<!-- Space: DevOps -->
+<!-- Parent: Test Area -->
+<!-- Title: mark-admonition-test -->
+
+# Main Headingssss
+
+## First Headings
+
+!!! note "NOTES:"
+    1. Note number one
+    1. Note number two
+
+    !!! note
+        a  
+        b
+
+    **Warn (Should not be picked as blockquote type)**
+
+## Second Heading
+
+!!! warning "Warn"
+    * Warn bullet 1
+    * Warn bullet 2
+
+* Regular list
+  that runs long
+
+## Third Heading
+
+!!! info
+    Test
+
+## Fourth Heading - Warn should not get picked as block quote
+
+!!! tip "TIP:"
+    1. Note number one
+    1. Note number two
+
+    !!! tip
+        a  
+        b
+
+    **Warn (Should not be picked as blockquote type)**
+
+## Simple Blockquote
+
+> This paragraph is a simple blockquote
+
+## GH Alerts Heading
+
+### Note Type Alert Heading
+
+!!! note
+    * Note bullet 1
+    * Note bullet 2
+
+### Tip Type Alert Heading
+
+!!! tip
+    * Tip bullet 1
+    * Tip bullet 2
+
+### Warning Type Alert Heading
+
+!!! warning
+    * Warning bullet 1
+    * Warning bullet 2
+
+### Important/Caution Type Alert Heading
+
+!!! info "[!IMPORTANT]"
+    * Important bullet 1
+    * Important bullet 2
+
+!!! warning "[!CAUTION]"
+    * Important bullet 1
+    * Important bullet 2
+
+### Should not be picked up and converted into blockquote macro
+
+> [[!NOTE]
+
+> [!NOTE
+
+> [Hey !NOTE]
+
+> [NOTE]
+
+> **TL;DR:** Thingy!
+> More stuff

--- a/testdata/admonitions.md
+++ b/testdata/admonitions.md
@@ -72,15 +72,3 @@
     * Important bullet 1
     * Important bullet 2
 
-### Should not be picked up and converted into blockquote macro
-
-> [[!NOTE]
-
-> [!NOTE
-
-> [Hey !NOTE]
-
-> [NOTE]
-
-> **TL;DR:** Thingy!
-> More stuff

--- a/testdata/admonitions.md
+++ b/testdata/admonitions.md
@@ -1,10 +1,6 @@
-<!-- Space: DevOps -->
-<!-- Parent: Test Area -->
-<!-- Title: mark-admonition-test -->
+# Main Heading
 
-# Main Headingssss
-
-## First Headings
+## First Heading
 
 !!! note "NOTES:"
     1. Note number one


### PR DESCRIPTION
# Support for Converting Material for MkDocs' Admonitions to Confluence Info Panels (#40)

## Summary  
This PR adds support for converting **Material for MkDocs' Admonitions** into **Confluence Info Panels**. It includes:  
- A **parser** for detecting admonitions in Markdown.  
- A **renderer** for converting them into Confluence's structured macro format.  
- **Unit tests** to ensure correctness.  

## Implementation Details  
- The parser is adapted from [`goldmark-admonitions`](https://github.com/stefanfritsch/goldmark-admonitions).  
- The renderer has been rewritten to generate Confluence-specific output.  

## Testing  
- Added unit tests to verify parsing and rendering behavior.  

## Notes  
- Please review the renderer changes in particular to ensure they align with project standards.  

Its my first contribution to open source ever, so let me know if any improvements are needed 😅
