### PR TITLE
Ignore `Include:` in a ```code block``` for self documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,11 @@ follows the `Include` and `Delims` tag, if present:
      <yaml-data> -->
 ```
 
+**Note:** `Include` directives inside fenced code blocks (```` ``` ```` or
+`~~~`) are left untouched. This makes it possible to document Mark itself
+on a Mark-managed page without the example directives being expanded.
+Directives inside indented (4-space) code blocks are still expanded.
+
 Mark also supports attachments. The standard way involves declaring an
 `Attachment` along with the other items in the header, then have any links
 with the same path:

--- a/includes/templates.go
+++ b/includes/templates.go
@@ -25,6 +25,94 @@ var reIncludeDirective = regexp.MustCompile(
 		`(?:\n(?P<config>.*?))?-->`,
 )
 
+// fenceRange covers the byte range of a fenced code block, from the start of
+// its opening fence line through the trailing newline of its closing fence
+// line (or to EOF for an unclosed fence).
+type fenceRange struct{ start, end int }
+
+// scanFenceRanges walks contents line-by-line and returns the byte ranges of
+// fenced code blocks. It recognizes ``` and ~~~ fences with up to 3 leading
+// spaces of indentation per CommonMark §4.5. A closing fence must use the
+// same character as its opener and be at least as long.
+//
+// Indented code blocks (CommonMark §4.4, 4+ leading spaces) are NOT detected:
+// Include directives inside them will still be expanded. Fenced blocks cover
+// the realistic self-documentation case from issue #717.
+func scanFenceRanges(contents []byte) []fenceRange {
+	var (
+		ranges    []fenceRange
+		inFence   bool
+		fenceChar byte
+		fenceLen  int
+		openStart int
+	)
+
+	pos := 0
+	for pos < len(contents) {
+		lineStart := pos
+		var lineEnd, nextStart int
+		if nl := bytes.IndexByte(contents[pos:], '\n'); nl < 0 {
+			lineEnd, nextStart = len(contents), len(contents)
+		} else {
+			lineEnd = pos + nl
+			nextStart = lineEnd + 1
+		}
+		line := contents[lineStart:lineEnd]
+		pos = nextStart
+
+		indent := 0
+		for indent < len(line) && indent < 4 && line[indent] == ' ' {
+			indent++
+		}
+		if indent >= 4 || indent >= len(line) {
+			continue
+		}
+		ch := line[indent]
+		if ch != '`' && ch != '~' {
+			continue
+		}
+		run := indent
+		for run < len(line) && line[run] == ch {
+			run++
+		}
+		runLen := run - indent
+		if runLen < 3 {
+			continue
+		}
+
+		if !inFence {
+			inFence, fenceChar, fenceLen, openStart = true, ch, runLen, lineStart
+			continue
+		}
+		if ch == fenceChar && runLen >= fenceLen {
+			ranges = append(ranges, fenceRange{start: openStart, end: nextStart})
+			inFence = false
+		}
+	}
+
+	if inFence {
+		ranges = append(ranges, fenceRange{start: openStart, end: len(contents)})
+	}
+	return ranges
+}
+
+func insideAnyFence(pos int, ranges []fenceRange) bool {
+	for _, r := range ranges {
+		if pos >= r.start && pos < r.end {
+			return true
+		}
+	}
+	return false
+}
+
+func formatVardump(data map[string]any) string {
+	var parts []string
+	for key, value := range data {
+		parts = append(parts, fmt.Sprintf("%s=%v", key, value))
+	}
+	return strings.Join(parts, ", ")
+}
+
 func LoadTemplate(
 	base string,
 	includePath string,
@@ -68,80 +156,96 @@ func LoadTemplate(
 	return templates, nil
 }
 
+func expandInclude(
+	spec []byte,
+	base string,
+	includePath string,
+	templates *template.Template,
+) ([]byte, *template.Template, error) {
+	groups := reIncludeDirective.FindSubmatch(spec)
+
+	var (
+		path       = string(groups[1])
+		delimsNone = string(groups[2])
+		left       = string(groups[3])
+		right      = string(groups[4])
+		config     = groups[5]
+		data       = map[string]any{}
+	)
+
+	if delimsNone == "none" {
+		left, right = "\x00", "\x01"
+	}
+
+	if err := yaml.Unmarshal(config, &data); err != nil {
+		return nil, templates, fmt.Errorf("unable to unmarshal template data config (path=%q, config=%q): %w", path, string(config), err)
+	}
+
+	log.Trace().Interface("vardump", data).Msgf("including template %q", path)
+
+	var err error
+	templates, err = LoadTemplate(base, includePath, path, left, right, templates)
+	if err != nil {
+		return nil, templates, fmt.Errorf("unable to load template %q: %w", path, err)
+	}
+
+	var buffer bytes.Buffer
+	if err := templates.Execute(&buffer, data); err != nil {
+		return nil, templates, fmt.Errorf("unable to execute template %q (vars: %s): %w", path, formatVardump(data), err)
+	}
+
+	return buffer.Bytes(), templates, nil
+}
+
+// ProcessIncludes uses FindAllIndex + a manual append loop instead of the
+// regexp.ReplaceAllFunc closure idiom used elsewhere in the project (see
+// macro.ExtractMacros), because skipping directives inside fenced code blocks
+// requires the byte position of each match to test against scanFenceRanges.
 func ProcessIncludes(
 	base string,
 	includePath string,
 	contents []byte,
 	templates *template.Template,
 ) (*template.Template, []byte, bool, error) {
-	formatVardump := func(
-		data map[string]any,
-	) string {
-		var parts []string
-		for key, value := range data {
-			parts = append(parts, fmt.Sprintf("%s=%v", key, value))
-		}
-
-		return strings.Join(parts, ", ")
+	matches := reIncludeDirective.FindAllIndex(contents, -1)
+	if len(matches) == 0 {
+		return templates, contents, false, nil
 	}
+
+	fences := scanFenceRanges(contents)
 
 	var (
 		recurse bool
 		err     error
 	)
 
-	contents = reIncludeDirective.ReplaceAllFunc(
-		contents,
-		func(spec []byte) []byte {
-			if err != nil {
-				return spec
-			}
+	out := make([]byte, 0, len(contents))
+	last := 0
 
-			groups := reIncludeDirective.FindSubmatch(spec)
+	for _, m := range matches {
+		out = append(out, contents[last:m[0]]...)
+		spec := contents[m[0]:m[1]]
+		last = m[1]
 
-			var (
-				path       = string(groups[1])
-				delimsNone = string(groups[2])
-				left       = string(groups[3])
-				right      = string(groups[4])
-				config     = groups[5]
-				data       = map[string]any{}
-			)
+		if err != nil || insideAnyFence(m[0], fences) {
+			out = append(out, spec...)
+			continue
+		}
 
-			if delimsNone == "none" {
-				left = "\x00"
-				right = "\x01"
-			}
+		var (
+			expanded []byte
+			expErr   error
+		)
+		expanded, templates, expErr = expandInclude(spec, base, includePath, templates)
+		if expErr != nil {
+			err = expErr
+			out = append(out, spec...)
+			continue
+		}
+		recurse = true
+		out = append(out, expanded...)
+	}
 
-			err = yaml.Unmarshal(config, &data)
-			if err != nil {
-				err = fmt.Errorf("unable to unmarshal template data config (path=%q, config=%q): %w", path, string(config), err)
-
-				return spec
-			}
-
-			log.Trace().Interface("vardump", data).Msgf("including template %q", path)
-
-			templates, err = LoadTemplate(base, includePath, path, left, right, templates)
-			if err != nil {
-				err = fmt.Errorf("unable to load template %q: %w", path, err)
-				return spec
-			}
-
-			var buffer bytes.Buffer
-
-			err = templates.Execute(&buffer, data)
-			if err != nil {
-				err = fmt.Errorf("unable to execute template %q (vars: %s): %w", path, formatVardump(data), err)
-
-				return spec
-			}
-
-			recurse = true
-
-			return buffer.Bytes()
-		},
-	)
-
-	return templates, contents, recurse, err
+	out = append(out, contents[last:]...)
+	return templates, out, recurse, err
 }

--- a/includes/templates_test.go
+++ b/includes/templates_test.go
@@ -1,0 +1,261 @@
+package includes
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// rangeOf returns a fenceRange spanning input[needleStart .. closingLineEnd+1].
+// closingNeedle is the closing fence text (e.g. "```\n") whose end-of-line
+// (including trailing newline if present) marks the range's end. Computing
+// expected ranges this way keeps tests robust to edits of the input string.
+func rangeOf(t *testing.T, input, openingNeedle, closingNeedle string) fenceRange {
+	t.Helper()
+	start := strings.Index(input, openingNeedle)
+	if start < 0 {
+		t.Fatalf("opening needle %q not in input", openingNeedle)
+	}
+	closeAt := strings.Index(input[start+len(openingNeedle):], closingNeedle)
+	if closeAt < 0 {
+		t.Fatalf("closing needle %q not in input after opening", closingNeedle)
+	}
+	end := start + len(openingNeedle) + closeAt + len(closingNeedle)
+	return fenceRange{start: start, end: end}
+}
+
+func TestScanFenceRanges(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  func(string) []fenceRange
+	}{
+		{
+			name:  "no code blocks",
+			input: "Hello world\nNo code here",
+			want:  func(string) []fenceRange { return nil },
+		},
+		{
+			name:  "single backtick fence",
+			input: "Some text\n```\ncode inside\n```\nmore text",
+			want: func(in string) []fenceRange {
+				return []fenceRange{rangeOf(t, in, "```\n", "```\n")}
+			},
+		},
+		{
+			name:  "single tilde fence",
+			input: "Some text\n~~~\ncode inside\n~~~\nmore text",
+			want: func(in string) []fenceRange {
+				return []fenceRange{rangeOf(t, in, "~~~\n", "~~~\n")}
+			},
+		},
+		{
+			name:  "fence with info string",
+			input: "Some text\n```bash\necho hello\n```\nmore text",
+			want: func(in string) []fenceRange {
+				return []fenceRange{rangeOf(t, in, "```bash\n", "```\n")}
+			},
+		},
+		{
+			name:  "two consecutive fences",
+			input: "First\n```\nblock 1\n```\nBetween\n```\nblock 2\n```\nLast",
+			want: func(in string) []fenceRange {
+				first := strings.Index(in, "```\n")
+				firstClose := first + len("```\n") + strings.Index(in[first+len("```\n"):], "```\n") + len("```\n")
+				second := firstClose + strings.Index(in[firstClose:], "```\n")
+				secondClose := second + len("```\n") + strings.Index(in[second+len("```\n"):], "```\n") + len("```\n")
+				return []fenceRange{
+					{start: first, end: firstClose},
+					{start: second, end: secondClose},
+				}
+			},
+		},
+		{
+			name:  "four-backtick fence closes only on four-or-more",
+			input: "Some text\n````\ncontains ``` inside\n````\nmore",
+			want: func(in string) []fenceRange {
+				return []fenceRange{rangeOf(t, in, "````\n", "````\n")}
+			},
+		},
+		{
+			name:  "shorter close does not close longer open",
+			input: "````\ncontent\n```\nstill in fence\n````\nafter",
+			want: func(in string) []fenceRange {
+				return []fenceRange{rangeOf(t, in, "````\n", "````\n")}
+			},
+		},
+		{
+			name:  "tilde inside backtick fence stays inside",
+			input: "```\n~~~\ntext\n~~~\n```\nafter",
+			want: func(in string) []fenceRange {
+				return []fenceRange{rangeOf(t, in, "```\n", "```\n")}
+			},
+		},
+		{
+			name:  "indented one-space fence",
+			input: "Hi\n ```\ncode\n ```\nbye",
+			want: func(in string) []fenceRange {
+				return []fenceRange{rangeOf(t, in, " ```\n", " ```\n")}
+			},
+		},
+		{
+			name:  "indented two-space fence",
+			input: "Hi\n  ```\ncode\n  ```\nbye",
+			want: func(in string) []fenceRange {
+				return []fenceRange{rangeOf(t, in, "  ```\n", "  ```\n")}
+			},
+		},
+		{
+			name:  "indented three-space fence",
+			input: "Hi\n   ```\ncode\n   ```\nbye",
+			want: func(in string) []fenceRange {
+				return []fenceRange{rangeOf(t, in, "   ```\n", "   ```\n")}
+			},
+		},
+		{
+			name:  "four-space indent is not a fence",
+			input: "Hi\n    ```\nnot a fence\n    ```\nbye",
+			want:  func(string) []fenceRange { return nil },
+		},
+		{
+			name:  "unclosed fence runs to EOF",
+			input: "intro\n```\nno close in sight\n",
+			want: func(in string) []fenceRange {
+				start := strings.Index(in, "```")
+				return []fenceRange{{start: start, end: len(in)}}
+			},
+		},
+		{
+			name:  "unclosed fence with no trailing newline",
+			input: "intro\n```\ndangling",
+			want: func(in string) []fenceRange {
+				start := strings.Index(in, "```")
+				return []fenceRange{{start: start, end: len(in)}}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scanFenceRanges([]byte(tt.input))
+			assert.Equal(t, tt.want(tt.input), got)
+		})
+	}
+}
+
+func TestInsideAnyFence(t *testing.T) {
+	ranges := []fenceRange{
+		{start: 10, end: 30},
+		{start: 50, end: 70},
+	}
+
+	cases := []struct {
+		pos  int
+		want bool
+	}{
+		{5, false},
+		{10, true},
+		{20, true},
+		{29, true},
+		{30, false},
+		{40, false},
+		{50, true},
+		{60, true},
+		{70, false},
+		{80, false},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.want, insideAnyFence(c.pos, ranges), "pos=%d", c.pos)
+	}
+}
+
+func TestProcessIncludes(t *testing.T) {
+	t.Run("skips directives inside code blocks", func(t *testing.T) {
+		templates := template.New("test")
+		_, err := templates.New("present").Parse("EXPANDED")
+		assert.NoError(t, err)
+
+		input := "Some text before\n\n" +
+			"```\n" +
+			"<!-- Include: example.md -->\n" +
+			"```\n\n" +
+			"Some text after\n" +
+			"<!-- Include: present.md -->\n" +
+			"End"
+
+		_, result, recurse, err := ProcessIncludes(".", "", []byte(input), templates)
+		assert.NoError(t, err)
+		assert.True(t, recurse)
+
+		resultStr := string(result)
+		assert.Contains(t, resultStr, "<!-- Include: example.md -->", "directive in code block must be preserved")
+		assert.Contains(t, resultStr, "```\n<!-- Include: example.md -->\n```", "code block structure must be intact")
+		assert.Contains(t, resultStr, "EXPANDED", "directive outside code block must be expanded")
+		assert.NotContains(t, resultStr, "<!-- Include: present.md -->", "expanded directive must be gone")
+	})
+
+	t.Run("processes directives outside code blocks", func(t *testing.T) {
+		templates := template.New("test")
+		templates, _ = templates.New("test-include").Parse("INCLUDED CONTENT")
+
+		input := `Normal text
+<!-- Include: test-include.md -->
+More text`
+
+		_, result, recurse, err := ProcessIncludes(".", "", []byte(input), templates)
+
+		assert.NoError(t, err)
+		assert.True(t, recurse)
+		assert.Contains(t, string(result), "INCLUDED CONTENT")
+		assert.NotContains(t, string(result), "<!-- Include:")
+	})
+
+	t.Run("self-documentation page leaves directives alone", func(t *testing.T) {
+		// Reproducer for https://github.com/kovetskiy/mark/issues/717: an
+		// Include directive inside a code block (e.g. self-documenting Mark
+		// usage) must not be processed.
+		input := "# Documentation page\n\nHere's how to use Mark:\n\n" +
+			"```\n" +
+			"<!-- Space: EXMPLSPC -->\n" +
+			"<!-- Title: Documentation as code -->\n" +
+			"<!-- Include: shared/disclaimer.md -->\n" +
+			"```\n\n" +
+			"Copy the above to your markdown file."
+
+		templates := template.New("test")
+
+		_, result, recurse, err := ProcessIncludes(".", "", []byte(input), templates)
+
+		assert.NoError(t, err)
+		assert.False(t, recurse, "no includes should have been processed")
+
+		resultStr := string(result)
+		assert.Contains(t, resultStr, "<!-- Include: shared/disclaimer.md -->")
+		assert.Contains(t, resultStr, "```\n<!-- Space: EXMPLSPC -->")
+	})
+
+	t.Run("mixed in and out of code blocks", func(t *testing.T) {
+		templates := template.New("test")
+		templates, _ = templates.New("real-include").Parse("REAL INCLUDED CONTENT")
+
+		input := "Some intro text\n\n" +
+			"<!-- Include: real-include.md -->\n\n" +
+			"Example code:\n\n" +
+			"```\n" +
+			"<!-- Include: example-in-codeblock.md -->\n" +
+			"```\n\n" +
+			"More text"
+
+		_, result, recurse, err := ProcessIncludes(".", "", []byte(input), templates)
+
+		assert.NoError(t, err)
+		assert.True(t, recurse, "outside-fence directive should have been processed")
+
+		resultStr := string(result)
+		assert.Contains(t, resultStr, "REAL INCLUDED CONTENT")
+		assert.Contains(t, resultStr, "<!-- Include: example-in-codeblock.md -->")
+	})
+}


### PR DESCRIPTION
Addresses #717

## What

`Include` directives inside fenced code blocks are now left untouched, so a Mark-managed page can document Mark's own directive syntax without the examples being expanded.

## How

- Scan the content for all fenced code block ranges (```` ``` ```` and `~~~`,
  per CommonMark §4.5, up to 3 spaces of indentation).
- Find all `Include` directive positions.
- Expand only the directives that fall outside any fenced block; those inside
  are emitted verbatim.

## Before / After

- **Before:** every `Include` directive was processed, including those shown as examples inside code blocks.
- **After:** directives inside fenced code blocks are preserved as-is.

## Scope / limitations

- **Indented (4-space) code blocks are not detected** — directives inside them are still expanded.
- Fences with info strings (e.g. ```` ```bash ````) are handled correctly.

## Notes

`go test ./...` and `go build ./...` pass 

This PR is a part of an internal mark image at my workplace.
We use it to document the way we use mark.
