### PR TITLE
Use mimesniffing to detect text files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/urfave/cli/v3 v3.6.1
 	github.com/yuin/goldmark v1.7.13
 	golang.org/x/text v0.32.0
-	golang.org/x/tools/godoc v0.1.0-deprecated
 	gopkg.in/yaml.v3 v3.0.1
 	oss.terrastruct.com/d2 v0.7.1
 	oss.terrastruct.com/util-go v0.0.0-20250213174338-243d8661088a

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,6 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
-golang.org/x/tools/godoc v0.1.0-deprecated h1:o+aZ1BOj6Hsx/GBdJO/s815sqftjSnrZZwyYTHODvtk=
-golang.org/x/tools/godoc v0.1.0-deprecated/go.mod h1:qM63CriJ961IHWmnWa9CjZnBndniPt4a3CK0PVB9bIg=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da h1:noIWHXmPHxILtqtCOPIhSt0ABwskkZKjD3bXGnZGpNY=
 golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=

--- a/page/link.go
+++ b/page/link.go
@@ -3,16 +3,17 @@ package page
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/kovetskiy/mark/confluence"
 	"github.com/kovetskiy/mark/metadata"
 	"github.com/reconquest/karma-go"
 	"github.com/reconquest/pkg/log"
-	"golang.org/x/tools/godoc/util"
 )
 
 type LinkSubstitution struct {
@@ -93,7 +94,10 @@ func resolveLink(
 
 		linkContents, err := os.ReadFile(filepath)
 
-		if !util.IsText(linkContents) {
+		contentType := http.DetectContentType(linkContents)
+		// Check if the MIME type starts with "text/"
+		if !strings.HasPrefix(contentType, "text/") {
+			log.Debugf(nil, "Ignoring link to file %q: detected content type %v", filepath, contentType)
 			return "", nil
 		}
 


### PR DESCRIPTION
This should be a bit more robust than the IsText() method from the deprecated godoc package.