### PR TITLE
Back-off and retry mechanism

### DIFF
--- a/confluence/api.go
+++ b/confluence/api.go
@@ -266,6 +266,7 @@ func (api *API) FindPage(
 	if err != nil {
 		return nil, err
 	}
+
 	if resp.StatusCode == http.StatusTooManyRequests {
 		time.Sleep(1 * time.Second)
 		return api.FindPage(space, title, pageType)
@@ -330,6 +331,7 @@ func (api *API) CreateAttachment(
 	if err != nil {
 		return info, err
 	}
+
 	if resp.StatusCode == http.StatusTooManyRequests {
 		time.Sleep(1 * time.Second)
 		return api.CreateAttachment(pageID, name, comment, reader)
@@ -412,6 +414,7 @@ func (api *API) UpdateAttachment(
 	if err != nil {
 		return info, err
 	}
+
 	if resp.StatusCode == http.StatusTooManyRequests {
 		time.Sleep(1 * time.Second)
 		return api.UpdateAttachment(pageID, attachID, name, comment, reader)


### PR DESCRIPTION
Confluence is introducing new [rate limits](https://developer.atlassian.com/cloud/confluence/rate-limiting/). This means that a request sometimes responds with a `429 (Too Many Requests)` status code. However, in contrast to other errors, this is a recoverable error. This pull request implements an exponential back-off and retry mechanism to resolve the problem.

I hope this will be useful. Let me know what you think 👍 