### PR TITLE
fix: preserve source-based checksum for mermaid/d2 attachments

### DIFF
--- a/attachment/attachment.go
+++ b/attachment/attachment.go
@@ -49,6 +49,13 @@ func ResolveAttachments(
 	attachments []Attachment,
 ) ([]Attachment, error) {
 	for i := range attachments {
+		// Skip checksum computation if already set (e.g. by mermaid/d2 renderers
+		// which use the source content as the stable checksum rather than the
+		// rendered PNG bytes, which may be non-deterministic across environments).
+		if attachments[i].Checksum != "" {
+			continue
+		}
+
 		checksum, err := GetChecksum(bytes.NewReader(attachments[i].FileBytes))
 		if err != nil {
 			return nil, fmt.Errorf("unable to get checksum for attachment %q: %w", attachments[i].Name, err)


### PR DESCRIPTION
# fix: preserve source-based checksum for mermaid/d2 attachments

## Problem

Mermaid (and D2) diagrams were being re-uploaded to Confluence on every sync, even when the diagram source had not changed.

`mermaid.go` and `d2.go` intentionally compute a stable checksum from the **diagram source + scale** — not from the rendered PNG bytes — because headless Chrome rendering can produce non-deterministic PNG output. However, `ResolveAttachments` in `attachment.go` was unconditionally overwriting the pre-set `Checksum` field with `SHA256(PNG bytes)`. This caused the checksum to differ on every run, making mark believe the attachment had changed and triggering a re-upload every time.

## Fix

Skip the checksum computation in `ResolveAttachments` when `Checksum` is already populated. This preserves the source-based checksum set by the mermaid/d2 renderers, so the change detection logic correctly identifies unmodified diagrams as unchanged.

## Changed files

- `attachment/attachment.go` — skip `GetChecksum(FileBytes)` in `ResolveAttachments` when `Checksum != ""`
