### PR TITLE
Add Parent-ID header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ File in the extended format should follow the specification:
 <!-- Space: <space key> -->
 <!-- Parent: <parent 1> -->
 <!-- Parent: <parent 2> -->
+<!-- Parent-ID: <parent page id> -->
 <!-- Title: <title> -->
 <!-- Attachment: <local path> -->
 <!-- Label: <label 1> -->
@@ -36,6 +37,15 @@ File in the extended format should follow the specification:
 
 There can be any number of `Parent` headers, if Mark can't find specified
 parent by title, Mark creates it.
+
+Alternatively, you can specify a single parent page by ID:
+
+```markdown
+<!-- Parent-ID: <parent page id> -->
+```
+
+If `Parent-ID` is set, any `Parent` headers are ignored (a warning is logged),
+and the page is placed directly under the specified parent page.
 
 Also, optional following headers are supported:
 

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -49,6 +49,10 @@ type PageInfo struct {
 	Title string `json:"title"`
 	Type  string `json:"type"`
 
+	Space struct {
+		Key string `json:"key"`
+	} `json:"space"`
+
 	Version struct {
 		Number  int64  `json:"number"`
 		Message string `json:"message"`
@@ -474,7 +478,7 @@ func (api *API) GetAttachments(pageID string) ([]AttachmentInfo, error) {
 func (api *API) GetPageByID(pageID string) (*PageInfo, error) {
 	request, err := api.rest.Res(
 		"content/"+pageID, &PageInfo{},
-	).Get(map[string]string{"expand": "ancestors,version"})
+	).Get(map[string]string{"expand": "ancestors,version,space"})
 	if err != nil {
 		return nil, err
 	}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -60,3 +60,27 @@ func TestSetTitleFromFilename(t *testing.T) {
 		assert.Equal(t, "Already Title Cased", meta.Title)
 	})
 }
+
+func TestExtractMetaParentID(t *testing.T) {
+	t.Run("parse Parent-ID", func(t *testing.T) {
+		data := []byte("<!-- Parent-ID: 12345 -->\ncontent\n")
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false)
+		assert.NoError(t, err)
+		assert.NotNil(t, meta)
+		assert.Equal(t, "12345", meta.ParentID)
+	})
+
+	t.Run("reject empty Parent-ID", func(t *testing.T) {
+		data := []byte("<!-- Parent-ID: -->\ncontent\n")
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false)
+		assert.Nil(t, meta)
+		assert.EqualError(t, err, "Parent-ID header value is empty")
+	})
+
+	t.Run("reject duplicate Parent-ID", func(t *testing.T) {
+		data := []byte("<!-- Parent-ID: 123 -->\n<!-- Parent-ID: 456 -->\n")
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false)
+		assert.Nil(t, meta)
+		assert.EqualError(t, err, "Parent-ID header is already set")
+	})
+}


### PR DESCRIPTION
This PR adds stable parent resolution by Confluence page ID via a dedicated `Parent-ID` header.

## Details
- add `Parent-ID` header support for stable parent resolution by Confluence page ID
- validate that Parent-ID pages belong to the specified space, and warn when Parent headers are ignored
- document the new header and add metadata parsing tests

## Testing
- `go test ./...` (fails in `d2` and `mermaid` image tests; same failures are present on `master` with differing expected dimensions)

## Notes
- `Parent-ID` is header-only (no CLI flag) and is single-use
- when `Parent-ID` is set, `Parent` headers are ignored and logged as a warning
- fixes: #644 
- fixes: #523