### PR TITLE
fix(table): fixes expected table html

### DIFF
--- a/testdata/table.html
+++ b/testdata/table.html
@@ -15,14 +15,14 @@
 <table>
 <thead>
 <tr>
-<th style="text-align:center">HEADER1</th>
-<th style="text-align:right">HEADER2</th>
+<th align="center">HEADER1</th>
+<th align="right">HEADER2</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td style="text-align:center">row1</td>
-<td style="text-align:right">row2</td>
+<td align="center">row1</td>
+<td align="right">row2</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
There is an error in tests data - in table.html
Due to the different alignment options and th tag for both rows and data.

Without that fix tests are failing with:

```
--- FAIL: TestCompileMarkdownDropH1 (0.03s)
    markdown_test.go:92:
        	Error Trace:	/Users/wrbbz/repos/mark/markdown/markdown_test.go:92
        	Error:      	Not equal:
        	            	expected: "<table>\n<thead>\n<tr>\n<th>HEADER1</th>\n<th>HEADER2</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>row1</td>\n<td>row2</td>\n</tr>\n</tbody>\n</table>\n<table>\n<thead>\n<tr>\n<th style=\"text-align:center\">HEADER1</th>\n<th style=\"text-align:right\">HEADER2</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style=\"text-align:center\">row1</td>\n<td style=\"text-align:right\">row2</td>\n</tr>\n</tbody>\n</table>\n"
        	            	actual  : "<table>\n<thead>\n<tr>\n<th>HEADER1</th>\n<th>HEADER2</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>row1</td>\n<td>row2</td>\n</tr>\n</tbody>\n</table>\n<table>\n<thead>\n<tr>\n<th align=\"center\">HEADER1</th>\n<th align=\"right\">HEADER2</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td align=\"center\">row1</td>\n<td align=\"right\">row2</td>\n</tr>\n</tbody>\n</table>\n"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -17,4 +17,4 @@
        	            	 <tr>
        	            	-<th style="text-align:center">HEADER1</th>
        	            	-<th style="text-align:right">HEADER2</th>
        	            	+<th align="center">HEADER1</th>
        	            	+<th align="right">HEADER2</th>
        	            	 </tr>
        	            	@@ -23,4 +23,4 @@
        	            	 <tr>
        	            	-<td style="text-align:center">row1</td>
        	            	-<td style="text-align:right">row2</td>
        	            	+<td align="center">row1</td>
        	            	+<td align="right">row2</td>
        	            	 </tr>
        	Test:       	TestCompileMarkdownDropH1
        	Messages:   	testdata/table.md vs testdata/table.html
```

After that - everything passes:
```
ok  	github.com/kovetskiy/mark	1.381s	coverage: 0.0% of statements
ok  	github.com/kovetskiy/mark/attachment	1.217s	coverage: 13.3% of statements
	github.com/kovetskiy/mark/confluence		coverage: 0.0% of statements
	github.com/kovetskiy/mark/includes		coverage: 0.0% of statements
	github.com/kovetskiy/mark/macro		coverage: 0.0% of statements
ok  	github.com/kovetskiy/mark/markdown	1.629s	coverage: 93.3% of statements
ok  	github.com/kovetskiy/mark/mermaid	1.846s	coverage: 0.0% of statements [no tests to run]
ok  	github.com/kovetskiy/mark/metadata	1.989s	coverage: 6.2% of statements
ok  	github.com/kovetskiy/mark/page	1.658s	coverage: 3.6% of statements
	github.com/kovetskiy/mark/parser		coverage: 0.0% of statements
	github.com/kovetskiy/mark/renderer		coverage: 0.0% of statements
	github.com/kovetskiy/mark/stdlib		coverage: 0.0% of statements
	github.com/kovetskiy/mark/util		coverage: 0.0% of statements
	github.com/kovetskiy/mark/vfs		coverage: 0.0% of statements
```