### PR TITLE
Initialize D2Scale configuration member

### DIFF
--- a/util/cli.go
+++ b/util/cli.go
@@ -222,6 +222,7 @@ func processFile(
 		cfg := types.MarkConfig{
 			MermaidProvider: cmd.String("mermaid-provider"),
 			MermaidScale:    cmd.Float("mermaid-scale"),
+			D2Scale:         cmd.Float("d2-scale"),
 			DropFirstH1:     cmd.Bool("drop-h1"),
 			StripNewlines:   cmd.Bool("strip-linebreaks"),
 			Features:        cmd.StringSlice("features"),
@@ -301,6 +302,7 @@ func processFile(
 	cfg := types.MarkConfig{
 		MermaidProvider: cmd.String("mermaid-provider"),
 		MermaidScale:    cmd.Float("mermaid-scale"),
+		D2Scale:         cmd.Float("d2-scale"),
 		DropFirstH1:     cmd.Bool("drop-h1"),
 		StripNewlines:   cmd.Bool("strip-linebreaks"),
 		Features:        cmd.StringSlice("features"),


### PR DESCRIPTION
The D2Scale property of MarkConfig was never initialized, leading to a default value of 0 being passed to the D2 renderer. This eventually led to calling chromedp.ScreenshotScale with a scale value of 0. Chrome doesn't like this, and never finishes the sceenshot operation.

Fixes #610