### PR TITLE
feat: Added support for PlantUML using Confluence PlantUML macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,21 @@ All you need is a codeblock marked as "d2".
 X -> Y
 ```
 
+### Render PlantUML Diagram
+
+Mark supports [PlantUML](https://plantuml.com/) diagrams using the [Confluence PlantUML macro](https://avono-support.atlassian.net/wiki/spaces/PUML/pages/9699367/Macro+plantuml). This feature is enabled by default.
+
+When you include a code block marked as "plantuml", mark will wrap it in the appropriate Confluence macro, allowing the PlantUML plugin in Confluence to render the diagram.
+
+**Note:** This requires the PlantUML plugin to be installed in your Confluence instance.
+
+```plantuml
+@startuml
+Alice -> Bob: Authentication Request
+Bob --> Alice: Authentication Response
+@enduml
+```
+
 ### MkDocs' Admonitions
 
 Optionally you can enable mkdocs-style [Admonitions](https://squidfunk.github.io/mkdocs-material/reference/admonitions/) via `--features="mkdocsadmonitions"`.
@@ -842,7 +857,7 @@ GLOBAL OPTIONS:
    --include-path string                    Path for shared includes, used as a fallback if the include doesn't exist in the current directory. [$MARK_INCLUDE_PATH]
    --changes-only                           Avoids re-uploading pages that haven't changed since the last run. [$MARK_CHANGES_ONLY]
    --d2-scale float                         defines the scaling factor for d2 renderings. (default: 1) [$MARK_D2_SCALE]
-   --features string [ --features string ]  Enables optional features. Current features: d2, mermaid, mention, mkdocsadmonitions (default: "mermaid", "mention") [$MARK_FEATURES]
+   --features string [ --features string ]  Enables optional features. Current features: d2, mermaid, mention, mkdocsadmonitions, plantuml (default: "mermaid", "mention", "plantuml") [$MARK_FEATURES]
    --insecure-skip-tls-verify               skip TLS certificate verification (useful for self-signed certificates) [$MARK_INSECURE_SKIP_TLS_VERIFY]
    --help, -h                               show help
    --version, -v                            print the version

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -64,7 +64,7 @@ func TestCompileMarkdown(t *testing.T) {
 			D2Scale:       1.0,
 			DropFirstH1:   false,
 			StripNewlines: false,
-			Features:      []string{"mkdocsadmonitions", "mention"},
+			Features:      []string{"mkdocsadmonitions", "mention", "plantuml"},
 		}
 
 		actual, _ := mark.CompileMarkdown(markdown, lib, filename, cfg)
@@ -94,7 +94,7 @@ func TestCompileMarkdownDropH1(t *testing.T) {
 		}
 		var variant string
 		switch filename {
-		case "testdata/quotes.md", "testdata/header.md", "testdata/admonitions.md":
+		case "testdata/quotes.md", "testdata/header.md", "testdata/admonitions.md", "testdata/plantuml.md":
 			variant = "-droph1"
 		default:
 			variant = ""
@@ -106,7 +106,7 @@ func TestCompileMarkdownDropH1(t *testing.T) {
 			D2Scale:       1.0,
 			DropFirstH1:   true,
 			StripNewlines: false,
-			Features:      []string{"mkdocsadmonitions", "mention"},
+			Features:      []string{"mkdocsadmonitions", "mention", "plantuml"},
 		}
 
 		actual, _ := mark.CompileMarkdown(markdown, lib, filename, cfg)
@@ -150,7 +150,7 @@ func TestCompileMarkdownStripNewlines(t *testing.T) {
 			D2Scale:       1.0,
 			DropFirstH1:   false,
 			StripNewlines: true,
-			Features:      []string{"mkdocsadmonitions", "mention"},
+			Features:      []string{"mkdocsadmonitions", "mention", "plantuml"},
 		}
 
 		actual, _ := mark.CompileMarkdown(markdown, lib, filename, cfg)

--- a/renderer/fencedcodeblock.go
+++ b/renderer/fencedcodeblock.go
@@ -194,6 +194,21 @@ func (r *ConfluenceFencedCodeBlockRenderer) renderFencedCodeBlock(writer util.Bu
 			return ast.WalkStop, err
 		}
 
+	} else if lang == "plantuml" && slices.Contains(r.MarkConfig.Features, "plantuml") {
+		err := r.Stdlib.Templates.ExecuteTemplate(
+			writer,
+			"ac:plantuml",
+			struct {
+				Text string
+			}{
+				strings.TrimSuffix(string(lval), "\n"),
+			},
+		)
+
+		if err != nil {
+			return ast.WalkStop, err
+		}
+
 	} else {
 		err := r.Stdlib.Templates.ExecuteTemplate(
 			writer,

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -100,6 +100,13 @@ func templates(api *confluence.API) (*template.Template, error) {
 			`</ac:structured-macro>`,
 		),
 
+		// This template is used for rendering PlantUML diagrams
+		`ac:plantuml`: text(
+			`<ac:structured-macro ac:name="plantuml">`,
+			/**/ `<ac:plain-text-body><![CDATA[{{ .Text | cdata }}]]></ac:plain-text-body>`,
+			`</ac:structured-macro>`,
+		),
+
 		`ac:status`: text(
 			`<ac:structured-macro ac:name="status">`,
 			`<ac:parameter ac:name="colour">{{ or .Color "Grey" }}</ac:parameter>`,

--- a/testdata/plantuml-droph1.html
+++ b/testdata/plantuml-droph1.html
@@ -1,0 +1,22 @@
+<p>A simple PlantUML diagram:</p>
+<ac:structured-macro ac:name="plantuml"><ac:plain-text-body><![CDATA[@startuml
+Alice -> Bob: Authentication Request
+Bob --> Alice: Authentication Response
+@enduml]]></ac:plain-text-body></ac:structured-macro><p>Another diagram with more complex syntax:</p>
+<ac:structured-macro ac:name="plantuml"><ac:plain-text-body><![CDATA[@startuml
+participant Participant as Foo
+actor       Actor       as Foo1
+boundary    Boundary    as Foo2
+control     Control     as Foo3
+entity      Entity      as Foo4
+database    Database    as Foo5
+collections Collections as Foo6
+queue       Queue       as Foo7
+Foo -> Foo1 : To actor 
+Foo -> Foo2 : To boundary
+Foo -> Foo3 : To control
+Foo -> Foo4 : To entity
+Foo -> Foo5 : To database
+Foo -> Foo6 : To collections
+Foo -> Foo7: To queue
+@enduml]]></ac:plain-text-body></ac:structured-macro>

--- a/testdata/plantuml.html
+++ b/testdata/plantuml.html
@@ -1,0 +1,23 @@
+<h1 id="PlantUML-Test">PlantUML Test</h1>
+<p>A simple PlantUML diagram:</p>
+<ac:structured-macro ac:name="plantuml"><ac:plain-text-body><![CDATA[@startuml
+Alice -> Bob: Authentication Request
+Bob --> Alice: Authentication Response
+@enduml]]></ac:plain-text-body></ac:structured-macro><p>Another diagram with more complex syntax:</p>
+<ac:structured-macro ac:name="plantuml"><ac:plain-text-body><![CDATA[@startuml
+participant Participant as Foo
+actor       Actor       as Foo1
+boundary    Boundary    as Foo2
+control     Control     as Foo3
+entity      Entity      as Foo4
+database    Database    as Foo5
+collections Collections as Foo6
+queue       Queue       as Foo7
+Foo -> Foo1 : To actor 
+Foo -> Foo2 : To boundary
+Foo -> Foo3 : To control
+Foo -> Foo4 : To entity
+Foo -> Foo5 : To database
+Foo -> Foo6 : To collections
+Foo -> Foo7: To queue
+@enduml]]></ac:plain-text-body></ac:structured-macro>

--- a/testdata/plantuml.md
+++ b/testdata/plantuml.md
@@ -1,0 +1,32 @@
+# PlantUML Test
+
+A simple PlantUML diagram:
+
+```plantuml
+@startuml
+Alice -> Bob: Authentication Request
+Bob --> Alice: Authentication Response
+@enduml
+```
+
+Another diagram with more complex syntax:
+
+```plantuml
+@startuml
+participant Participant as Foo
+actor       Actor       as Foo1
+boundary    Boundary    as Foo2
+control     Control     as Foo3
+entity      Entity      as Foo4
+database    Database    as Foo5
+collections Collections as Foo6
+queue       Queue       as Foo7
+Foo -> Foo1 : To actor 
+Foo -> Foo2 : To boundary
+Foo -> Foo3 : To control
+Foo -> Foo4 : To entity
+Foo -> Foo5 : To database
+Foo -> Foo6 : To collections
+Foo -> Foo7: To queue
+@enduml
+```

--- a/util/flags.go
+++ b/util/flags.go
@@ -192,8 +192,8 @@ var Flags = []cli.Flag{
 
 	&cli.StringSliceFlag{
 		Name:    "features",
-		Value:   []string{"mermaid", "mention"},
-		Usage:   "Enables optional features. Current features: d2, mermaid, mention, mkdocsadmonitions",
+		Value:   []string{"mermaid", "mention", "plantuml"},
+		Usage:   "Enables optional features. Current features: d2, mermaid, mention, mkdocsadmonitions, plantuml",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_FEATURES"), altsrctoml.TOML("features", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.BoolFlag{


### PR DESCRIPTION
Added support of PlantUML based diagrams using [Confluence PlantUML macro](https://avono-support.atlassian.net/wiki/spaces/PUML/pages/9699367/Macro+plantuml). 

All rendering will be done by Confluence if PlantUML plugin is installed.