### PR TITLE
fix: prevent panic on files without trailing newline

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -144,6 +144,13 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 		return nil, nil, err
 	}
 
+	// Cap offset to data length. The scanner loop adds +1 per line to
+	// account for the stripped newline, but the final line of a file may
+	// not end with a newline, making offset exceed len(data).
+	if offset > len(data) {
+		offset = len(data)
+	}
+
 	if titleFromH1 || titleFromFilename || spaceFromCli != "" {
 		if meta == nil {
 			meta = &Meta{}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -89,3 +89,33 @@ func TestExtractMetaContentAppearance(t *testing.T) {
 		assert.Equal(t, FullWidthContentAppearance, meta.ContentAppearance)
 	})
 }
+
+func TestExtractMetaNoTrailingNewline(t *testing.T) {
+	t.Run("header-only file without trailing newline does not panic", func(t *testing.T) {
+		data := []byte("# Blogs")
+
+		assert.NotPanics(t, func() {
+			_, _, _ = ExtractMeta(data, "", true, false, "", nil, false, "")
+		})
+	})
+
+	t.Run("body without trailing newline", func(t *testing.T) {
+		data := []byte("some content")
+
+		meta, body, err := ExtractMeta(data, "", false, false, "", nil, false, "")
+		assert.NoError(t, err)
+		assert.Nil(t, meta)
+		assert.Equal(t, []byte("some content"), body)
+	})
+
+	t.Run("metadata headers without trailing newline on last header", func(t *testing.T) {
+		data := []byte("<!-- Space: DOC -->\n<!-- Title: Example -->")
+
+		meta, body, err := ExtractMeta(data, "", false, false, "", nil, false, "")
+		assert.NoError(t, err)
+		assert.NotNil(t, meta)
+		assert.Equal(t, "Example", meta.Title)
+		assert.Equal(t, "DOC", meta.Space)
+		assert.Empty(t, body)
+	})
+}


### PR DESCRIPTION
Fixes #686

## Problem

`ExtractMeta` panics with `slice bounds out of range [8:7]` when processing a file that does not end with a trailing newline (e.g. a file containing exactly `# Blogs` with no final `\n`).

The scanner loop at `metadata/metadata.go:66` increments `offset` by `len(line) + 1` for each line, where `+1` accounts for the `\n` stripped by `bufio.Scanner`. When the last line has no newline, this causes `offset` to exceed `len(data)`, and the subsequent `data[offset:]` slice panics.

## Reproduction

```
# File with no trailing newline
printf '# Blogs' > test.md
mark --drop-h1 --title-from-h1 -f test.md
# panic: runtime error: slice bounds out of range [8:7]
```

## Fix

Cap `offset` to `len(data)` after the scanner loop completes. This is a one-line guard that prevents the out-of-range slice without changing any other behavior.

## Validation

- Added regression tests covering three no-trailing-newline scenarios
- All existing tests pass (`go test ./metadata/ ./util/`)
- `go vet ./...` clean