### PR TITLE
fix: when using confluence cloud (with prefix) the /wiki keeps getting removed

### DIFF
--- a/util/auth.go
+++ b/util/auth.go
@@ -61,14 +61,14 @@ func GetCredentials(
 		)
 	}
 
-	if url.Host == "" {
-		if baseURL == "" {
-			return nil, errors.New(
-				"confluence base URL should be specified using -l " +
-					"flag or be stored in configuration file",
-			)
-		}
-	} else {
+	if url.Host == "" && baseURL == "" {
+		return nil, errors.New(
+			"confluence base URL should be specified using -l " +
+				"flag or be stored in configuration file",
+		)
+	}
+	
+	if baseURL == "" {
 		baseURL = url.Scheme + "://" + url.Host
 	}
 


### PR DESCRIPTION
Basically, with -b `<baseURL> -l <targetURL>`, the targetURL variable will overwrite baseURL with only `<scheme>://<host>`, which does not respect the baseURL set. this fixes this issue.