### PR TITLE
feat(renderer): add `inline-link-card` feature for Confluence smart-cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,6 +802,25 @@ When enabled, this renders note, warning, tip, info admonitions as Confluence al
 !!! note
 ```
 
+### Inline Link Cards
+
+Optionally you can render bare URLs as Confluence Cloud **inline smart cards** via `--features="inline-link-card"`.
+
+When enabled, auto-detected URLs in markdown (e.g. `<https://example.com>` or
+a bare URL on its own line) are rendered with the `data-card-appearance="inline"`
+attribute, which Confluence Cloud uses as a hint to display the link as an
+inline card preview (page title, Jira issue summary, GitHub repo card, etc.)
+instead of a plain blue hyperlink.
+
+```markdown
+See <https://your-instance.atlassian.net/wiki/spaces/DOCS/pages/12345/Page+Title>
+for context.
+```
+
+Only **auto-detected URLs** (bare URLs / `<…>` autolinks) are affected.
+Markdown-explicit links (`[label](https://…)`) keep their author-chosen
+display text and render as regular hyperlinks, unchanged.
+
 ## Installation
 
 ### Homebrew

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -85,6 +85,12 @@ func (c *ConfluenceLegacyExtension) Extend(m goldmark.Markdown) {
 		))
 	}
 
+	if slices.Contains(c.MarkConfig.Features, "inline-link-card") {
+		m.Renderer().AddOptions(renderer.WithNodeRenderers(
+			util.Prioritized(crenderer.NewConfluenceAutoLinkRenderer(), 100),
+		))
+	}
+
 	m.Parser().AddOptions(parser.WithInlineParsers(
 		// Must be registered with a higher priority than goldmark's linkParser to make sure goldmark doesn't parse
 		// the <ac:*/> tags.
@@ -230,6 +236,16 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 
 		m.Renderer().AddOptions(renderer.WithNodeRenderers(
 			util.Prioritized(crenderer.NewConfluenceMentionRenderer(c.Stdlib), 100),
+		))
+	}
+
+	// Add inline-link-card support if requested · renders auto-detected bare
+	// URLs with the `data-card-appearance="inline"` hint, prompting Confluence
+	// Cloud to display them as inline smart cards (page mentions, Jira issues,
+	// GitHub references, etc.) instead of plain hyperlinks.
+	if slices.Contains(c.MarkConfig.Features, "inline-link-card") {
+		m.Renderer().AddOptions(renderer.WithNodeRenderers(
+			util.Prioritized(crenderer.NewConfluenceAutoLinkRenderer(), 100),
 		))
 	}
 

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -159,6 +159,36 @@ func TestCompileMarkdownStripNewlines(t *testing.T) {
 	}
 }
 
+func TestCompileMarkdownInlineLinkCard(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	dir := path.Join(path.Dir(filename), "..")
+	err := os.Chdir(dir)
+	if err != nil {
+		panic(err)
+	}
+
+	test := assert.New(t)
+
+	lib, err := stdlib.New(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	const fixture = "testdata/inline-link-card.md"
+	markdown, htmlname, html := loadData(t, fixture, "-inlinecard")
+
+	cfg := types.MarkConfig{
+		MermaidScale:  1.0,
+		D2Scale:       1.0,
+		DropFirstH1:   false,
+		StripNewlines: false,
+		Features:      []string{"mkdocsadmonitions", "mention", "inline-link-card"},
+	}
+
+	actual, _, _ := mark.CompileMarkdown(markdown, lib, fixture, cfg)
+	test.EqualValues(strings.TrimSuffix(string(html), "\n"), strings.TrimSuffix(actual, "\n"), fixture+" vs "+htmlname)
+}
+
 func TestContinueOnError(t *testing.T) {
 	cmd := &cli.Command{
 		Name:                  "temp-mark",

--- a/renderer/autolink.go
+++ b/renderer/autolink.go
@@ -1,0 +1,62 @@
+package renderer
+
+import (
+	"bytes"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/util"
+)
+
+// ConfluenceAutoLinkRenderer renders ast.KindAutoLink (bare URLs in markdown,
+// goldmark-autodetected) as anchor tags carrying the
+// `data-card-appearance="inline"` attribute. Confluence Cloud uses that hint
+// to render the URL as an inline smart card (page mention / Jira / GitHub /
+// etc.) instead of a plain hyperlink.
+//
+// Markdown-explicit links (`[text](url)`) are left to the existing
+// ConfluenceLinkRenderer so that author-chosen display text is preserved
+// unchanged as a regular hyperlink. Only bare/auto-detected URLs become
+// inline cards.
+type ConfluenceAutoLinkRenderer struct {
+	html.Config
+}
+
+// NewConfluenceAutoLinkRenderer creates an instance of the autolink renderer.
+func NewConfluenceAutoLinkRenderer(opts ...html.Option) renderer.NodeRenderer {
+	r := &ConfluenceAutoLinkRenderer{
+		Config: html.NewConfig(),
+	}
+	for _, opt := range opts {
+		opt.SetHTMLOption(&r.Config)
+	}
+	return r
+}
+
+// RegisterFuncs implements renderer.NodeRenderer.
+func (r *ConfluenceAutoLinkRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(ast.KindAutoLink, r.renderAutoLink)
+}
+
+func (r *ConfluenceAutoLinkRenderer) renderAutoLink(
+	w util.BufWriter, source []byte, node ast.Node, entering bool,
+) (ast.WalkStatus, error) {
+	n := node.(*ast.AutoLink)
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	url := util.URLEscape(n.URL(source), false)
+	label := n.Label(source)
+	_, _ = w.WriteString(`<a href="`)
+	if n.AutoLinkType == ast.AutoLinkEmail && !bytes.HasPrefix(bytes.ToLower(url), []byte("mailto:")) {
+		_, _ = w.WriteString("mailto:")
+	}
+	if r.Unsafe || !html.IsDangerousURL(url) {
+		_, _ = w.Write(util.EscapeHTML(url))
+	}
+	_, _ = w.WriteString(`" data-card-appearance="inline">`)
+	_, _ = w.Write(util.EscapeHTML(label))
+	_, _ = w.WriteString(`</a>`)
+	return ast.WalkContinue, nil
+}

--- a/testdata/inline-link-card-inlinecard.html
+++ b/testdata/inline-link-card-inlinecard.html
@@ -1,0 +1,3 @@
+<p>Bare URL autolink · <a href="https://example.com" data-card-appearance="inline">https://example.com</a></p>
+<p>Bare email autolink · <a href="mailto:user@example.com" data-card-appearance="inline">user@example.com</a></p>
+<p>Inline-explicit markdown link is unaffected by the feature · <a href="https://example.com">example</a></p>

--- a/testdata/inline-link-card.html
+++ b/testdata/inline-link-card.html
@@ -1,0 +1,3 @@
+<p>Bare URL autolink · <a href="https://example.com">https://example.com</a></p>
+<p>Bare email autolink · <a href="mailto:user@example.com">user@example.com</a></p>
+<p>Inline-explicit markdown link is unaffected by the feature · <a href="https://example.com">example</a></p>

--- a/testdata/inline-link-card.md
+++ b/testdata/inline-link-card.md
@@ -1,0 +1,5 @@
+Bare URL autolink · <https://example.com>
+
+Bare email autolink · <user@example.com>
+
+Inline-explicit markdown link is unaffected by the feature · [example](https://example.com)

--- a/util/flags.go
+++ b/util/flags.go
@@ -210,7 +210,7 @@ var Flags = []cli.Flag{
 	&cli.StringSliceFlag{
 		Name:    "features",
 		Value:   []string{"mermaid", "mention"},
-		Usage:   "Enables optional features. Current features: d2, mermaid, mention, mkdocsadmonitions",
+		Usage:   "Enables optional features. Current features: d2, mermaid, mention, mkdocsadmonitions, inline-link-card",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_FEATURES"), altsrctoml.TOML("features", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.BoolFlag{


### PR DESCRIPTION
## Summary

Adds an opt-in feature `inline-link-card` that makes mark render auto-detected URLs as Confluence Cloud **inline smart cards** (page-title preview, Jira issue card, GitHub repo card, etc.) instead of plain hyperlinks.

The change is **strictly opt-in** — default output is unchanged, so existing pages and golden tests are not affected. Users enable the behaviour with `--features inline-link-card`.

## Why

Confluence Cloud renders anchor tags carrying the `data-card-appearance="inline"` attribute as inline smart cards. mark's default output does not emit this hint, so auto-detected URLs render as regular blue text links — visually inferior to the native inline-card preview that the Confluence editor produces when you paste a URL.

## Behaviour

| Input | Feature off (default) | Feature on |
|---|---|---|
| `<https://example.com>` (markdown autolink) | hyperlink | inline card |
| Bare URL detected by goldmark linkify | hyperlink | inline card |
| `[label](https://example.com)` (explicit link) | hyperlink, text=label | hyperlink, text=label (unchanged) |

Markdown-explicit links are intentionally left to the existing `ConfluenceLinkRenderer` so that author-chosen display text is preserved verbatim.

## Implementation

* **New** `renderer/autolink.go` · `ConfluenceAutoLinkRenderer`. Mirrors goldmark's default `renderAutoLink` and additionally emits the `data-card-appearance="inline"` attribute.
* **Conditional registration** in both `ConfluenceExtension.Extend` and `ConfluenceLegacyExtension.Extend`, gated on `slices.Contains(c.MarkConfig.Features, "inline-link-card")`.
* **Tests**:
  * New fixture pair under `testdata/` (vanilla `inline-link-card.html` + `inline-link-card-inlinecard.html` variant). The vanilla file confirms that the default test suite (feature off) keeps producing standard hyperlinks; the variant confirms the smart-card output when the feature is enabled.
  * New `TestCompileMarkdownInlineLinkCard` that compiles the same markdown with `Features: ["...", "inline-link-card"]` and asserts against the `-inlinecard` golden output.
* **Docs**:
  * README new "Inline Link Cards" section.
  * `--features` usage string updated to list `inline-link-card`.

## Test plan

- [x] `go test ./...` (all packages green, including new `markdown` test)
- [x] Default `TestCompileMarkdown`, `TestCompileMarkdownDropH1`, `TestCompileMarkdownStripNewlines` still pass (verifies no regression for users who don't opt in)
- [x] New `TestCompileMarkdownInlineLinkCard` passes (verifies attribute emission when feature enabled)
- [x] Manual end-to-end against a real Confluence Cloud space: bare URLs render as live smart cards (page mention, Jira issue, GitHub repo) with the feature enabled; render as plain hyperlinks when disabled.

## Notes for reviewers

* I considered making this the default behaviour but kept it opt-in to:
  * preserve backward compatibility of golden tests / existing pages,
  * leave the choice to users whose Confluence renderers might display smart cards differently (Server / Data Center installs, plugin variations).
* The attribute `data-card-appearance="inline"` is the documented Confluence Cloud signal for inline cards. Alternative card appearances (`block`, `embed`) could be added later as feature variants without changing this PR's surface.
* No third-party dependencies added.