### PR TITLE
feat: publish mermaid diagrams as SVG, optionally with their source bundled in

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,6 +1251,17 @@ graph TD;
 A-->B;
 ```
 
+A diagram is published as a PNG by default, scaled by `--mermaid-scale`.
+`--mermaid-output=svg` publishes the drawing itself instead: one file that is
+sharp at any zoom and whose text stays text, on an instance that displays an SVG
+attachment. A scale has nothing to multiply there, so setting one alongside it
+is refused rather than quietly ignored.
+
+`--mermaid-bundle` keeps the diagram's own source inside that SVG, in its
+`<desc>` element, so what was published can be opened and edited again from the
+attachment without the document it came from. It needs `--mermaid-output=svg`:
+a PNG has nowhere to keep it.
+
 ### Render D2 Diagram
 
 Optionally you can enable [D2](https://github.com/terrastruct/d2) rendering via `--features="d2"`.
@@ -1599,7 +1610,9 @@ GLOBAL OPTIONS:
    --parents string                         A list containing the parents of the document separated by parents-delimiter (default: '/'). These will be prepended to the ones defined in the document itself. [$MARK_PARENTS]
    --parents-delimiter string               The delimiter used for the parents list (default: "/") [$MARK_PARENTS_DELIMITER]
    --content-appearance string              default content appearance for pages without a Content-Appearance header. Possible values: full-width, fixed, default. [$MARK_CONTENT_APPEARANCE]
-   --mermaid-scale float                    defines the scaling factor for mermaid renderings. (default: 1) [$MARK_MERMAID_SCALE]
+   --mermaid-scale float                    defines the scaling factor for mermaid PNG renderings; not accepted when mermaid-output is svg. (default: 1) [$MARK_MERMAID_SCALE]
+   --mermaid-output string                  image a mermaid diagram is published as: png (rasterised, and scaled by --mermaid-scale) or svg (vector and sharp at any zoom, where the instance displays an SVG attachment). (default: "png") [$MARK_MERMAID_OUTPUT]
+   --mermaid-bundle                         keep the diagram's own source inside the SVG published for it, in its <desc> element, so the drawing can be edited again from the attachment. Needs --mermaid-output=svg. [$MARK_MERMAID_BUNDLE]
    --include-path string                    Path for shared includes, used as a fallback if the include doesn't exist in the current directory. [$MARK_INCLUDE_PATH]
    --changes-only                           Avoids re-uploading pages that haven't changed since the last run. [$MARK_CHANGES_ONLY]
    --output-format string                   how to report what the run did: "url" prints the address of each published page (the default), "json" prints one object describing the whole run, "github" prints GitHub Actions workflow commands so that failures appear against the file that caused them. [$MARK_OUTPUT_FORMAT]

--- a/mark.go
+++ b/mark.go
@@ -177,6 +177,29 @@ func run(ctx context.Context, config Config) error {
 		)
 	}
 
+	// Checked here as well as in the CLI, because Config is a public API and a
+	// library caller reaches this without passing a flag at all. A value the
+	// renderer does not know falls to its default branch, so an unrecognised
+	// format publishes a PNG without a word -- taking a bundle asked for
+	// alongside it down with it. An empty value is not that: it is a caller
+	// that never set the field, and it means the PNG mark has always published.
+	switch config.MermaidOutput {
+	case "", "png", "svg":
+		// ok
+	default:
+		return fmt.Errorf(
+			"invalid MermaidOutput %q: expected \"png\", \"svg\", or \"\" for the default",
+			config.MermaidOutput,
+		)
+	}
+
+	if config.MermaidBundle && config.MermaidOutput != "svg" {
+		return errors.New(
+			"MermaidBundle needs MermaidOutput \"svg\": " +
+				"there is nowhere in a PNG to keep the diagram's source",
+		)
+	}
+
 	if config.CheckLinksWarnOnly && len(config.CheckLinks) == 0 {
 		return fmt.Errorf(
 			"--check-links-warn-only requires --check-links: " +

--- a/mark.go
+++ b/mark.go
@@ -86,6 +86,8 @@ type Config struct {
 	DropH1          bool
 	StripLinebreaks bool
 	MermaidScale    float64
+	MermaidOutput   string
+	MermaidBundle   bool
 	D2Scale         float64
 	MathFormat      string
 	MathScale       float64
@@ -694,6 +696,8 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 
 		cfg := types.MarkConfig{
 			MermaidScale:  config.MermaidScale,
+			MermaidOutput: config.MermaidOutput,
+			MermaidBundle: config.MermaidBundle,
 			D2Scale:       config.D2Scale,
 			MathFormat:    config.MathFormat,
 			MathScale:     config.MathScale,
@@ -914,6 +918,8 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 
 	cfg := types.MarkConfig{
 		MermaidScale:  config.MermaidScale,
+		MermaidOutput: config.MermaidOutput,
+		MermaidBundle: config.MermaidBundle,
 		D2Scale:       config.D2Scale,
 		MathFormat:    config.MathFormat,
 		MathScale:     config.MathScale,

--- a/mark_mermaid_test.go
+++ b/mark_mermaid_test.go
@@ -1,0 +1,68 @@
+package mark
+
+import (
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mermaidFixture returns a server and a configuration that publishes one
+// ordinary document, so that what a test changes about the mermaid settings is
+// the only thing that can fail the run.
+func mermaidFixture(t *testing.T) Config {
+	t.Helper()
+
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md", "<!-- Space: DOCS -->\n<!-- Title: Doc -->\n\nBody.\n")
+
+	return Config{
+		BaseURL:  server.URL,
+		Username: "user",
+		Password: "token",
+		Files:    filepath.Join(dir, "*.md"),
+		Output:   io.Discard,
+	}
+}
+
+// TestMermaidOutputRejectsAFormatMarkCannotPublish covers the settings from the
+// side the flags do not reach. Config is a public API, so a library caller
+// arrives here without a command line to have been checked, and a format the
+// renderer does not know falls to its default branch: a PNG, published without
+// a word about the SVG that was asked for.
+func TestMermaidOutputRejectsAFormatMarkCannotPublish(t *testing.T) {
+	config := mermaidFixture(t)
+	config.MermaidOutput = "jpeg"
+
+	err := Run(config)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "MermaidOutput")
+}
+
+// TestMermaidBundleNeedsAnSVGToGoIn is the same for the pair of them: a bundle
+// is kept inside the SVG, so asking for one alongside a PNG asks for something
+// that cannot happen, and silently getting the PNG is the worst reading of it.
+func TestMermaidBundleNeedsAnSVGToGoIn(t *testing.T) {
+	config := mermaidFixture(t)
+	config.MermaidBundle = true
+
+	err := Run(config)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "MermaidBundle")
+}
+
+// TestMermaidDefaultsPublishAsBefore is the control, and the reason the empty
+// value is accepted rather than checked against the two names: a caller that
+// never heard of these fields leaves them zero, and has always got a PNG.
+func TestMermaidDefaultsPublishAsBefore(t *testing.T) {
+	require.NoError(t, Run(mermaidFixture(t)))
+}

--- a/mermaid/mermaid.go
+++ b/mermaid/mermaid.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -87,26 +89,27 @@ func discardEngine(engine *mermaid.RenderEngine) {
 	engine.Cancel()
 }
 
-// renderPNG renders one diagram, deciding from mermaid.go's sentinel errors
-// whether the engine survived the failure and whether another attempt is worth
-// making.
-func renderPNG(title, diagram string, scale float64) ([]byte, *mermaid.BoxModel, error) {
+// render runs one diagram through the shared engine, deciding from mermaid.go's
+// sentinel errors whether the engine survived the failure and whether another
+// attempt is worth making. What to render with it is left to the caller, since
+// a PNG and an SVG differ in nothing else.
+func render(title string, once func(ctx context.Context, engine *mermaid.RenderEngine) error) error {
 	for attempt := 1; ; attempt++ {
 		engine, err := getMermaidEngine()
 		if err != nil {
-			return nil, nil, err
+			return err
 		}
 
 		// The context bounds the wait for a turn on the engine's page as well as
 		// the render, which the engine's own timeout does not: that clock only
 		// starts once the render begins.
 		ctx, cancel := context.WithTimeout(context.Background(), renderTimeout)
-		pngBytes, boxModel, err := engine.RenderAsScaledPngContext(ctx, diagram, scale)
+		err = once(ctx, engine)
 		cancel()
 
 		switch {
 		case err == nil:
-			return pngBytes, boxModel, nil
+			return nil
 
 		case errors.Is(err, mermaid.ErrTargetCrashed), errors.Is(err, mermaid.ErrEngineClosed):
 			// Every later render on this engine fails the same way, so it is
@@ -117,30 +120,66 @@ func renderPNG(title, diagram string, scale float64) ([]byte, *mermaid.BoxModel,
 				log.Warn().Err(err).Msgf("Mermaid render engine died on %q, retrying with a new browser", title)
 				continue
 			}
-			return nil, nil, err
+			return err
 
 		case errors.Is(err, mermaid.ErrRenderException):
 			// The diagram is what failed, so the engine is still good and a
 			// retry would fail identically. mermaid.go keeps chrome's
 			// *runtime.ExceptionDetails in the chain, so the message already
 			// names the mermaid parse error.
-			return nil, nil, fmt.Errorf("invalid mermaid diagram: %w", err)
+			return fmt.Errorf("invalid mermaid diagram: %w", err)
 
 		case errors.Is(err, context.DeadlineExceeded):
 			// Cancelling a render only aborts its in-flight commands, so the
 			// engine stays usable and is kept for the next diagram. Retrying is
 			// not worth another renderTimeout on a diagram that has already
 			// shown it does not settle.
-			return nil, nil, fmt.Errorf("mermaid rendering timed out after %v: %w", renderTimeout, err)
+			return fmt.Errorf("mermaid rendering timed out after %v: %w", renderTimeout, err)
 
 		default:
 			// An unclassified failure says nothing about whether the browser
 			// survived it, so it is discarded: starting the next diagram over is
 			// cheap next to producing a page with a diagram missing from it.
 			discardEngine(engine)
-			return nil, nil, err
+			return err
 		}
 	}
+}
+
+func renderPNG(title, diagram string, scale float64) ([]byte, *mermaid.BoxModel, error) {
+	var (
+		pngBytes []byte
+		boxModel *mermaid.BoxModel
+	)
+
+	err := render(title, func(ctx context.Context, engine *mermaid.RenderEngine) error {
+		var err error
+		pngBytes, boxModel, err = engine.RenderAsScaledPngContext(ctx, diagram, scale)
+
+		return err
+	})
+
+	return pngBytes, boxModel, err
+}
+
+// renderSVG renders one diagram as the SVG the browser drew, rather than a
+// picture of it. bundle keeps the diagram's own source in the SVG's <desc>
+// element, which is what makes the drawing editable again from the attachment.
+func renderSVG(title, diagram string, bundle bool) (string, error) {
+	var svg string
+
+	err := render(title, func(ctx context.Context, engine *mermaid.RenderEngine) error {
+		var err error
+		if bundle {
+			svg, err = engine.RenderContext(ctx, diagram, mermaid.WithBundle())
+		} else {
+			svg, err = engine.RenderContext(ctx, diagram)
+		}
+
+		return err
+	})
+
+	return svg, err
 }
 
 func ProcessMermaidLocally(title string, mermaidDiagram []byte, scale float64) (attachment.Attachment, error) {
@@ -179,6 +218,150 @@ func ProcessMermaidLocally(title string, mermaidDiagram []byte, scale float64) (
 		Width:     strconv.FormatInt(boxModel.Width, 10),
 		Height:    strconv.FormatInt(boxModel.Height, 10),
 	}, nil
+}
+
+// ProcessMermaidSVG publishes a diagram as the SVG it was drawn as: one file at
+// every zoom, and text that stays text. MermaidScale has nothing to multiply
+// here and does not apply.
+func ProcessMermaidSVG(title string, mermaidDiagram []byte) (attachment.Attachment, error) {
+	return processMermaidSVG(title, mermaidDiagram, false)
+}
+
+// ProcessMermaidWithBundle does the same and keeps the diagram's source inside
+// the SVG, in its <desc> element, so that what was published can be opened and
+// edited again without the document it came from.
+func ProcessMermaidWithBundle(title string, mermaidDiagram []byte) (attachment.Attachment, error) {
+	return processMermaidSVG(title, mermaidDiagram, true)
+}
+
+func processMermaidSVG(title string, mermaidDiagram []byte, bundle bool) (attachment.Attachment, error) {
+	log.Debug().Msgf("Rendering SVG (bundle=%v): %q", bundle, title)
+
+	svg, err := renderSVG(title, string(mermaidDiagram), bundle)
+	if err != nil {
+		return attachment.Attachment{}, err
+	}
+
+	// The flag goes into the checksum for the same reason the scale does on the
+	// PNG side: the same diagram published with and without its source is two
+	// different attachments, and a checksum taken over the diagram alone would
+	// call the second one unchanged and leave the first in place.
+	checksumInput := make([]byte, 0, len(mermaidDiagram)+1)
+	checksumInput = append(checksumInput, mermaidDiagram...)
+	checksumInput = append(checksumInput, boolByte(bundle))
+
+	checkSum, err := attachment.GetChecksum(bytes.NewReader(checksumInput))
+	log.Debug().Msgf("Checksum: %q -> %s", title, checkSum)
+
+	if err != nil {
+		return attachment.Attachment{}, err
+	}
+
+	if title == "" {
+		title = checkSum
+	}
+
+	width, height := extractSVGDimensions(svg)
+
+	return attachment.Attachment{
+		ID:        "",
+		Name:      title,
+		Filename:  title + ".svg",
+		FileBytes: []byte(svg),
+		Checksum:  checkSum,
+		Replace:   title,
+		Width:     width,
+		Height:    height,
+	}, nil
+}
+
+func boolByte(b bool) byte {
+	if b {
+		return 1
+	}
+
+	return 0
+}
+
+// extractSVGDimensions reports the size of a rendered diagram in pixels, which
+// is what decides its alignment and display width on the page.
+//
+// The root element's width and height are preferred, and the viewBox is the
+// fallback for either of them -- mermaid draws a diagram wide enough to need
+// one as width="100%", which is not a number of pixels and would otherwise be
+// read as 100 of them, laying out a wide diagram as a narrow one.
+func extractSVGDimensions(svg string) (width, height string) {
+	var attrWidth, attrHeight, attrViewBox string
+
+	decoder := xml.NewDecoder(strings.NewReader(svg))
+
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			break
+		}
+
+		element, ok := token.(xml.StartElement)
+		if !ok || element.Name.Local != "svg" {
+			continue
+		}
+
+		for _, attr := range element.Attr {
+			switch attr.Name.Local {
+			case "width":
+				attrWidth = attr.Value
+			case "height":
+				attrHeight = attr.Value
+			case "viewBox":
+				attrViewBox = attr.Value
+			}
+		}
+
+		break
+	}
+
+	width = absoluteLength(attrWidth)
+	height = absoluteLength(attrHeight)
+
+	// "minX minY width height", separated by whitespace or commas.
+	if (width == "" || height == "") && attrViewBox != "" {
+		fields := strings.Fields(strings.ReplaceAll(attrViewBox, ",", " "))
+		if len(fields) == 4 {
+			if width == "" {
+				width = absoluteLength(fields[2])
+			}
+
+			if height == "" {
+				height = absoluteLength(fields[3])
+			}
+		}
+	}
+
+	return width, height
+}
+
+// absoluteLength reads a length that is a number of pixels -- bare, or written
+// with px -- and returns it rounded, or "" for anything else. A relative unit
+// (%, em, rem, vw, vh) is not a size on its own, so it is reported as unknown
+// rather than as the number in front of it.
+func absoluteLength(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+
+	if suffix := strings.TrimSuffix(value, "px"); suffix != value {
+		value = strings.TrimSpace(suffix)
+	} else if last := value[len(value)-1]; last < '0' || last > '9' {
+		return ""
+	}
+
+	pixels, err := strconv.ParseFloat(value, 64)
+	if err != nil || math.IsNaN(pixels) || math.IsInf(pixels, 0) {
+		return ""
+	}
+
+	return strconv.Itoa(int(math.Round(pixels)))
 }
 
 func Cleanup() {

--- a/mermaid/mermaid_test.go
+++ b/mermaid/mermaid_test.go
@@ -2,8 +2,10 @@ package mermaid
 
 import (
 	"context"
+	"encoding/xml"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -103,4 +105,197 @@ func TestRenderTimeoutKeepsEngine(t *testing.T) {
 	got, err := ProcessMermaidLocally("after-timeout", []byte("graph TD;\n A-->B;"), 1.0)
 	require.NoError(t, err)
 	assert.NotEmpty(t, got.FileBytes)
+}
+
+// TestProcessMermaidSVG covers the other thing a diagram can be published as:
+// the drawing itself rather than a picture of it.
+func TestProcessMermaidSVG(t *testing.T) {
+	got, err := ProcessMermaidSVG("svgtest", []byte("graph TD;\n A-->B;"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "svgtest.svg", got.Filename)
+	assert.Equal(t, "svgtest", got.Name)
+	assert.Equal(t, "svgtest", got.Replace)
+	assert.True(t, hasSVGRoot(string(got.FileBytes)), "the attachment should be an SVG document")
+
+	assertPixelSize(t, got.Width, got.Height)
+}
+
+// TestProcessMermaidWithBundle covers --mermaid-bundle: the same SVG, with the
+// diagram's own source kept in it, so that what was published can be opened and
+// edited again without the document it came from.
+func TestProcessMermaidWithBundle(t *testing.T) {
+	got, err := ProcessMermaidWithBundle("bundletest", []byte("graph TD;\n A-->B;"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "bundletest.svg", got.Filename)
+	assert.True(t, hasSVGRoot(string(got.FileBytes)), "the attachment should be an SVG document")
+
+	source, found := descContent(string(got.FileBytes))
+	require.True(t, found, "a bundled SVG carries its source in a <desc> element")
+	assert.Contains(t, source, "graph TD;")
+
+	assertPixelSize(t, got.Width, got.Height)
+}
+
+// TestSVGChecksumsDifferByBundle covers what decides whether a diagram already
+// on the page is uploaded again. The same diagram with and without its source
+// is two different attachments, so a checksum that could not tell them apart
+// would leave the first one in place forever.
+func TestSVGChecksumsDifferByBundle(t *testing.T) {
+	diagram := []byte("graph TD;\n A-->B;")
+
+	plain, err := ProcessMermaidSVG("chk", diagram)
+	require.NoError(t, err)
+
+	bundled, err := ProcessMermaidWithBundle("chk", diagram)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, plain.Checksum, bundled.Checksum)
+}
+
+// TestExtractSVGDimensions covers the sizes an SVG can state, and the one it
+// cannot: mermaid draws a diagram too wide for the page as width="100%", which
+// is not a number of pixels. Read as 100 of them, a wide diagram is laid out as
+// a narrow one, so anything that is not an absolute length falls back to the
+// viewBox.
+func TestExtractSVGDimensions(t *testing.T) {
+	tests := []struct {
+		name   string
+		svg    string
+		width  string
+		height string
+	}{
+		{
+			name:   "width and height attributes",
+			svg:    `<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200"></svg>`,
+			width:  "300",
+			height: "200",
+		},
+		{
+			name:   "px is a number of pixels like any other",
+			svg:    `<svg xmlns="http://www.w3.org/2000/svg" width="450px" height="300px"></svg>`,
+			width:  "450",
+			height: "300",
+		},
+		{
+			name:   "a fraction is rounded, since a size in pixels is whole",
+			svg:    `<svg xmlns="http://www.w3.org/2000/svg" width="85.4375" height="42.5"></svg>`,
+			width:  "85",
+			height: "43",
+		},
+		{
+			name:   "no width or height at all falls back to the viewBox",
+			svg:    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480"></svg>`,
+			width:  "640",
+			height: "480",
+		},
+		{
+			name:   "and so does whichever of the two is missing",
+			svg:    `<svg xmlns="http://www.w3.org/2000/svg" width="320" viewBox="0 0 640 480"></svg>`,
+			width:  "320",
+			height: "480",
+		},
+		{
+			name:   "a percentage is not a size",
+			svg:    `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 800 600"></svg>`,
+			width:  "800",
+			height: "600",
+		},
+		{
+			name:   "nor is a length in em",
+			svg:    `<svg xmlns="http://www.w3.org/2000/svg" width="20em" height="15em" viewBox="0 0 320 240"></svg>`,
+			width:  "320",
+			height: "240",
+		},
+		{
+			name:   "the viewBox may separate its numbers with commas",
+			svg:    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0,0,640,480"></svg>`,
+			width:  "640",
+			height: "480",
+		},
+		{
+			name:   "nothing to go on is reported as nothing",
+			svg:    `<svg xmlns="http://www.w3.org/2000/svg"></svg>`,
+			width:  "",
+			height: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			width, height := extractSVGDimensions(test.svg)
+
+			assert.Equal(t, test.width, width)
+			assert.Equal(t, test.height, height)
+		})
+	}
+}
+
+// assertPixelSize asserts that a rendered diagram reported a size the page can
+// lay out: whole pixels, and more than none of them.
+func assertPixelSize(t *testing.T, width, height string) {
+	t.Helper()
+
+	pixels, err := strconv.Atoi(width)
+	require.NoError(t, err, "width should be a whole number of pixels")
+	assert.Positive(t, pixels)
+
+	pixels, err = strconv.Atoi(height)
+	require.NoError(t, err, "height should be a whole number of pixels")
+	assert.Positive(t, pixels)
+}
+
+// hasSVGRoot reports whether the document's root element is an <svg>, looking
+// past a processing instruction or a comment before it.
+func hasSVGRoot(document string) bool {
+	decoder := xml.NewDecoder(strings.NewReader(document))
+
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			return false
+		}
+
+		if element, ok := token.(xml.StartElement); ok {
+			return element.Name.Local == "svg"
+		}
+	}
+}
+
+// descContent returns the text of the first <desc> element, whatever namespace
+// or attributes it carries.
+func descContent(document string) (string, bool) {
+	decoder := xml.NewDecoder(strings.NewReader(document))
+
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			return "", false
+		}
+
+		element, ok := token.(xml.StartElement)
+		if !ok || element.Name.Local != "desc" {
+			continue
+		}
+
+		var text strings.Builder
+
+		for {
+			inner, err := decoder.Token()
+			if err != nil {
+				break
+			}
+
+			if data, ok := inner.(xml.CharData); ok {
+				text.Write(data)
+			}
+
+			if end, ok := inner.(xml.EndElement); ok && end.Name.Local == "desc" {
+				break
+			}
+		}
+
+		return text.String(), true
+	}
 }

--- a/renderer/fencedcodeblock.go
+++ b/renderer/fencedcodeblock.go
@@ -269,16 +269,31 @@ func (r *ConfluenceFencedCodeBlockRenderer) renderFencedCodeBlock(writer util.Bu
 		}
 
 	} else if lang == "mermaid" && slices.Contains(r.MarkConfig.Features, "mermaid") {
-		attachment, err := mermaid.ProcessMermaidLocally(title, lval, r.MarkConfig.MermaidScale)
+		var (
+			att attachment.Attachment
+			err error
+		)
+
+		switch {
+		case r.MarkConfig.MermaidOutput == "svg" && r.MarkConfig.MermaidBundle:
+			att, err = mermaid.ProcessMermaidWithBundle(title, lval)
+
+		case r.MarkConfig.MermaidOutput == "svg":
+			att, err = mermaid.ProcessMermaidSVG(title, lval)
+
+		default:
+			att, err = mermaid.ProcessMermaidLocally(title, lval, r.MarkConfig.MermaidScale)
+		}
+
 		if err != nil {
 			line, col := GetLineCol(source, node.Pos())
 			return ast.WalkStop, fmt.Errorf("line %d, col %d: mermaid rendering failed: %w", line, col, err)
 		}
-		r.Attachments.Attach(attachment)
+		r.Attachments.Attach(att)
 
-		effectiveAlign := calculateAlign(r.MarkConfig.ImageAlign, attachment.Width)
-		effectiveLayout := calculateLayout(effectiveAlign, attachment.Width)
-		displayWidth := calculateDisplayWidth(attachment.Width, effectiveLayout)
+		effectiveAlign := calculateAlign(r.MarkConfig.ImageAlign, att.Width)
+		effectiveLayout := calculateLayout(effectiveAlign, att.Width)
+		displayWidth := calculateDisplayWidth(att.Width, effectiveLayout)
 
 		err = r.Stdlib.Templates.ExecuteTemplate(
 			writer,
@@ -297,8 +312,8 @@ func (r *ConfluenceFencedCodeBlockRenderer) renderFencedCodeBlock(writer util.Bu
 			}{
 				effectiveAlign,
 				effectiveLayout,
-				attachment.Width,
-				attachment.Height,
+				att.Width,
+				att.Height,
 				displayWidth,
 				"",
 				// The display title, not the attachment name: when the author gave
@@ -308,7 +323,7 @@ func (r *ConfluenceFencedCodeBlockRenderer) renderFencedCodeBlock(writer util.Bu
 				// diagram. The attachment keeps its checksum-derived name.
 				title,
 				"",
-				attachment.Filename,
+				att.Filename,
 				"",
 			},
 		)

--- a/types/types.go
+++ b/types/types.go
@@ -2,7 +2,13 @@ package types
 
 type MarkConfig struct {
 	MermaidScale float64
-	D2Scale      float64
+	// MermaidOutput is the image a diagram is published as, "png" or "svg".
+	// MermaidScale multiplies the pixels of a PNG one, and does not apply to an
+	// SVG. MermaidBundle keeps the diagram's source inside the SVG it is
+	// published as, and applies to nothing else.
+	MermaidOutput string
+	MermaidBundle bool
+	D2Scale       float64
 	// MathFormat is the image a formula is published as, "svg" or "png".
 	// MathScale multiplies the pixels of a PNG one, and is ignored for SVG.
 	MathFormat    string

--- a/util/cli.go
+++ b/util/cli.go
@@ -129,6 +129,8 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 		DropH1:          cmd.Bool("drop-h1"),
 		StripLinebreaks: cmd.Bool("strip-linebreaks"),
 		MermaidScale:    cmd.Float("mermaid-scale"),
+		MermaidOutput:   cmd.String("mermaid-output"),
+		MermaidBundle:   cmd.Bool("mermaid-bundle"),
 		D2Scale:         cmd.Float("d2-scale"),
 		MathFormat:      cmd.String("math-format"),
 		MathScale:       cmd.Float("math-scale"),

--- a/util/cli_test.go
+++ b/util/cli_test.go
@@ -15,6 +15,9 @@ func runWithArgs(args []string) error {
 			&cli.BoolFlag{Name: "title-from-h1"},
 			&cli.BoolFlag{Name: "title-from-filename"},
 			&cli.StringFlag{Name: "content-appearance"},
+			&cli.StringFlag{Name: "mermaid-output", Value: "png"},
+			&cli.BoolFlag{Name: "mermaid-bundle"},
+			&cli.FloatFlag{Name: "mermaid-scale", Value: 1.0},
 		},
 		Before: CheckFlags,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
@@ -118,4 +121,47 @@ func Test_setLogLevel(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMermaidOutputFlagValidation covers the two settings that only mean
+// anything in one of the two output formats, and the format itself.
+func TestMermaidOutputFlagValidation(t *testing.T) {
+	t.Run("png is accepted", func(t *testing.T) {
+		assert.NoError(t, runWithArgs([]string{"cmd", "--mermaid-output", "png"}))
+	})
+
+	t.Run("svg is accepted", func(t *testing.T) {
+		assert.NoError(t, runWithArgs([]string{"cmd", "--mermaid-output", "svg"}))
+	})
+
+	t.Run("anything else is rejected", func(t *testing.T) {
+		assert.Error(t, runWithArgs([]string{"cmd", "--mermaid-output", "jpeg"}))
+	})
+
+	// A flag carrying a default is never empty unless somebody emptied it, so
+	// an empty value is somebody's doing and not the absence of one. Left to
+	// fall through it would publish a PNG without a word, which is the one
+	// thing a value set on purpose should not do.
+	t.Run("emptied on purpose is rejected", func(t *testing.T) {
+		assert.Error(t, runWithArgs([]string{"cmd", "--mermaid-output", ""}))
+	})
+
+	t.Run("a scale does not apply to an svg", func(t *testing.T) {
+		assert.Error(t, runWithArgs([]string{"cmd", "--mermaid-output", "svg", "--mermaid-scale", "2"}))
+	})
+
+	t.Run("a bundle needs an svg to go in", func(t *testing.T) {
+		assert.Error(t, runWithArgs([]string{"cmd", "--mermaid-output", "png", "--mermaid-bundle"}))
+	})
+
+	// Switching a bundle off is not asking for one. Read as "the flag was
+	// mentioned" rather than as its value, mermaid-bundle = false left beside
+	// the default PNG output failed a run that had asked for nothing.
+	t.Run("but switching one off asks for nothing", func(t *testing.T) {
+		assert.NoError(t, runWithArgs([]string{"cmd", "--mermaid-output", "png", "--mermaid-bundle=false"}))
+	})
+
+	t.Run("and a bundle in an svg is the point", func(t *testing.T) {
+		assert.NoError(t, runWithArgs([]string{"cmd", "--mermaid-output", "svg", "--mermaid-bundle"}))
+	})
 }

--- a/util/cli_test.go
+++ b/util/cli_test.go
@@ -146,6 +146,14 @@ func TestMermaidOutputFlagValidation(t *testing.T) {
 		assert.Error(t, runWithArgs([]string{"cmd", "--mermaid-output", ""}))
 	})
 
+	// What is checked has to be what is used. Trimmed for the check and passed
+	// on whole, " svg " was accepted here and then compared literally by the
+	// renderer, which knows no such format and publishes a PNG -- taking a
+	// bundle asked for alongside it down with it.
+	t.Run("a padded value is not the value it is padding", func(t *testing.T) {
+		assert.Error(t, runWithArgs([]string{"cmd", "--mermaid-output", " svg "}))
+	})
+
 	t.Run("a scale does not apply to an svg", func(t *testing.T) {
 		assert.Error(t, runWithArgs([]string{"cmd", "--mermaid-output", "svg", "--mermaid-scale", "2"}))
 	})

--- a/util/flags.go
+++ b/util/flags.go
@@ -441,8 +441,13 @@ func CheckFlags(context context.Context, command *cli.Command) (context.Context,
 		}
 	}
 
+	// Asked of IsSet as well as of the value, because a flag carrying a default
+	// is never empty unless somebody emptied it: mermaid-output = "" in the
+	// configuration file, or MARK_MERMAID_OUTPUT exported with nothing in it,
+	// would otherwise skip the check below and quietly publish a PNG. A command
+	// that does not carry the flag at all has neither, and is left alone.
 	mermaidOutput := strings.TrimSpace(command.String("mermaid-output"))
-	if mermaidOutput != "" {
+	if mermaidOutput != "" || command.IsSet("mermaid-output") {
 		switch mermaidOutput {
 		case "png", "svg":
 			// ok
@@ -455,16 +460,21 @@ func CheckFlags(context context.Context, command *cli.Command) (context.Context,
 	}
 
 	// A scale that does nothing and a bundle that goes nowhere are both worth
-	// saying out loud rather than dropping: each was set on purpose, and each
-	// silently does not happen. Asked of IsSet rather than of the value, so
-	// that the defaults -- which every run carries -- contradict nothing.
+	// saying out loud rather than dropping: each was asked for on purpose, and
+	// each silently does not happen.
+	//
+	// The scale is asked of IsSet, since 1.0 is a scale like any other and
+	// there is nothing else to tell a default from a value somebody chose. The
+	// bundle is asked of its value instead, because false is exactly what a
+	// bundle nobody asked for looks like -- so mermaid-bundle = false, or
+	// --mermaid-bundle=false, contradicts a PNG in no way at all.
 	if mermaidOutput == "svg" && command.IsSet("mermaid-scale") {
 		return context, errors.New(
 			"--mermaid-scale does not apply to --mermaid-output=svg: an SVG is the same drawing at every size",
 		)
 	}
 
-	if mermaidOutput == "png" && command.IsSet("mermaid-bundle") {
+	if mermaidOutput == "png" && command.Bool("mermaid-bundle") {
 		return context, errors.New(
 			"--mermaid-bundle needs --mermaid-output=svg: there is nowhere in a PNG to keep the diagram's source",
 		)

--- a/util/flags.go
+++ b/util/flags.go
@@ -218,8 +218,20 @@ var Flags = []cli.Flag{
 	&cli.FloatFlag{
 		Name:    "mermaid-scale",
 		Value:   1.0,
-		Usage:   "defines the scaling factor for mermaid renderings.",
+		Usage:   "defines the scaling factor for mermaid PNG renderings; not accepted when mermaid-output is svg.",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MERMAID_SCALE"), altsrctoml.TOML("mermaid-scale", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:    "mermaid-output",
+		Value:   "png",
+		Usage:   "image a mermaid diagram is published as: png (rasterised, and scaled by --mermaid-scale) or svg (vector and sharp at any zoom, where the instance displays an SVG attachment).",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MERMAID_OUTPUT"), altsrctoml.TOML("mermaid-output", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "mermaid-bundle",
+		Value:   false,
+		Usage:   "keep the diagram's own source inside the SVG published for it, in its <desc> element, so the drawing can be edited again from the attachment. Needs --mermaid-output=svg.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MERMAID_BUNDLE"), altsrctoml.TOML("mermaid-bundle", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.StringFlag{
 		Name:    "math-format",
@@ -427,6 +439,35 @@ func CheckFlags(context context.Context, command *cli.Command) (context.Context,
 				imageAlign,
 			)
 		}
+	}
+
+	mermaidOutput := strings.TrimSpace(command.String("mermaid-output"))
+	if mermaidOutput != "" {
+		switch mermaidOutput {
+		case "png", "svg":
+			// ok
+		default:
+			return context, fmt.Errorf(
+				"invalid value for --mermaid-output: %q (expected: png or svg)",
+				mermaidOutput,
+			)
+		}
+	}
+
+	// A scale that does nothing and a bundle that goes nowhere are both worth
+	// saying out loud rather than dropping: each was set on purpose, and each
+	// silently does not happen. Asked of IsSet rather than of the value, so
+	// that the defaults -- which every run carries -- contradict nothing.
+	if mermaidOutput == "svg" && command.IsSet("mermaid-scale") {
+		return context, errors.New(
+			"--mermaid-scale does not apply to --mermaid-output=svg: an SVG is the same drawing at every size",
+		)
+	}
+
+	if mermaidOutput == "png" && command.IsSet("mermaid-bundle") {
+		return context, errors.New(
+			"--mermaid-bundle needs --mermaid-output=svg: there is nowhere in a PNG to keep the diagram's source",
+		)
 	}
 
 	mathFormat := strings.TrimSpace(command.String("math-format"))

--- a/util/flags.go
+++ b/util/flags.go
@@ -441,12 +441,17 @@ func CheckFlags(context context.Context, command *cli.Command) (context.Context,
 		}
 	}
 
+	// Checked as written, without trimming, because what is checked has to be
+	// what is used: the value goes into the configuration whole, and the
+	// renderer compares it literally, so a trimmed " svg " would pass here and
+	// publish a PNG -- taking a bundle asked for alongside it down with it.
+	//
 	// Asked of IsSet as well as of the value, because a flag carrying a default
 	// is never empty unless somebody emptied it: mermaid-output = "" in the
 	// configuration file, or MARK_MERMAID_OUTPUT exported with nothing in it,
 	// would otherwise skip the check below and quietly publish a PNG. A command
 	// that does not carry the flag at all has neither, and is left alone.
-	mermaidOutput := strings.TrimSpace(command.String("mermaid-output"))
+	mermaidOutput := command.String("mermaid-output")
 	if mermaidOutput != "" || command.IsSet("mermaid-output") {
 		switch mermaidOutput {
 		case "png", "svg":


### PR DESCRIPTION
Adds SVG rendering for Mermaid diagrams, with an optional bundled-source variant.

## New flags

- `--mermaid-output` (env: `MARK_MERMAID_OUTPUT`, toml: `mermaid-output`): the image a diagram is published as. `png` (default) is rasterised and scaled by `--mermaid-scale`; `svg` publishes the drawing itself — one file that is sharp at any zoom and whose text stays text, on an instance that displays an SVG attachment.
- `--mermaid-bundle` (env: `MARK_MERMAID_BUNDLE`, toml: `mermaid-bundle`): keeps the diagram’s own source inside that SVG, in its `<desc>` element (mermaid.go’s `WithBundle()`), so what was published can be opened and edited again from the attachment without the document it came from.

## Validation

Checked in `CheckFlags`, beside the checks that already reject an unknown `--math-format`:

- `--mermaid-output` must be `png` or `svg` — including when it is set to an empty value, which is somebody emptying a flag that has a default rather than leaving it alone.
- `--mermaid-scale` with `--mermaid-output=svg` → error. A scale multiplies pixels, of which an SVG has no fixed number.
- `--mermaid-bundle` with `--mermaid-output=png` → error. A PNG has nowhere to keep the source. Switching the bundle *off* (`--mermaid-bundle=false`, or `mermaid-bundle = false` in the file) asks for nothing and is not a contradiction.

## Implementation

- `ProcessMermaidSVG()` and `ProcessMermaidWithBundle()` in `mermaid/mermaid.go`, over a shared `processMermaidSVG` helper.
- Rendering goes through the engine the PNG path already shares — one browser for the whole run, discarded and relaunched only for the failure a retry can fix — so the retry loop now lives in a `render()` helper that both render calls hand a closure to, rather than being written twice.
- SVG dimensions come from the root element’s `width`/`height` (bare numbers or `px`, rounded to whole pixels so `strconv.Atoi` in the layout logic can read them), with the `viewBox` as the fallback for either: a diagram too wide for the page is drawn as `width="100%"`, which read as 100 pixels would lay a wide diagram out as a narrow one.
- The bundle flag goes into the checksum, for the reason the scale does on the PNG side: the same diagram with and without its source is two different attachments, and a checksum taken over the diagram alone would call the second one unchanged.
- `MermaidOutput`/`MermaidBundle` added to `types.MarkConfig` and `mark.Config`, wired through `util/flags.go`, `util/cli.go` and both construction sites in `mark.go`; `renderer/fencedcodeblock.go` dispatches on them.
- Tests for both SVG paths, the dimension cases (px, fractions, `%`, `em`, comma-separated viewBox, nothing at all), checksum non-collision, and the flag validation.

In the spirit of https://github.com/kovetskiy/mark/pull/719