### PR TITLE
 Make more genric

### DIFF
--- a/page/link.go
+++ b/page/link.go
@@ -200,8 +200,7 @@ func getConfluenceLink(
 	space, title string,
 ) (string, error) {
 	link := fmt.Sprintf(
-		"%s/display/%s/%s",
-		api.BaseURL,
+		"/display/%s/%s",
 		space,
 		url.QueryEscape(title),
 	)
@@ -212,7 +211,7 @@ func getConfluenceLink(
 	}
 
 	if page != nil {
-		link = api.BaseURL + page.Links.Full
+		link = page.Links.Full
 	}
 
 	linkUrl, err := url.Parse(link)

--- a/util/cli.go
+++ b/util/cli.go
@@ -49,7 +49,7 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	api := confluence.NewAPI(creds.BaseURL, creds.Username, creds.Password, cmd.Bool("insecure-skip-tls-verify"))
+	api := confluence.NewAPI(creds.BaseURL, creds.Username, creds.Password, cmd.Bool("insecure-skip-tls-verify"), cmd.StringMap("additional-headers"), cmd.String("rest-api-suffix"))
 
 	files, err := doublestar.FilepathGlob(cmd.String("files"))
 	if err != nil {

--- a/util/flags.go
+++ b/util/flags.go
@@ -202,6 +202,18 @@ var Flags = []cli.Flag{
 		Usage:   "skip TLS certificate verification (useful for self-signed certificates)",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_INSECURE_SKIP_TLS_VERIFY"), altsrctoml.TOML("insecure-skip-tls-verify", altsrc.NewStringPtrSourcer(&filename))),
 	},
+	&cli.StringMapFlag{
+		Name:    "additional-headers",
+		Value:   map[string]string{},
+		Usage:   "adding more headers to api requests",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_ADDITIONAL_HEADERS"), altsrctoml.TOML("additional-headers", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:    "rest-api-suffix",
+		Value:   "/rest/api",
+		Usage:   "path to rest api",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_REST_API_SUFFIX"), altsrctoml.TOML("rest-api-suffix", altsrc.NewStringPtrSourcer(&filename))),
+	},
 }
 
 // CheckMutuallyExclusiveTitleFlags checks if both title-from-h1 and title-from-filename are set


### PR DESCRIPTION
Cool work! 
I had the scenario thats an proxy is beween confluence server. 
So therefor some changes happen. 

I did not change logic in general. (expect  **two** places ==> will write comments there) 
Just make it more generic. 

Changes can be collected: 

refactor: 
  - make api rest suffix as flag. 
  - getConfluenceLink make links relativ instand of absolute

feat: 
  - adding flag to extends extra headers