### PR TITLE
Add support for using the filename as the page title

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,6 +811,7 @@ GLOBAL OPTIONS:
    --strip-linebreaks, -L                   remove linebreaks inside of tags, to accommodate non-standard Confluence behavior (default: false) [$MARK_STRIP_LINEBREAKS]
    --title-from-h1                          extract page title from a leading H1 heading. If no H1 heading on a page exists, then title must be set in the page metadata. (default: false) [$MARK_TITLE_FROM_H1]
    --title-append-generated-hash            appends a short hash generated from the path of the page (space, parents, and title) to the title (default: false) [$MARK_TITLE_APPEND_GENERATED_HASH]
+   --title-from-filename                    use the filename (without extension) as the Confluence page title if no explicit 'Title' header or H1 heading is found. (default: false) [$MARK_TITLE_FROM_FILENAME]
    --minor-edit                             don't send notifications while updating Confluence page. (default: false) [$MARK_MINOR_EDIT]
    --version-message string                 add a message to the page version, to explain the edit (default: "") [$MARK_VERSION_MESSAGE]
    --color string                           display logs in color. Possible values: auto, never. (default: "auto") [$MARK_COLOR]

--- a/README.md
+++ b/README.md
@@ -186,8 +186,9 @@ You can use the `--title-from-h1` flag to extract the page title from the first 
 ### From the filename
 
 You can use the `--title-from-filename` flag to use the filename (without the extension) as the page title. `mark` will automatically convert the filename to a more readable title by:
-*   Replacing underscores (`_`) and dashes (`-`) with spaces.
-*   Applying title case to the filename.
+
+* Replacing underscores (`_`) and dashes (`-`) with spaces.
+* Applying title case to the filename.
 
 For example, a file named `my_awesome-page.md` will have the title "My Awesome Page".
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,24 @@ The key's value must be a string which defines the template's content.
   </tblbox>
 ```
 
+## Automatic Page Title
+
+If you don't want to specify the page title in the metadata of each file, `mark` provides two ways to set it automatically.
+
+### From the first H1 heading
+
+You can use the `--title-from-h1` flag to extract the page title from the first H1 heading in the markdown file. If no H1 heading is found, the title must be set in the page metadata.
+
+### From the filename
+
+You can use the `--title-from-filename` flag to use the filename (without the extension) as the page title. `mark` will automatically convert the filename to a more readable title by:
+*   Replacing underscores (`_`) and dashes (`-`) with spaces.
+*   Applying title case to the filename.
+
+For example, a file named `my_awesome-page.md` will have the title "My Awesome Page".
+
+These two options are mutually exclusive. If both flags are provided, `mark` will produce an error.
+
 ## Customizing the page layout
 
 If you set the Layout to plain, the page layout can be customized using HTML comments inside the markdown:
@@ -811,7 +829,7 @@ GLOBAL OPTIONS:
    --strip-linebreaks, -L                   remove linebreaks inside of tags, to accommodate non-standard Confluence behavior (default: false) [$MARK_STRIP_LINEBREAKS]
    --title-from-h1                          extract page title from a leading H1 heading. If no H1 heading on a page exists, then title must be set in the page metadata. (default: false) [$MARK_TITLE_FROM_H1]
    --title-append-generated-hash            appends a short hash generated from the path of the page (space, parents, and title) to the title (default: false) [$MARK_TITLE_APPEND_GENERATED_HASH]
-   --title-from-filename                    use the filename (without extension) as the Confluence page title if no explicit 'Title' header or H1 heading is found. (default: false) [$MARK_TITLE_FROM_FILENAME]
+   --title-from-filename                    use the filename (without extension) as the Confluence page title if no explicit page title is set in the metadata. Mutually exclusive with --title-from-h1. (default: false) [$MARK_TITLE_FROM_FILENAME]
    --minor-edit                             don't send notifications while updating Confluence page. (default: false) [$MARK_MINOR_EDIT]
    --version-message string                 add a message to the page version, to explain the edit (default: "") [$MARK_VERSION_MESSAGE]
    --color string                           display logs in color. Possible values: auto, never. (default: "auto") [$MARK_COLOR]

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+
 var (
 	version = "dev"
 	commit  = "none"

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-
 var (
 	version = "dev"
 	commit  = "none"
@@ -30,6 +29,7 @@ func main() {
 		Flags:                 util.Flags,
 		EnableShellCompletion: true,
 		HideHelpCommand:       true,
+		Before:                util.CheckMutuallyExclusiveTitleFlags,
 		Action:                util.RunMark,
 	}
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -159,8 +159,7 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 			meta.Title = ExtractDocumentLeadingH1(data)
 		}
 		if titleFromFilename && meta.Title == "" && filename != "" {
-			base := filepath.Base(filename)
-			meta.Title = strings.TrimSuffix(base, filepath.Ext(base))
+			setTitleFromFilename(meta, filename)
 		}
 		if spaceFromCli != "" && meta.Space == "" {
 			meta.Space = spaceFromCli
@@ -190,6 +189,11 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 	}
 
 	return meta, data[offset:], nil
+}
+
+func setTitleFromFilename(meta *Meta, filename string) {
+	base := filepath.Base(filename)
+	meta.Title = strings.TrimSuffix(base, filepath.Ext(base))
 }
 
 // ExtractDocumentLeadingH1 will extract leading H1 heading

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -48,7 +49,7 @@ var (
 	reHeaderPatternMacro = regexp.MustCompile(`<!-- Macro: .*`)
 )
 
-func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, parents []string, titleAppendGeneratedHash bool) (*Meta, []byte, error) {
+func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFilename bool, filename string, parents []string, titleAppendGeneratedHash bool) (*Meta, []byte, error) {
 	var (
 		meta   *Meta
 		offset int
@@ -141,7 +142,7 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, parents []s
 		}
 	}
 
-	if titleFromH1 || spaceFromCli != "" {
+	if titleFromH1 || spaceFromCli != "" || titleFromFilename {
 		if meta == nil {
 			meta = &Meta{}
 		}
@@ -156,6 +157,10 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, parents []s
 
 		if titleFromH1 && meta.Title == "" {
 			meta.Title = ExtractDocumentLeadingH1(data)
+		}
+		if titleFromFilename && meta.Title == "" && filename != "" {
+			base := filepath.Base(filename)
+			meta.Title = strings.TrimSuffix(base, filepath.Ext(base))
 		}
 		if spaceFromCli != "" && meta.Space == "" {
 			meta.Space = spaceFromCli

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -142,7 +142,7 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 		}
 	}
 
-	if titleFromH1 || spaceFromCli != "" || titleFromFilename {
+	if titleFromH1 || titleFromFilename || spaceFromCli != "" {
 		if meta == nil {
 			meta = &Meta{}
 		}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/reconquest/pkg/log"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -82,8 +84,7 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 			meta.ContentAppearance = FullWidthContentAppearance // Default to full-width for backwards compatibility
 		}
 
-		//nolint:staticcheck
-		header := strings.Title(matches[1])
+		header := cases.Title(language.English).String(matches[1])
 
 		var value string
 		if len(matches) > 1 {
@@ -193,7 +194,10 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 
 func setTitleFromFilename(meta *Meta, filename string) {
 	base := filepath.Base(filename)
-	meta.Title = strings.TrimSuffix(base, filepath.Ext(base))
+	title := strings.TrimSuffix(base, filepath.Ext(base))
+	title = strings.ReplaceAll(title, "_", " ")
+	title = strings.ReplaceAll(title, "-", " ")
+	meta.Title = cases.Title(language.English).String(title)
 }
 
 // ExtractDocumentLeadingH1 will extract leading H1 heading

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -33,6 +33,30 @@ func TestSetTitleFromFilename(t *testing.T) {
 	t.Run("set title from filename", func(t *testing.T) {
 		meta := &Meta{Title: ""}
 		setTitleFromFilename(meta, "/path/to/test.md")
-		assert.Equal(t, "test", meta.Title)
+		assert.Equal(t, "Test", meta.Title)
+	})
+
+	t.Run("replace underscores with spaces", func(t *testing.T) {
+		meta := &Meta{Title: ""}
+		setTitleFromFilename(meta, "/path/to/test_with_underscores.md")
+		assert.Equal(t, "Test With Underscores", meta.Title)
+	})
+
+	t.Run("replace dashes with spaces", func(t *testing.T) {
+		meta := &Meta{Title: ""}
+		setTitleFromFilename(meta, "/path/to/test-with-dashes.md")
+		assert.Equal(t, "Test With Dashes", meta.Title)
+	})
+
+	t.Run("mixed underscores and dashes", func(t *testing.T) {
+		meta := &Meta{Title: ""}
+		setTitleFromFilename(meta, "/path/to/test_with-mixed_separators.md")
+		assert.Equal(t, "Test With Mixed Separators", meta.Title)
+	})
+
+	t.Run("already title cased", func(t *testing.T) {
+		meta := &Meta{Title: ""}
+		setTitleFromFilename(meta, "/path/to/Already-Title-Cased.md")
+		assert.Equal(t, "Already Title Cased", meta.Title)
 	})
 }

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -28,3 +28,11 @@ func TestExtractDocumentLeadingH1(t *testing.T) {
 
 	assert.Equal(t, "a", actual)
 }
+
+func TestSetTitleFromFilename(t *testing.T) {
+	t.Run("set title from filename", func(t *testing.T) {
+		meta := &Meta{Title: ""}
+		setTitleFromFilename(meta, "/path/to/test.md")
+		assert.Equal(t, "test", meta.Title)
+	})
+}

--- a/page/link.go
+++ b/page/link.go
@@ -33,6 +33,7 @@ func ResolveRelativeLinks(
 	base string,
 	spaceFromCli string,
 	titleFromH1 bool,
+	titleFromFilename bool,
 	parents []string,
 	titleAppendGeneratedHash bool,
 ) ([]LinkSubstitution, error) {
@@ -47,7 +48,7 @@ func ResolveRelativeLinks(
 			match.filename,
 			match.hash,
 		)
-		resolved, err := resolveLink(api, base, match, spaceFromCli, titleFromH1, parents, titleAppendGeneratedHash)
+		resolved, err := resolveLink(api, base, match, spaceFromCli, titleFromH1, titleFromFilename, parents, titleAppendGeneratedHash)
 		if err != nil {
 			return nil, karma.Format(err, "resolve link: %q", match.full)
 		}
@@ -71,6 +72,7 @@ func resolveLink(
 	link markdownLink,
 	spaceFromCli string,
 	titleFromH1 bool,
+	titleFromFilename bool,
 	parents []string,
 	titleAppendGeneratedHash bool,
 ) (string, error) {
@@ -107,7 +109,7 @@ func resolveLink(
 
 		// This helps to determine if found link points to file that's
 		// not markdown or have mark required metadata
-		linkMeta, _, err := metadata.ExtractMeta(linkContents, spaceFromCli, titleFromH1, parents, titleAppendGeneratedHash)
+		linkMeta, _, err := metadata.ExtractMeta(linkContents, spaceFromCli, titleFromH1, titleFromFilename, filepath, parents, titleAppendGeneratedHash)
 		if err != nil {
 			log.Errorf(
 				err,

--- a/util/cli.go
+++ b/util/cli.go
@@ -116,7 +116,7 @@ func processFile(
 
 	parents := strings.Split(cmd.String("parents"), cmd.String("parents-delimiter"))
 
-	meta, markdown, err := metadata.ExtractMeta(markdown, cmd.String("space"), cmd.Bool("title-from-h1"), parents, cmd.Bool("title-append-generated-hash"))
+	meta, markdown, err := metadata.ExtractMeta(markdown, cmd.String("space"), cmd.Bool("title-from-h1"), cmd.Bool("title-from-filename"), file, parents, cmd.Bool("title-append-generated-hash"))
 	if err != nil {
 		fatalErrorHandler.Handle(err, "unable to extract metadata from file %q", file)
 		return nil
@@ -132,7 +132,10 @@ func processFile(
 	}
 
 	if pageID == "" && meta == nil {
-		fatalErrorHandler.Handle(nil, "specified file doesn't contain metadata and URL is not specified via command line or doesn't contain pageId GET-parameter")
+		fatalErrorHandler.Handle(
+			nil,
+			"specified file doesn't contain metadata and URL is not specified via command line or doesn't contain pageId GET-parameter",
+		)
 		return nil
 	}
 
@@ -143,7 +146,10 @@ func processFile(
 		}
 
 		if meta.Title == "" {
-			fatalErrorHandler.Handle(nil, "page title is not set ('Title' header is not set and '--title-from-h1' option and 'h1-title' config is not set or there is no H1 in the file)")
+			fatalErrorHandler.Handle(
+				nil,
+				"page title is not set: use the 'Title' header, or the --title-from-h1 / --title-from-filename flags",
+			)
 			return nil
 		}
 	}
@@ -196,7 +202,7 @@ func processFile(
 		}
 	}
 
-	links, err := page.ResolveRelativeLinks(api, meta, markdown, filepath.Dir(file), cmd.String("space"), cmd.Bool("title-from-h1"), parents, cmd.Bool("title-append-generated-hash"))
+	links, err := page.ResolveRelativeLinks(api, meta, markdown, filepath.Dir(file), cmd.String("space"), cmd.Bool("title-from-h1"), cmd.Bool("title-from-filename"), parents, cmd.Bool("title-append-generated-hash"))
 	if err != nil {
 		fatalErrorHandler.Handle(err, "unable to resolve relative links")
 		return nil
@@ -220,11 +226,11 @@ func processFile(
 		}
 
 		cfg := types.MarkConfig{
-			MermaidScale:    cmd.Float("mermaid-scale"),
-			D2Scale:         cmd.Float("d2-scale"),
-			DropFirstH1:     cmd.Bool("drop-h1"),
-			StripNewlines:   cmd.Bool("strip-linebreaks"),
-			Features:        cmd.StringSlice("features"),
+			MermaidScale:  cmd.Float("mermaid-scale"),
+			D2Scale:       cmd.Float("d2-scale"),
+			DropFirstH1:   cmd.Bool("drop-h1"),
+			StripNewlines: cmd.Bool("strip-linebreaks"),
+			Features:      cmd.StringSlice("features"),
 		}
 		html, _ := mark.CompileMarkdown(markdown, stdlib, file, cfg)
 		fmt.Println(html)
@@ -299,11 +305,11 @@ func processFile(
 		)
 	}
 	cfg := types.MarkConfig{
-		MermaidScale:    cmd.Float("mermaid-scale"),
-		D2Scale:         cmd.Float("d2-scale"),
-		DropFirstH1:     cmd.Bool("drop-h1"),
-		StripNewlines:   cmd.Bool("strip-linebreaks"),
-		Features:        cmd.StringSlice("features"),
+		MermaidScale:  cmd.Float("mermaid-scale"),
+		D2Scale:       cmd.Float("d2-scale"),
+		DropFirstH1:   cmd.Bool("drop-h1"),
+		StripNewlines: cmd.Bool("strip-linebreaks"),
+		Features:      cmd.StringSlice("features"),
 	}
 
 	html, inlineAttachments := mark.CompileMarkdown(markdown, stdlib, file, cfg)

--- a/util/cli.go
+++ b/util/cli.go
@@ -132,10 +132,7 @@ func processFile(
 	}
 
 	if pageID == "" && meta == nil {
-		fatalErrorHandler.Handle(
-			nil,
-			"specified file doesn't contain metadata and URL is not specified via command line or doesn't contain pageId GET-parameter",
-		)
+		fatalErrorHandler.Handle(nil, "specified file doesn't contain metadata and URL is not specified via command line or doesn't contain pageId GET-parameter")
 		return nil
 	}
 
@@ -146,10 +143,7 @@ func processFile(
 		}
 
 		if meta.Title == "" {
-			fatalErrorHandler.Handle(
-				nil,
-				"page title is not set: use the 'Title' header, or the --title-from-h1 / --title-from-filename flags",
-			)
+			fatalErrorHandler.Handle(nil, "page title is not set: use the 'Title' header, or the --title-from-h1 / --title-from-filename flags")
 			return nil
 		}
 	}
@@ -226,11 +220,11 @@ func processFile(
 		}
 
 		cfg := types.MarkConfig{
-			MermaidScale:  cmd.Float("mermaid-scale"),
-			D2Scale:       cmd.Float("d2-scale"),
-			DropFirstH1:   cmd.Bool("drop-h1"),
-			StripNewlines: cmd.Bool("strip-linebreaks"),
-			Features:      cmd.StringSlice("features"),
+			MermaidScale:    cmd.Float("mermaid-scale"),
+			D2Scale:         cmd.Float("d2-scale"),
+			DropFirstH1:     cmd.Bool("drop-h1"),
+			StripNewlines:   cmd.Bool("strip-linebreaks"),
+			Features:        cmd.StringSlice("features"),
 		}
 		html, _ := mark.CompileMarkdown(markdown, stdlib, file, cfg)
 		fmt.Println(html)
@@ -305,11 +299,11 @@ func processFile(
 		)
 	}
 	cfg := types.MarkConfig{
-		MermaidScale:  cmd.Float("mermaid-scale"),
-		D2Scale:       cmd.Float("d2-scale"),
-		DropFirstH1:   cmd.Bool("drop-h1"),
-		StripNewlines: cmd.Bool("strip-linebreaks"),
-		Features:      cmd.StringSlice("features"),
+		MermaidScale:    cmd.Float("mermaid-scale"),
+		D2Scale:         cmd.Float("d2-scale"),
+		DropFirstH1:     cmd.Bool("drop-h1"),
+		StripNewlines:   cmd.Bool("strip-linebreaks"),
+		Features:        cmd.StringSlice("features"),
 	}
 
 	html, inlineAttachments := mark.CompileMarkdown(markdown, stdlib, file, cfg)

--- a/util/cli_test.go
+++ b/util/cli_test.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"context"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+)
+
+func runWithArgs(args []string) error {
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.BoolFlag{Name: "title-from-h1"},
+			&cli.BoolFlag{Name: "title-from-filename"},
+		},
+		Before: CheckMutuallyExclusiveTitleFlags,
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			return nil
+		},
+	}
+	return cmd.Run(context.Background(), args)
+}
+
+func TestCheckMutuallyExclusiveTitleFlags(t *testing.T) {
+	t.Run("neither flag set", func(t *testing.T) {
+		err := runWithArgs([]string{"cmd"})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("only title-from-h1 set", func(t *testing.T) {
+		err := runWithArgs([]string{"cmd", "--title-from-h1"})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("only title-from-filename set", func(t *testing.T) {
+		err := runWithArgs([]string{"cmd", "--title-from-filename"})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("both flags set", func(t *testing.T) {
+		err := runWithArgs([]string{"cmd", "--title-from-h1", "--title-from-filename"})
+		if err == nil {
+			t.Errorf("expected error, got nil")
+		}
+	})
+}

--- a/util/flags.go
+++ b/util/flags.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"context"
+	"errors"
+
 	altsrc "github.com/urfave/cli-altsrc/v3"
 	altsrctoml "github.com/urfave/cli-altsrc/v3/toml"
 	"github.com/urfave/cli/v3"
@@ -58,13 +61,13 @@ var Flags = []cli.Flag{
 	&cli.BoolFlag{
 		Name:    "title-from-h1",
 		Value:   false,
-		Usage:   "extract page title from a leading H1 heading. If no H1 heading on a page exists, then title must be set in the page metadata.",
+		Usage:   "extract page title from a leading H1 heading. If no H1 heading on a page exists, then title must be set in the page metadata. Mutually exclusive with --title-from-filename.",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_FROM_H1"), altsrctoml.TOML("title-from-h1", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.BoolFlag{
 		Name:    "title-from-filename",
 		Value:   false,
-		Usage:   "use the filename (without extension) as the Confluence page title if no explicit 'Title' header or H1 heading is found.",
+		Usage:   "use the filename (without extension) as the Confluence page title if no explicit page title is set in the metadata. Mutually exclusive with --title-from-h1.",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_FROM_FILENAME"), altsrctoml.TOML("title-from-filename", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.BoolFlag{
@@ -193,4 +196,12 @@ var Flags = []cli.Flag{
 		Usage:   "Enables optional features. Current features: d2, mermaid, mkdocsadmonitions",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_FEATURES"), altsrctoml.TOML("features", altsrc.NewStringPtrSourcer(&filename))),
 	},
+}
+
+// CheckMutuallyExclusiveTitleFlags checks if both title-from-h1 and title-from-filename are set
+func CheckMutuallyExclusiveTitleFlags(context context.Context, command *cli.Command) (context.Context, error) {
+	if command.Bool("title-from-h1") && command.Bool("title-from-filename") {
+		return context, errors.New("flags --title-from-h1 and --title-from-filename are mutually exclusive. Please specify only one")
+	}
+	return context, nil
 }

--- a/util/flags.go
+++ b/util/flags.go
@@ -62,6 +62,12 @@ var Flags = []cli.Flag{
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_FROM_H1"), altsrctoml.TOML("title-from-h1", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.BoolFlag{
+		Name:    "title-from-filename",
+		Value:   false,
+		Usage:   "use the filename (without extension) as the Confluence page title if no explicit 'Title' header or H1 heading is found.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_FROM_FILENAME"), altsrctoml.TOML("title-from-filename", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
 		Name:    "title-append-generated-hash",
 		Value:   false,
 		Usage:   "appends a short hash generated from the path of the page (space, parents, and title) to the title",


### PR DESCRIPTION
This PR adds support for a `--title-from-filename` flag that will use the filename as the Confluence page name if the title is not explicitly set in the metadata.

## Why this feature is useful
Our usecase of this tool is as follows: We have a "Documentation" repository that houses a lot of markdown files. The organization primarily uses Confluence so, as a compromise, we want to one-way sync our GitHub to Confluence, which this tool can do for us. This way, we can keep doing our documenting in Git, keeping our peer-reviewing and workflows as-is, and still be compliant with company standards.

Our markdown files are mainly RFC-style documents where, usually, the first heading is something like `Introduction` or `Problem statement`. So unless we change every file to have a unique and descriptive first-heading, the `--title-from-h1` doesn't work, since it will overwrite files because of naming collisions. Ideally, we don't notice - nor care - about how the tool syncs it to Confluence. Because we already use a file structure for descriptors of the documents, we would like to use this instead. As such, we think this feature would fit very well.

From a quick adoption POV (like we have), I think this would be the quickest way to adopt this tool for multiple people who just have documents that they want to mirror to Confluence.