### PR TITLE
feature: add Server param to Jira ticket template

### DIFF
--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -150,6 +150,7 @@ func templates(api *confluence.API) (*template.Template, error) {
 		`ac:jira:ticket`: text(
 			`<ac:structured-macro ac:name="jira">`,
 			`<ac:parameter ac:name="key">{{ .Ticket }}</ac:parameter>`,
+			`<ac:parameter ac:name="server">{{ or .Server "System JIRA" }}</ac:parameter>`,
 			`</ac:structured-macro>`,
 		),
 


### PR DESCRIPTION
This pull request makes a small update to the template rendering for Jira ticket macros. 

* Added a new parameter to the Jira macro template to include the server name, using "System JIRA" as a default if `.Server` is not set (`stdlib/stdlib.go`).

Closes #654