### PR TITLE
feat: add "default" as valid Content-Appearance value

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ Also, optional following headers are supported:
 * blogpost: [Blog post](https://confluence.atlassian.com/doc/blog-posts-834222533.html) in `Space`.  Cannot have `Parent`(s)
 
 ```markdown
-<!-- Content-Appearance: (full-width|fixed) -->
+<!-- Content-Appearance: (full-width|fixed|default) -->
 ```
 
 * (default) full-width: content will fill the full page width
 * fixed: content will be rendered in a fixed narrow view
+* default: sets the Confluence property value to `"default"`, which is the narrow layout as set by the Confluence UI. Note: `fixed` maps to a different Confluence property value and can cause misaligned page title and body content — use `default` instead for the narrow layout.
 
 ```markdown
 <!-- Sidebar: <h2>Test</h2> -->
@@ -876,7 +877,7 @@ GLOBAL OPTIONS:
    --space string                           use specified space key. If the space key is not specified, it must be set in the page metadata. [$MARK_SPACE]
    --parents string                         A list containing the parents of the document separated by parents-delimiter (default: '/'). These will be prepended to the ones defined in the document itself. [$MARK_PARENTS]
    --parents-delimiter string               The delimiter used for the parents list (default: "/") [$MARK_PARENTS_DELIMITER]
-   --content-appearance string              default content appearance for pages without a Content-Appearance header. Possible values: full-width, fixed. [$MARK_CONTENT_APPEARANCE]
+   --content-appearance string              default content appearance for pages without a Content-Appearance header. Possible values: full-width, fixed, default. [$MARK_CONTENT_APPEARANCE]
    --mermaid-scale float                    defines the scaling factor for mermaid renderings. (default: 1) [$MARK_MERMAID_SCALE]
    --include-path string                    Path for shared includes, used as a fallback if the include doesn't exist in the current directory. [$MARK_INCLUDE_PATH]
    --changes-only                           Avoids re-uploading pages that haven't changed since the last run. [$MARK_CHANGES_ONLY]

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -46,6 +46,7 @@ type Meta struct {
 const (
 	FullWidthContentAppearance = "full-width"
 	FixedContentAppearance     = "fixed"
+	DefaultContentAppearance   = "default"
 )
 
 var (
@@ -122,9 +123,12 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 			continue
 
 		case ContentAppearance:
-			if strings.TrimSpace(value) == FixedContentAppearance {
+			switch strings.TrimSpace(value) {
+			case FixedContentAppearance:
 				meta.ContentAppearance = FixedContentAppearance
-			} else {
+			case DefaultContentAppearance:
+				meta.ContentAppearance = DefaultContentAppearance
+			default:
 				meta.ContentAppearance = FullWidthContentAppearance
 			}
 
@@ -166,9 +170,12 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 
 	// Use the global content appearance flag if the header is not set in the document
 	if meta != nil && defaultContentAppearance != "" && meta.ContentAppearance == "" {
-		if strings.TrimSpace(defaultContentAppearance) == FixedContentAppearance {
+		switch strings.TrimSpace(defaultContentAppearance) {
+		case FixedContentAppearance:
 			meta.ContentAppearance = FixedContentAppearance
-		} else {
+		case DefaultContentAppearance:
+			meta.ContentAppearance = DefaultContentAppearance
+		default:
 			meta.ContentAppearance = FullWidthContentAppearance
 		}
 	} else if meta != nil && meta.ContentAppearance == "" {

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -88,4 +88,22 @@ func TestExtractMetaContentAppearance(t *testing.T) {
 		assert.NotNil(t, meta)
 		assert.Equal(t, FullWidthContentAppearance, meta.ContentAppearance)
 	})
+
+	t.Run("default appearance via cli flag", func(t *testing.T) {
+		data := []byte("<!-- Space: DOC -->\n<!-- Title: Example -->\n\nbody\n")
+
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, DefaultContentAppearance)
+		assert.NoError(t, err)
+		assert.NotNil(t, meta)
+		assert.Equal(t, DefaultContentAppearance, meta.ContentAppearance)
+	})
+
+	t.Run("default appearance via header", func(t *testing.T) {
+		data := []byte("<!-- Space: DOC -->\n<!-- Title: Example -->\n<!-- Content-Appearance: default -->\n\nbody\n")
+
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, "")
+		assert.NoError(t, err)
+		assert.NotNil(t, meta)
+		assert.Equal(t, DefaultContentAppearance, meta.ContentAppearance)
+	})
 }

--- a/util/flags.go
+++ b/util/flags.go
@@ -169,7 +169,7 @@ var Flags = []cli.Flag{
 	&cli.StringFlag{
 		Name:  "content-appearance",
 		Value: "",
-		Usage: "default content appearance for pages without a Content-Appearance header. Possible values: full-width, fixed.",
+		Usage: "default content appearance for pages without a Content-Appearance header. Possible values: full-width, fixed, default.",
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar("MARK_CONTENT_APPEARANCE"),
 			altsrctoml.TOML("content-appearance", altsrc.NewStringPtrSourcer(&filename)),
@@ -236,11 +236,11 @@ func CheckFlags(context context.Context, command *cli.Command) (context.Context,
 	contentAppearance := strings.TrimSpace(command.String("content-appearance"))
 	if contentAppearance != "" {
 		switch contentAppearance {
-		case "full-width", "fixed":
+		case "full-width", "fixed", "default":
 			// ok
 		default:
 			return context, fmt.Errorf(
-				"invalid value for --content-appearance: %q (expected: full-width or fixed)",
+				"invalid value for --content-appearance: %q (expected: full-width, fixed, or default)",
 				contentAppearance,
 			)
 		}


### PR DESCRIPTION
Problem:
When using `<!-- Content-Appearance: fixed -->` the generated Confluence page rendered its body nicely, but the title and page metadata was misaligned with the content.

The page title was left-aligned while the body content was centered, making them visually misaligned.

 Fix:
  The Confluence API uses "default" as the property value for the narrow/fixed-width page layout (what the UI labels "narrow"). Previously, mark only accepted full-width and fixed — but fixed maps to a different Confluence property value
  and causes the misalignment. "default" is the correct value to match what the Confluence UI sets.

  - Adds `"default"` as a valid value for the `Content-Appearance` header and `--content-appearance` CLI flag
  - Passes the value through as-is to the `content-appearance-published` Confluence API property
  - Updates README and adds tests for both the header and CLI flag code paths

  Extends #258 which originally introduced full-width and fixed.