### PR TITLE
Bump to go 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
     - master
 
 env:
-  GO_VERSION: "~1.23"
+  GO_VERSION: "~1.24"
 
 jobs:
   # Runs Golangci-lint on the source code

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set Up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "1.23"
+        go-version: "1.24"
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.8 AS builder
+FROM golang:1.24.2 AS builder
 ENV GOPATH="/go"
 WORKDIR /go/src/github.com/kovetskiy/mark
 COPY / .

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/kovetskiy/mark
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.3
+toolchain go1.24.2
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.8.1

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -75,13 +75,13 @@ func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib, path string, mermaidPr
 
 	converter := goldmark.New(
 		goldmark.WithExtensions(
-			extension.GFM,
 			extension.Footnote,
 			extension.DefinitionList,
 			extension.NewTable(
 				extension.WithTableCellAlignMethod(extension.TableCellAlignStyle),
 			),
 			confluenceExtension,
+                        extension.GFM,
 		),
 		goldmark.WithParserOptions(
 			parser.WithAutoHeadingID(),


### PR DESCRIPTION
Looks like something changed with the order of extensions being loaded between go 1.24 and go 1.23, this fixes the failing test.