### PR TITLE
fix(confluence): support scoped API tokens via the api.atlassian.com gateway

### DIFF
--- a/confluence/api.go
+++ b/confluence/api.go
@@ -237,15 +237,35 @@ func (api *API) FindHomePage(space string) (*PageInfo, error) {
 	request, err := api.rest.Res(
 		"space/"+space, &SpaceInfo{},
 	).Get(payload)
+	if err == nil && request.Raw.StatusCode == http.StatusOK {
+		return &request.Response.(*SpaceInfo).Homepage, nil
+	}
+
+	// Confluence Cloud answers 404 on the v1 space endpoint for tokens
+	// without classic scopes; fall back to the v2 spaces API.
+	v2Result := struct {
+		Results []struct {
+			ID         string `json:"id"`
+			HomepageID string `json:"homepageId"`
+		} `json:"results"`
+	}{}
+
+	request, err = api.restV2.Res(
+		"spaces", &v2Result,
+	).Get(map[string]string{"keys": space})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get space %s (tried both v1 and v2 APIs): %w", space, err)
 	}
 
 	if request.Raw.StatusCode != http.StatusOK {
 		return nil, newErrorStatusNotOK(request)
 	}
 
-	return &request.Response.(*SpaceInfo).Homepage, nil
+	if len(v2Result.Results) == 0 || v2Result.Results[0].HomepageID == "" {
+		return nil, fmt.Errorf("space with key %s not found", space)
+	}
+
+	return api.GetPageByID(v2Result.Results[0].HomepageID)
 }
 
 func (api *API) FindPage(
@@ -940,7 +960,11 @@ func (api *API) RestrictPageUpdatesServer(
 
 func (api *API) IsCloud() bool {
 	host := api.rest.Api.BaseUrl.Host
-	return strings.HasSuffix(host, "jira.com") || strings.HasSuffix(host, "atlassian.net")
+	// api.atlassian.com is the gateway required by scoped API tokens
+	// (https://api.atlassian.com/ex/confluence/<cloudId>/wiki).
+	return strings.HasSuffix(host, "jira.com") ||
+		strings.HasSuffix(host, "atlassian.net") ||
+		host == "api.atlassian.com"
 }
 
 func (api *API) RestrictPageUpdates(

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -335,11 +335,11 @@ func (api *API) FindHomePage(space string) (*PageInfo, error) {
 		"expand": "homepage",
 	}
 
-	request, err := api.rest.Res(
+	v1Request, v1Err := api.rest.Res(
 		"space/"+space, &SpaceInfo{},
 	).Get(payload)
-	if err == nil && request.Raw.StatusCode == http.StatusOK {
-		return &request.Response.(*SpaceInfo).Homepage, nil
+	if v1Err == nil && v1Request.Raw.StatusCode == http.StatusOK {
+		return &v1Request.Response.(*SpaceInfo).Homepage, nil
 	}
 
 	// Any non-OK v1 answer falls through to v2, mirroring GetSpaceID. The case
@@ -355,15 +355,23 @@ func (api *API) FindHomePage(space string) (*PageInfo, error) {
 		} `json:"results"`
 	}{}
 
-	request, err = api.restV2.Res(
+	v2Request, v2Err := api.restV2.Res(
 		"spaces", &v2Result,
 	).Get(map[string]string{"keys": space})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get space %s (tried both v1 and v2 APIs): %w", space, err)
+	if v2Err == nil && v2Request.Raw.StatusCode != http.StatusOK {
+		v2Err = newErrorStatusNotOK(v2Request)
 	}
 
-	if request.Raw.StatusCode != http.StatusOK {
-		return nil, newErrorStatusNotOK(request)
+	// When v2 cannot answer either, report why v1 refused rather than why v2
+	// did. Server/DC has no /api/v2 at all, so every fallback there ends in a
+	// 404 from a path that was never going to exist, and surfacing that instead
+	// of v1's answer turns a clear "401 (Unauthorized)" -- the error a Server
+	// user with bad credentials should see -- into a misleading "404".
+	if v2Err != nil {
+		if v1Err == nil {
+			v1Err = newErrorStatusNotOK(v1Request)
+		}
+		return nil, fmt.Errorf("v1 API: %w (v2 fallback also failed: %w)", v1Err, v2Err)
 	}
 
 	if len(v2Result.Results) == 0 {

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -342,8 +342,12 @@ func (api *API) FindHomePage(space string) (*PageInfo, error) {
 		return &request.Response.(*SpaceInfo).Homepage, nil
 	}
 
-	// Confluence Cloud answers 404 on the v1 space endpoint for tokens
-	// without classic scopes; fall back to the v2 spaces API.
+	// Any non-OK v1 answer falls through to v2, mirroring GetSpaceID. The case
+	// that motivated the fallback is a scoped API token going through the
+	// api.atlassian.com gateway: those tokens lack the classic scopes, so the
+	// v1 space endpoint answers 404 and every run aborted here. The fallback is
+	// deliberately not narrowed to 404: a token with partial scopes can also
+	// draw 401/403 from v1 while v2 still answers.
 	v2Result := struct {
 		Results []struct {
 			ID         string `json:"id"`
@@ -362,8 +366,15 @@ func (api *API) FindHomePage(space string) (*PageInfo, error) {
 		return nil, newErrorStatusNotOK(request)
 	}
 
-	if len(v2Result.Results) == 0 || v2Result.Results[0].HomepageID == "" {
+	if len(v2Result.Results) == 0 {
 		return nil, fmt.Errorf("space with key %s not found", space)
+	}
+
+	// A space that exists but has no homepage is a different failure from a
+	// space that does not exist, and reporting it as "not found" sends people
+	// looking for a typo in a space key that is perfectly correct.
+	if v2Result.Results[0].HomepageID == "" {
+		return nil, fmt.Errorf("space %s has no home page", space)
 	}
 
 	return api.GetPageByID(v2Result.Results[0].HomepageID)
@@ -1091,6 +1102,33 @@ func (api *API) GetCurrentUser() (*User, error) {
 	return &user, nil
 }
 
+// isCloudHost reports whether a host is a known Confluence Cloud host, without
+// issuing a request.
+//
+// Matching is on a dot boundary rather than a bare suffix: strings.HasSuffix on
+// "atlassian.net" also accepts "notatlassian.net", which would send a
+// self-hosted instance down the Cloud code paths.
+//
+// api.atlassian.com is the gateway that scoped API tokens must go through
+// (https://api.atlassian.com/ex/confluence/<cloudId>/wiki). It always fronts
+// Cloud, and matching it here means the common scoped-token setup answers from
+// the fast path instead of paying for a probe.
+func isCloudHost(host string) bool {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+
+	if host == "api.atlassian.com" {
+		return true
+	}
+
+	for _, domain := range []string{"jira.com", "atlassian.net"} {
+		if host == domain || strings.HasSuffix(host, "."+domain) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IsCloud reports whether the target is Confluence Cloud, probing at most once
 // per API value.
 //
@@ -1101,9 +1139,8 @@ func (api *API) GetCurrentUser() (*User, error) {
 // reading a half-written one.
 func (api *API) IsCloud() bool {
 	api.isCloudOnce.Do(func() {
-		// 1. Fast path: check default domain suffix
-		host := api.rest.Api.BaseUrl.Hostname()
-		if strings.HasSuffix(host, "jira.com") || strings.HasSuffix(host, "atlassian.net") {
+		// 1. Fast path: check for a known Cloud host
+		if isCloudHost(api.rest.Api.BaseUrl.Hostname()) {
 			api.isCloudFlag = true
 			return
 		}

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -338,15 +338,35 @@ func (api *API) FindHomePage(space string) (*PageInfo, error) {
 	request, err := api.rest.Res(
 		"space/"+space, &SpaceInfo{},
 	).Get(payload)
+	if err == nil && request.Raw.StatusCode == http.StatusOK {
+		return &request.Response.(*SpaceInfo).Homepage, nil
+	}
+
+	// Confluence Cloud answers 404 on the v1 space endpoint for tokens
+	// without classic scopes; fall back to the v2 spaces API.
+	v2Result := struct {
+		Results []struct {
+			ID         string `json:"id"`
+			HomepageID string `json:"homepageId"`
+		} `json:"results"`
+	}{}
+
+	request, err = api.restV2.Res(
+		"spaces", &v2Result,
+	).Get(map[string]string{"keys": space})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get space %s (tried both v1 and v2 APIs): %w", space, err)
 	}
 
 	if request.Raw.StatusCode != http.StatusOK {
 		return nil, newErrorStatusNotOK(request)
 	}
 
-	return &request.Response.(*SpaceInfo).Homepage, nil
+	if len(v2Result.Results) == 0 || v2Result.Results[0].HomepageID == "" {
+		return nil, fmt.Errorf("space with key %s not found", space)
+	}
+
+	return api.GetPageByID(v2Result.Results[0].HomepageID)
 }
 
 func (api *API) FindPage(

--- a/confluence/api_server_test.go
+++ b/confluence/api_server_test.go
@@ -656,3 +656,31 @@ func TestFindHomePageSpaceWithoutHomepage(t *testing.T) {
 	assert.Contains(t, err.Error(), "has no home page")
 	assert.NotContains(t, err.Error(), "not found")
 }
+
+// TestFindHomePageReportsV1ErrorWhenV2Unavailable guards the diagnosability of
+// the most common first failure mark can hit: FindHomePage is the first call
+// made for any page, so wrong credentials surface here.
+//
+// Server/DC has no /api/v2, so the fallback always ends in a 404 from a path
+// that never existed. Reporting that instead of v1's answer would tell a Server
+// user with a bad token "404 (Not Found)" when the truth is 401.
+func TestFindHomePageReportsV1ErrorWhenV2Unavailable(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddSpace("DOCS")
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if strings.HasPrefix(r.URL.Path, "/rest/api/space/") {
+			return http.StatusUnauthorized, `{"message":"bad credentials"}`, true
+		}
+		// Confluence Server has no v2 API; every path under it is absent.
+		if strings.HasPrefix(r.URL.Path, "/api/v2") {
+			return http.StatusNotFound, `<html>404</html>`, true
+		}
+		return 0, "", false
+	})
+
+	_, err := api.FindHomePage("DOCS")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401",
+		"the v1 status is the one that explains the failure")
+	assert.Contains(t, err.Error(), "Unauthorized")
+}

--- a/confluence/api_server_test.go
+++ b/confluence/api_server_test.go
@@ -562,3 +562,97 @@ func TestIsCloudCachesAcrossSequentialCalls(t *testing.T) {
 	assert.Equal(t, before, server.CountRequests("GET", "/api/v2/spaces"),
 		"repeat calls must not re-probe")
 }
+
+// scopedTokenV1Gone makes the v1 space endpoint answer as it does for an
+// Atlassian scoped API token: those tokens lack the classic scopes, so v1
+// reports the space as absent even though it exists and v2 can see it.
+func scopedTokenV1Gone(status int) confluencetest.FailFunc {
+	return func(r *http.Request) (int, string, bool) {
+		if strings.HasPrefix(r.URL.Path, "/rest/api/space/") {
+			return status, `{"message":"no permission"}`, true
+		}
+		return 0, "", false
+	}
+}
+
+// TestFindHomePageFallsBackToV2 is the case from issue #341: with a scoped
+// token the v1 space endpoint 404s and mark aborted with "can't obtain home
+// page from space" before ever reaching a working v2 endpoint.
+func TestFindHomePageFallsBackToV2(t *testing.T) {
+	api, server := newAPI(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.SetFail(scopedTokenV1Gone(http.StatusNotFound))
+
+	page, err := api.FindHomePage("DOCS")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+	assert.Equal(t, "Home", page.Title)
+	assert.Equal(t, home.ID, page.ID)
+
+	assert.Equal(t, 1, server.CountRequests("GET", "/rest/api/space/DOCS"),
+		"v1 is still tried first")
+	assert.Equal(t, 1, server.CountRequests("GET", "/api/v2/spaces"),
+		"and v2 resolves the space once v1 refuses")
+}
+
+// TestFindHomePageFallsBackOnAnyNonOK covers the widening the fallback is
+// deliberately written for: a token with partial scopes draws 401/403 from v1
+// rather than 404, and those must fall through too.
+func TestFindHomePageFallsBackOnAnyNonOK(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			api, server := newAPI(t)
+			home := server.AddPage("DOCS", "Home", "page", "")
+			server.SetHomepage("DOCS", home.ID)
+			server.SetFail(scopedTokenV1Gone(status))
+
+			page, err := api.FindHomePage("DOCS")
+			require.NoError(t, err)
+			require.NotNil(t, page)
+			assert.Equal(t, "Home", page.Title)
+		})
+	}
+}
+
+// TestFindHomePagePrefersV1 pins that the fallback is a fallback: a classic
+// token still gets its answer from v1, with no extra v2 round trip.
+func TestFindHomePagePrefersV1(t *testing.T) {
+	api, server := newAPI(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+
+	page, err := api.FindHomePage("DOCS")
+	require.NoError(t, err)
+	assert.Equal(t, "Home", page.Title)
+
+	assert.Equal(t, 0, server.CountRequests("GET", "/api/v2/spaces"),
+		"v1 answered, so v2 must not be consulted")
+}
+
+// TestFindHomePageMissingSpace: when neither API knows the space, the error
+// must name the space rather than surfacing a bare 404.
+func TestFindHomePageMissingSpace(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddSpace("DOCS")
+	server.SetFail(scopedTokenV1Gone(http.StatusNotFound))
+
+	_, err := api.FindHomePage("NOPE")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "NOPE")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestFindHomePageSpaceWithoutHomepage separates "no such space" from "space
+// has no homepage" -- reporting the latter as not-found sends people hunting
+// for a typo in a space key that is correct.
+func TestFindHomePageSpaceWithoutHomepage(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddSpace("DOCS")
+	server.SetFail(scopedTokenV1Gone(http.StatusNotFound))
+
+	_, err := api.FindHomePage("DOCS")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has no home page")
+	assert.NotContains(t, err.Error(), "not found")
+}

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -170,3 +170,38 @@ func TestPageCacheZeroValueAPI(t *testing.T) {
 	api2.setCacheEntry("key", &PageInfo{ID: "123"})
 	api2.pageCacheMutex.Unlock()
 }
+
+// TestIsCloudHost pins the host classification the IsCloud fast path relies on.
+// The gateway host matters because scoped API tokens can only be used against
+// it, and the dot-boundary cases matter because a bare suffix check accepted
+// hosts like "notatlassian.net" and sent self-hosted instances down the Cloud
+// code paths.
+func TestIsCloudHost(t *testing.T) {
+	cloud := []string{
+		"example.atlassian.net",
+		"example.jira.com",
+		"atlassian.net",
+		"jira.com",
+		"api.atlassian.com",
+		"API.Atlassian.Com",         // hosts are case-insensitive
+		"example.ATLASSIAN.net",     // ... in the suffix match too
+		"example.atlassian.net.",    // fully qualified, trailing root label
+		"deep.nested.atlassian.net", // more than one label deep
+	}
+	for _, host := range cloud {
+		assert.True(t, isCloudHost(host), "%q should be recognised as Cloud", host)
+	}
+
+	notCloud := []string{
+		"confluence.example.com",
+		"notatlassian.net",
+		"eviljira.com",
+		"atlassian.net.example.com", // the domain appears, but not as a suffix
+		"api.atlassian.com.evil.io",
+		"myapi.atlassian.com", // only the exact gateway host is the gateway
+		"",
+	}
+	for _, host := range notCloud {
+		assert.False(t, isCloudHost(host), "%q should not be recognised as Cloud", host)
+	}
+}

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -417,7 +417,15 @@ func (s *Server) handleV2(w http.ResponseWriter, r *http.Request, path string) {
 		results := []map[string]any{}
 		for _, sp := range s.spaces {
 			if key == "" || sp.Key == key {
-				results = append(results, map[string]any{"id": sp.ID, "key": sp.Key})
+				// v2 reports the homepage as an id, unlike v1 which expands the
+				// whole page object. FindHomePage's v2 fallback resolves it with
+				// a second call, so the field has to be here for that path to be
+				// exercised.
+				results = append(results, map[string]any{
+					"id":         sp.ID,
+					"key":        sp.Key,
+					"homepageId": sp.HomepageID,
+				})
 			}
 		}
 		sort.Slice(results, func(i, j int) bool {


### PR DESCRIPTION
## Problem

Atlassian's **scoped API tokens** only authenticate against the gateway URL `https://api.atlassian.com/ex/confluence/<cloudId>/wiki` — used directly against `<site>.atlassian.net` they are treated as anonymous. Running mark in that setup currently fails in two places:

1. **`FindHomePage` fails with 404** — the v1 endpoint `GET /rest/api/space/<key>` answers 404 for scoped tokens (they lack the classic scopes), so every run aborts with `can't obtain home page from space` (#341 reports this symptom).
2. **Folder support is rejected** — `IsCloud()` only recognizes `*.jira.com` / `*.atlassian.net`, so with the gateway base URL mark refuses `<!-- Folder: -->` even though the gateway always fronts a Cloud instance.

## Fix

- `FindHomePage`: keep the v1 call, but on a non-OK response fall back to the v2 spaces API (`GET /api/v2/spaces?keys=<key>`) and resolve the homepage via `GetPageByID`. Behaviour for classic tokens / Server is unchanged (v1 still wins when it works).
- `IsCloud()`: additionally recognize the host `api.atlassian.com`.

## Testing

- `go build ./...`, `go vet`, `go test ./...` all pass.
- Running in production since 2026-07-03 (as a patch on v16.5.0) in a GitHub Actions pipeline publishing a docs repo to Confluence Cloud with a scoped token via the gateway, including folder parents — pages and folders sync correctly.

Fixes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)