### PR TITLE
fix: config should be _ instead of -

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,9 +838,9 @@ located in a system specific directory (or specified via `-c --config <path>`) w
 username = "your-email"
 password = "password-or-api-key-for-confluence-cloud"
 # If you are using Confluence Cloud add the /wiki suffix to base_url
-base-url = "http://confluence.local"
-title-from-h1 = true
-drop-h1 = true
+base_url = "http://confluence.local"
+title_from_h1 = true
+drop_h1 = true
 ```
 
 **NOTE**: Labels aren't supported when using `minor-edit`!


### PR DESCRIPTION
config demonstrated on README should be _ instead of -