### PR TITLE
Feature/yaml frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,42 @@ Mark uses an extended file format, which, still being valid markdown,
 contains several HTML-ish metadata headers, which can be used to locate page inside
 Confluence instance and update it accordingly.
 
-File in the extended format should follow the specification:
+File metadata can be written as YAML front matter when the `frontmatter`
+feature is enabled. Because specifying `--features` replaces the defaults,
+include the default features explicitly if needed:
+
+```shell
+mark --features=mermaid --features=mention --features=frontmatter
+```
+
+YAML front matter uses the following format:
+
+```markdown
+---
+space: <space key>
+parents:
+  - <parent 1>
+  - <parent 2>
+folders:
+  - <folder 1>
+  - <folder 2>
+title: <title>
+attachments:
+  - <local path>
+labels:
+  - <label 1>
+  - <label 2>
+image-align: <left|center|right>
+---
+
+<page contents>
+```
+
+The legacy HTML header format is also supported:
+
+When both formats are present, HTML headers override matching scalar front
+matter values. Repeatable parents, folders, attachments, and labels are
+appended to the values from front matter.
 
 ```markdown
 <!-- Space: <space key> -->
@@ -905,7 +940,7 @@ GLOBAL OPTIONS:
    --changes-only                           Avoids re-uploading pages that haven't changed since the last run. [$MARK_CHANGES_ONLY]
    --preserve-comments                      Fetch and preserve inline comments on existing Confluence pages. [$MARK_PRESERVE_COMMENTS]
    --d2-scale float                         defines the scaling factor for d2 renderings. (default: 1) [$MARK_D2_SCALE]
-   --features string [ --features string ]  Enables optional features. Current features: d2, mermaid, mention, mkdocsadmonitions, plantuml (default: "mermaid", "mention") [$MARK_FEATURES]
+   --features string [ --features string ]  Enables optional features. Current features: d2, frontmatter, mermaid, mention, mkdocsadmonitions, plantuml (default: "mermaid", "mention") [$MARK_FEATURES]
    --insecure-skip-tls-verify               skip TLS certificate verification (useful for self-signed certificates) [$MARK_INSECURE_SKIP_TLS_VERIFY]
    --image-align string                     set image alignment (left, center, right). Can be overridden per-file via the Image-Align header. [$MARK_IMAGE_ALIGN]
    --help, -h                               show help

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/urfave/cli-altsrc/v3 v3.1.0
 	github.com/urfave/cli/v3 v3.10.1
 	github.com/yuin/goldmark v1.8.4
+	go.abhg.dev/goldmark/frontmatter v0.3.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/text v0.40.0
 	oss.terrastruct.com/d2 v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3i
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.8.4 h1:oat/nd3U6NeQqFEL3xpEJq7d7c86NI+DbSNGAs4xnjA=
 github.com/yuin/goldmark v1.8.4/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+go.abhg.dev/goldmark/frontmatter v0.3.0 h1:ZOrMkeyyYzhlbenFNmOXyGFx1dFE8TgBWAgZfs9D5RA=
+go.abhg.dev/goldmark/frontmatter v0.3.0/go.mod h1:W3KXvVveKKxU1FIFZ7fgFFQrlkcolnDcOVmu19cCO9U=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=

--- a/mark.go
+++ b/mark.go
@@ -147,6 +147,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 	}
 
 	markdown = bytes.ReplaceAll(markdown, []byte("\r\n"), []byte("\n"))
+	frontMatterEnabled := slices.Contains(config.Features, "frontmatter")
 
 	meta, markdown, err := metadata.ExtractMeta(
 		markdown,
@@ -157,6 +158,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 		config.Parents,
 		config.TitleAppendGeneratedHash,
 		config.ContentAppearance,
+		frontMatterEnabled,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to extract metadata from file %q: %w", file, err)
@@ -241,6 +243,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 		config.TitleFromFilename,
 		config.Parents,
 		config.TitleAppendGeneratedHash,
+		frontMatterEnabled,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to resolve relative links: %w", err)

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	mark "github.com/kovetskiy/mark/v16/markdown"
+	"github.com/kovetskiy/mark/v16/metadata"
 	"github.com/kovetskiy/mark/v16/stdlib"
 	"github.com/kovetskiy/mark/v16/types"
 	"github.com/kovetskiy/mark/v16/util"
@@ -59,15 +60,26 @@ func TestCompileMarkdown(t *testing.T) {
 		}
 		markdown, htmlname, html := loadData(t, filename, "")
 
+		var body []byte
+		if filename == "testdata/frontmatter.md" {
+			var err error
+			_, body, err = metadata.ExtractMeta(markdown, "", false, false, "", nil, false, "", true)
+			if err != nil {
+				panic(err)
+			}
+		} else {
+			body = markdown
+		}
+
 		cfg := types.MarkConfig{
 			MermaidScale:  1.0,
 			D2Scale:       1.0,
 			DropFirstH1:   false,
 			StripNewlines: false,
-			Features:      []string{"mkdocsadmonitions", "mention", "plantuml"},
+			Features:      []string{"mkdocsadmonitions", "mention", "plantuml", "frontmatter"},
 		}
 
-		actual, _, _ := mark.CompileMarkdown(markdown, lib, filename, cfg)
+		actual, _, _ := mark.CompileMarkdown(body, lib, filename, cfg)
 		test.EqualValues(strings.TrimSuffix(string(html), "\n"), strings.TrimSuffix(actual, "\n"), filename+" vs "+htmlname)
 	}
 }
@@ -94,22 +106,33 @@ func TestCompileMarkdownDropH1(t *testing.T) {
 		}
 		var variant string
 		switch filename {
-		case "testdata/quotes.md", "testdata/header.md", "testdata/admonitions.md", "testdata/plantuml.md", "testdata/codeblock-comments.md":
+		case "testdata/quotes.md", "testdata/header.md", "testdata/admonitions.md", "testdata/plantuml.md", "testdata/codeblock-comments.md", "testdata/frontmatter.md":
 			variant = "-droph1"
 		default:
 			variant = ""
 		}
 		markdown, htmlname, html := loadData(t, filename, variant)
 
+		var body []byte
+		if filename == "testdata/frontmatter.md" {
+			var err error
+			_, body, err = metadata.ExtractMeta(markdown, "", false, false, "", nil, false, "", true)
+			if err != nil {
+				panic(err)
+			}
+		} else {
+			body = markdown
+		}
+
 		cfg := types.MarkConfig{
 			MermaidScale:  1.0,
 			D2Scale:       1.0,
 			DropFirstH1:   true,
 			StripNewlines: false,
-			Features:      []string{"mkdocsadmonitions", "mention", "plantuml"},
+			Features:      []string{"mkdocsadmonitions", "mention", "plantuml", "frontmatter"},
 		}
 
-		actual, _, _ := mark.CompileMarkdown(markdown, lib, filename, cfg)
+		actual, _, _ := mark.CompileMarkdown(body, lib, filename, cfg)
 		test.EqualValues(strings.TrimSuffix(string(html), "\n"), strings.TrimSuffix(actual, "\n"), filename+" vs "+htmlname)
 
 	}
@@ -145,15 +168,26 @@ func TestCompileMarkdownStripNewlines(t *testing.T) {
 
 		markdown, htmlname, html := loadData(t, filename, variant)
 
+		var body []byte
+		if filename == "testdata/frontmatter.md" {
+			var err error
+			_, body, err = metadata.ExtractMeta(markdown, "", false, false, "", nil, false, "", true)
+			if err != nil {
+				panic(err)
+			}
+		} else {
+			body = markdown
+		}
+
 		cfg := types.MarkConfig{
 			MermaidScale:  1.0,
 			D2Scale:       1.0,
 			DropFirstH1:   false,
 			StripNewlines: true,
-			Features:      []string{"mkdocsadmonitions", "mention", "plantuml"},
+			Features:      []string{"mkdocsadmonitions", "mention", "plantuml", "frontmatter"},
 		}
 
-		actual, _, _ := mark.CompileMarkdown(markdown, lib, filename, cfg)
+		actual, _, _ := mark.CompileMarkdown(body, lib, filename, cfg)
 		test.EqualValues(strings.TrimSuffix(string(html), "\n"), strings.TrimSuffix(actual, "\n"), filename+" vs "+htmlname)
 
 	}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"path/filepath"
@@ -9,7 +10,9 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/text"
+	"go.abhg.dev/goldmark/frontmatter"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -51,15 +54,134 @@ const (
 	DefaultContentAppearance   = "default"
 )
 
-func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFilename bool, filename string, parents []string, titleAppendGeneratedHash bool, defaultContentAppearance string) (*Meta, []byte, error) {
-	var (
-		meta   *Meta
-		offset int
-	)
+type yamlFrontMatter struct {
+	Parents                     []string `yaml:"parents"`
+	Parent                      string   `yaml:"parent"`
+	Folders                     []string `yaml:"folders"`
+	Folder                      string   `yaml:"folder"`
+	Space                       string   `yaml:"space"`
+	Type                        string   `yaml:"type"`
+	Title                       string   `yaml:"title"`
+	Layout                      string   `yaml:"layout"`
+	Sidebar                     string   `yaml:"sidebar"`
+	Emoji                       string   `yaml:"emoji"`
+	Attachments                 []string `yaml:"attachments"`
+	Attachment                  string   `yaml:"attachment"`
+	Labels                      []string `yaml:"labels"`
+	Label                       string   `yaml:"label"`
+	ContentAppearance           string   `yaml:"content-appearance"`
+	ContentAppearanceUnderscore string   `yaml:"content_appearance"`
+	ImageAlign                  string   `yaml:"image-align"`
+	ImageAlignUnderscore        string   `yaml:"image_align"`
+}
 
-	reader := text.NewReader(data)
-	parser := goldmark.DefaultParser()
-	doc := parser.Parse(reader)
+func (frontMatter yamlFrontMatter) meta() *Meta {
+	meta := &Meta{
+		Space:   strings.TrimSpace(frontMatter.Space),
+		Type:    strings.TrimSpace(frontMatter.Type),
+		Title:   strings.TrimSpace(frontMatter.Title),
+		Layout:  strings.TrimSpace(frontMatter.Layout),
+		Sidebar: strings.TrimSpace(frontMatter.Sidebar),
+		Emoji:   strings.TrimSpace(frontMatter.Emoji),
+	}
+	if meta.Type == "" {
+		meta.Type = "page"
+	}
+	if meta.Sidebar != "" {
+		meta.Layout = "article"
+	}
+
+	meta.Parents = appendTrimmed(meta.Parents, frontMatter.Parent)
+	meta.Parents = appendTrimmed(meta.Parents, frontMatter.Parents...)
+	meta.Folders = appendTrimmed(meta.Folders, frontMatter.Folder)
+	meta.Folders = appendTrimmed(meta.Folders, frontMatter.Folders...)
+	meta.Attachments = appendTrimmed(meta.Attachments, frontMatter.Attachment)
+	meta.Attachments = appendTrimmed(meta.Attachments, frontMatter.Attachments...)
+	meta.Labels = appendTrimmed(meta.Labels, frontMatter.Label)
+	meta.Labels = appendTrimmed(meta.Labels, frontMatter.Labels...)
+
+	if value := firstNonEmpty(frontMatter.ContentAppearance, frontMatter.ContentAppearanceUnderscore); value != "" {
+		setContentAppearance(meta, value)
+	}
+	meta.ImageAlign = strings.ToLower(strings.TrimSpace(firstNonEmpty(frontMatter.ImageAlign, frontMatter.ImageAlignUnderscore)))
+
+	return meta
+}
+
+func appendTrimmed(dst []string, values ...string) []string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			dst = append(dst, value)
+		}
+	}
+	return dst
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func setContentAppearance(meta *Meta, value string) {
+	switch strings.TrimSpace(value) {
+	case FixedContentAppearance:
+		meta.ContentAppearance = FixedContentAppearance
+	case DefaultContentAppearance:
+		meta.ContentAppearance = DefaultContentAppearance
+	default:
+		meta.ContentAppearance = FullWidthContentAppearance
+	}
+}
+
+func stripFrontMatter(data []byte) ([]byte, error) {
+	delimiter, rest, ok := bytes.Cut(data, []byte("\n"))
+	if !ok {
+		return nil, fmt.Errorf("unterminated YAML front matter")
+	}
+	delimiter = bytes.TrimSuffix(delimiter, []byte("\r"))
+
+	for {
+		line, remaining, hasNewline := bytes.Cut(rest, []byte("\n"))
+		if bytes.Equal(bytes.TrimSuffix(line, []byte("\r")), delimiter) {
+			return remaining, nil
+		}
+		if !hasNewline {
+			return nil, fmt.Errorf("unterminated YAML front matter")
+		}
+		rest = remaining
+	}
+}
+
+func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFilename bool, filename string, parents []string, titleAppendGeneratedHash bool, defaultContentAppearance string, frontMatterEnabled bool) (*Meta, []byte, error) {
+	var meta *Meta
+	body := data
+
+	markdown := goldmark.New()
+	if frontMatterEnabled {
+		(&frontmatter.Extender{
+			Formats: []frontmatter.Format{frontmatter.YAML},
+		}).Extend(markdown)
+	}
+
+	ctx := parser.NewContext()
+	doc := markdown.Parser().Parse(text.NewReader(data), parser.WithContext(ctx))
+	if frontMatterData := frontmatter.Get(ctx); frontMatterData != nil {
+		var parsed yamlFrontMatter
+		if err := frontMatterData.Decode(&parsed); err != nil {
+			return nil, nil, fmt.Errorf("decode YAML front matter: %w", err)
+		}
+
+		meta = parsed.meta()
+		var err error
+		body, err = stripFrontMatter(data)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
 
 	var lastStop int
 	shouldBreak := false
@@ -128,14 +250,7 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 					continue
 
 				case ContentAppearance:
-					switch strings.TrimSpace(value) {
-					case FixedContentAppearance:
-						meta.ContentAppearance = FixedContentAppearance
-					case DefaultContentAppearance:
-						meta.ContentAppearance = DefaultContentAppearance
-					default:
-						meta.ContentAppearance = FullWidthContentAppearance
-					}
+					setContentAppearance(meta, value)
 
 				case HeaderImageAlign:
 					meta.ImageAlign = strings.ToLower(strings.TrimSpace(value))
@@ -157,7 +272,9 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 		}
 	}
 
-	offset = lastStop
+	if lastStop > 0 {
+		body = data[lastStop:]
+	}
 
 	if titleFromH1 || titleFromFilename || spaceFromCli != "" {
 		if meta == nil {
@@ -181,14 +298,7 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 
 	// Use the global content appearance flag if the header is not set in the document
 	if meta != nil && defaultContentAppearance != "" && meta.ContentAppearance == "" {
-		switch strings.TrimSpace(defaultContentAppearance) {
-		case FixedContentAppearance:
-			meta.ContentAppearance = FixedContentAppearance
-		case DefaultContentAppearance:
-			meta.ContentAppearance = DefaultContentAppearance
-		default:
-			meta.ContentAppearance = FullWidthContentAppearance
-		}
+		setContentAppearance(meta, defaultContentAppearance)
 	} else if meta != nil && meta.ContentAppearance == "" {
 		meta.ContentAppearance = FullWidthContentAppearance // Default to full-width if nothing else is set for backwards compatibility
 	}
@@ -214,7 +324,7 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 	// Remove trailing spaces from title
 	meta.Title = strings.Trim(meta.Title, " ")
 	meta.Space = strings.Trim(meta.Space, " ")
-	return meta, data[offset:], nil
+	return meta, body, nil
 }
 
 func setTitleFromFilename(meta *Meta, filename string) {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -54,74 +54,28 @@ const (
 	DefaultContentAppearance   = "default"
 )
 
-type yamlFrontMatter struct {
-	Parents                     []string `yaml:"parents"`
-	Parent                      string   `yaml:"parent"`
-	Folders                     []string `yaml:"folders"`
-	Folder                      string   `yaml:"folder"`
-	Space                       string   `yaml:"space"`
-	Type                        string   `yaml:"type"`
-	Title                       string   `yaml:"title"`
-	Layout                      string   `yaml:"layout"`
-	Sidebar                     string   `yaml:"sidebar"`
-	Emoji                       string   `yaml:"emoji"`
-	Attachments                 []string `yaml:"attachments"`
-	Attachment                  string   `yaml:"attachment"`
-	Labels                      []string `yaml:"labels"`
-	Label                       string   `yaml:"label"`
-	ContentAppearance           string   `yaml:"content-appearance"`
-	ContentAppearanceUnderscore string   `yaml:"content_appearance"`
-	ImageAlign                  string   `yaml:"image-align"`
-	ImageAlignUnderscore        string   `yaml:"image_align"`
-}
-
-func (frontMatter yamlFrontMatter) meta() *Meta {
-	meta := &Meta{
-		Space:   strings.TrimSpace(frontMatter.Space),
-		Type:    strings.TrimSpace(frontMatter.Type),
-		Title:   strings.TrimSpace(frontMatter.Title),
-		Layout:  strings.TrimSpace(frontMatter.Layout),
-		Sidebar: strings.TrimSpace(frontMatter.Sidebar),
-		Emoji:   strings.TrimSpace(frontMatter.Emoji),
+func toStringSlice(val any) []string {
+	v, ok := val.([]any)
+	if !ok {
+		return nil
 	}
-	if meta.Type == "" {
-		meta.Type = "page"
-	}
-	if meta.Sidebar != "" {
-		meta.Layout = "article"
-	}
-
-	meta.Parents = appendTrimmed(meta.Parents, frontMatter.Parent)
-	meta.Parents = appendTrimmed(meta.Parents, frontMatter.Parents...)
-	meta.Folders = appendTrimmed(meta.Folders, frontMatter.Folder)
-	meta.Folders = appendTrimmed(meta.Folders, frontMatter.Folders...)
-	meta.Attachments = appendTrimmed(meta.Attachments, frontMatter.Attachment)
-	meta.Attachments = appendTrimmed(meta.Attachments, frontMatter.Attachments...)
-	meta.Labels = appendTrimmed(meta.Labels, frontMatter.Label)
-	meta.Labels = appendTrimmed(meta.Labels, frontMatter.Labels...)
-
-	if value := firstNonEmpty(frontMatter.ContentAppearance, frontMatter.ContentAppearanceUnderscore); value != "" {
-		setContentAppearance(meta, value)
-	}
-	meta.ImageAlign = strings.ToLower(strings.TrimSpace(firstNonEmpty(frontMatter.ImageAlign, frontMatter.ImageAlignUnderscore)))
-
-	return meta
-}
-
-func appendTrimmed(dst []string, values ...string) []string {
-	for _, value := range values {
-		if value = strings.TrimSpace(value); value != "" {
-			dst = append(dst, value)
+	var res []string
+	for _, item := range v {
+		if s, ok := item.(string); ok {
+			if s = strings.TrimSpace(s); s != "" {
+				res = append(res, s)
+			}
 		}
 	}
-	return dst
+	return res
 }
 
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
+func toString(val any) string {
+	if val == nil {
+		return ""
+	}
+	if s, ok := val.(string); ok {
+		return strings.TrimSpace(s)
 	}
 	return ""
 }
@@ -142,11 +96,11 @@ func stripFrontMatter(data []byte) ([]byte, error) {
 	if !ok {
 		return nil, fmt.Errorf("unterminated YAML front matter")
 	}
-	delimiter = bytes.TrimSuffix(delimiter, []byte("\r"))
+	delimiter = bytes.TrimRight(delimiter, " \r\t")
 
 	for {
 		line, remaining, hasNewline := bytes.Cut(rest, []byte("\n"))
-		if bytes.Equal(bytes.TrimSuffix(line, []byte("\r")), delimiter) {
+		if bytes.Equal(bytes.TrimRight(line, " \r\t"), delimiter) {
 			return remaining, nil
 		}
 		if !hasNewline {
@@ -170,12 +124,50 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 	ctx := parser.NewContext()
 	doc := markdown.Parser().Parse(text.NewReader(data), parser.WithContext(ctx))
 	if frontMatterData := frontmatter.Get(ctx); frontMatterData != nil {
-		var parsed yamlFrontMatter
+		var parsed map[string]any
 		if err := frontMatterData.Decode(&parsed); err != nil {
 			return nil, nil, fmt.Errorf("decode YAML front matter: %w", err)
 		}
 
-		meta = parsed.meta()
+		meta = &Meta{}
+		meta.Type = "page" // Default type
+
+		for k, v := range parsed {
+			normKey := strings.ToLower(k)
+			normKey = strings.ReplaceAll(normKey, "-", "")
+			normKey = strings.ReplaceAll(normKey, "_", "")
+
+			switch normKey {
+			case "parents":
+				meta.Parents = append(meta.Parents, toStringSlice(v)...)
+			case "folders":
+				meta.Folders = append(meta.Folders, toStringSlice(v)...)
+			case "space":
+				meta.Space = toString(v)
+			case "type":
+				meta.Type = toString(v)
+			case "title":
+				meta.Title = toString(v)
+			case "layout":
+				meta.Layout = toString(v)
+			case "sidebar":
+				meta.Sidebar = toString(v)
+				if meta.Sidebar != "" {
+					meta.Layout = "article"
+				}
+			case "emoji":
+				meta.Emoji = toString(v)
+			case "attachments":
+				meta.Attachments = append(meta.Attachments, toStringSlice(v)...)
+			case "labels":
+				meta.Labels = append(meta.Labels, toStringSlice(v)...)
+			case "contentappearance":
+				setContentAppearance(meta, toString(v))
+			case "imagealign":
+				meta.ImageAlign = strings.ToLower(toString(v))
+			}
+		}
+
 		var err error
 		body, err = stripFrontMatter(data)
 		if err != nil {

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -187,11 +187,11 @@ image-align: center
 func TestExtractMetaYAMLFrontMatterScalarAliases(t *testing.T) {
 	markdown := `---
 space: DOCS
-parent: Parent
-folder: Folder
+parents: [ Parent ]
+folders: [ Folder ]
 title: Test Page
-attachment: image.png
-label: alpha
+attachments: [ image.png ]
+labels: [ alpha ]
 content_appearance: fixed
 image_align: right
 ---
@@ -275,7 +275,7 @@ title: YAML Title
 labels:
   - yaml
 ---
-<!-- Space: LEGACY -->
+<!-- Space: HTML -->
 <!-- Title: HTML Title -->
 <!-- Parent: Parent Page -->
 <!-- Label: html -->
@@ -284,12 +284,34 @@ labels:
 
 	meta, body, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", true)
 	assert.NoError(t, err)
-	assert.Equal(t, "LEGACY", meta.Space)
+	assert.Equal(t, "HTML", meta.Space)
 	assert.Equal(t, "HTML Title", meta.Title)
 	assert.Equal(t, []string{"Parent Page"}, meta.Parents)
 	assert.Equal(t, []string{"yaml", "html"}, meta.Labels)
 	assert.Equal(t, "# Content\n", string(body))
 }
+
+func TestExtractMetaYAMLFrontMatterSmartKeys(t *testing.T) {
+	markdown := `---
+SPACE: DOCS
+parents: [ "A Single Parent" ]
+Folders: [ "Folder A", "Folder B" ]
+Content_Appearance: fixed
+Image-Align: center
+---
+# Content
+`
+
+	meta, body, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", true)
+	assert.NoError(t, err)
+	assert.Equal(t, "DOCS", meta.Space)
+	assert.Equal(t, []string{"A Single Parent"}, meta.Parents)
+	assert.Equal(t, []string{"Folder A", "Folder B"}, meta.Folders)
+	assert.Equal(t, FixedContentAppearance, meta.ContentAppearance)
+	assert.Equal(t, "center", meta.ImageAlign)
+	assert.Equal(t, "# Content\n", string(body))
+}
+
 
 func TestExtractMetaYAMLFrontMatterWithoutTrailingNewline(t *testing.T) {
 	markdown := "---\nspace: DOCS\ntitle: Test Page\n---"

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -69,7 +69,7 @@ func TestExtractMetaContentAppearance(t *testing.T) {
 	t.Run("default fills missing content appearance", func(t *testing.T) {
 		data := []byte("<!-- Space: DOC -->\n<!-- Title: Example -->\n\nbody\n")
 
-		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, FixedContentAppearance)
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, FixedContentAppearance, false)
 		assert.NoError(t, err)
 		assert.NotNil(t, meta)
 		assert.Equal(t, FixedContentAppearance, meta.ContentAppearance)
@@ -78,7 +78,7 @@ func TestExtractMetaContentAppearance(t *testing.T) {
 	t.Run("header takes precedence over default", func(t *testing.T) {
 		data := []byte("<!-- Space: DOC -->\n<!-- Title: Example -->\n<!-- Content-Appearance: full-width -->\n\nbody\n")
 
-		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, FixedContentAppearance)
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, FixedContentAppearance, false)
 		assert.NoError(t, err)
 		assert.NotNil(t, meta)
 		assert.Equal(t, FullWidthContentAppearance, meta.ContentAppearance)
@@ -87,7 +87,7 @@ func TestExtractMetaContentAppearance(t *testing.T) {
 	t.Run("falls back to full-width when default isn't set", func(t *testing.T) {
 		data := []byte("<!-- Space: DOC -->\n<!-- Title: Example -->\n\nbody\n")
 
-		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, "")
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, "", false)
 		assert.NoError(t, err)
 		assert.NotNil(t, meta)
 		assert.Equal(t, FullWidthContentAppearance, meta.ContentAppearance)
@@ -96,7 +96,7 @@ func TestExtractMetaContentAppearance(t *testing.T) {
 	t.Run("default appearance via cli flag", func(t *testing.T) {
 		data := []byte("<!-- Space: DOC -->\n<!-- Title: Example -->\n\nbody\n")
 
-		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, DefaultContentAppearance)
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, DefaultContentAppearance, false)
 		assert.NoError(t, err)
 		assert.NotNil(t, meta)
 		assert.Equal(t, DefaultContentAppearance, meta.ContentAppearance)
@@ -105,11 +105,200 @@ func TestExtractMetaContentAppearance(t *testing.T) {
 	t.Run("default appearance via header", func(t *testing.T) {
 		data := []byte("<!-- Space: DOC -->\n<!-- Title: Example -->\n<!-- Content-Appearance: default -->\n\nbody\n")
 
-		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, "")
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, "", false)
 		assert.NoError(t, err)
 		assert.NotNil(t, meta)
 		assert.Equal(t, DefaultContentAppearance, meta.ContentAppearance)
 	})
+}
+
+func TestExtractMetaYAMLFrontMatterDisabled(t *testing.T) {
+	markdown := `---
+space: DOCS
+title: Test Page
+---
+# Content
+`
+
+	meta, body, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", false)
+	assert.NoError(t, err)
+	assert.Nil(t, meta)
+	assert.Equal(t, markdown, string(body))
+}
+
+func TestExtractMetaYAMLFrontMatterDoesNotEnableTOML(t *testing.T) {
+	markdown := `+++
+space = "DOCS"
+title = "Test Page"
++++
+# Content
+`
+
+	meta, body, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", true)
+	assert.NoError(t, err)
+	assert.Nil(t, meta)
+	assert.Equal(t, markdown, string(body))
+}
+
+func TestExtractMetaYAMLFrontMatter(t *testing.T) {
+	markdown := `---
+space: DOCS
+parents:
+  - Parent 1
+  - Parent 2
+folders:
+  - Folder 1
+  - Folder 2
+title: Test Page
+type: page
+layout: article
+sidebar: <p>Side</p>
+emoji: rocket
+attachments:
+  - image.png
+labels:
+  - alpha
+  - beta
+content-appearance: default
+image-align: center
+---
+# Content
+`
+
+	meta, body, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", true)
+	assert.NoError(t, err)
+	assert.Equal(t, &Meta{
+		Parents:           []string{"Parent 1", "Parent 2"},
+		Folders:           []string{"Folder 1", "Folder 2"},
+		Space:             "DOCS",
+		Type:              "page",
+		Title:             "Test Page",
+		Layout:            "article",
+		Sidebar:           "<p>Side</p>",
+		Emoji:             "rocket",
+		Attachments:       []string{"image.png"},
+		Labels:            []string{"alpha", "beta"},
+		ContentAppearance: DefaultContentAppearance,
+		ImageAlign:        "center",
+	}, meta)
+	assert.Equal(t, "# Content\n", string(body))
+}
+
+func TestExtractMetaYAMLFrontMatterScalarAliases(t *testing.T) {
+	markdown := `---
+space: DOCS
+parent: Parent
+folder: Folder
+title: Test Page
+attachment: image.png
+label: alpha
+content_appearance: fixed
+image_align: right
+---
+# Content
+`
+
+	meta, body, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", true)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"Parent"}, meta.Parents)
+	assert.Equal(t, []string{"Folder"}, meta.Folders)
+	assert.Equal(t, []string{"image.png"}, meta.Attachments)
+	assert.Equal(t, []string{"alpha"}, meta.Labels)
+	assert.Equal(t, FixedContentAppearance, meta.ContentAppearance)
+	assert.Equal(t, "right", meta.ImageAlign)
+	assert.Equal(t, "# Content\n", string(body))
+}
+
+func TestExtractMetaYAMLFrontMatterSidebarForcesArticleLayout(t *testing.T) {
+	markdown := `---
+space: DOCS
+title: Test Page
+layout: plain
+sidebar: <p>Side</p>
+---
+# Content
+`
+
+	meta, _, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", true)
+	assert.NoError(t, err)
+	assert.Equal(t, "article", meta.Layout)
+	assert.Equal(t, "<p>Side</p>", meta.Sidebar)
+}
+
+func TestExtractMetaYAMLFrontMatterAllowsExtraKeysAndFallbacks(t *testing.T) {
+	markdown := `---
+product:
+  - uks
+doc_type: explanation
+status: draft
+owner: []
+labels:
+  - k8s-docs
+---
+# Title From H1
+`
+
+	meta, body, err := ExtractMeta([]byte(markdown), "DOCS", true, false, "", nil, false, "", true)
+	assert.NoError(t, err)
+	assert.Equal(t, "DOCS", meta.Space)
+	assert.Equal(t, "Title From H1", meta.Title)
+	assert.Equal(t, "page", meta.Type)
+	assert.Equal(t, []string{"k8s-docs"}, meta.Labels)
+	assert.Equal(t, FullWidthContentAppearance, meta.ContentAppearance)
+	assert.Equal(t, "# Title From H1\n", string(body))
+}
+
+func TestExtractMetaYAMLFrontMatterDoesNotCloseOnIndentedDelimiter(t *testing.T) {
+	markdown := `---
+space: DOCS
+title: Test Page
+description: |
+  First paragraph.
+  ---
+  Second paragraph.
+labels:
+  - expected-label
+---
+# Content
+`
+
+	meta, body, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", true)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"expected-label"}, meta.Labels)
+	assert.Equal(t, "# Content\n", string(body))
+}
+
+func TestExtractMetaYAMLFrontMatterWithHTMLHeaders(t *testing.T) {
+	markdown := `---
+space: DOCS
+title: YAML Title
+labels:
+  - yaml
+---
+<!-- Space: LEGACY -->
+<!-- Title: HTML Title -->
+<!-- Parent: Parent Page -->
+<!-- Label: html -->
+# Content
+`
+
+	meta, body, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", true)
+	assert.NoError(t, err)
+	assert.Equal(t, "LEGACY", meta.Space)
+	assert.Equal(t, "HTML Title", meta.Title)
+	assert.Equal(t, []string{"Parent Page"}, meta.Parents)
+	assert.Equal(t, []string{"yaml", "html"}, meta.Labels)
+	assert.Equal(t, "# Content\n", string(body))
+}
+
+func TestExtractMetaYAMLFrontMatterWithoutTrailingNewline(t *testing.T) {
+	markdown := "---\nspace: DOCS\ntitle: Test Page\n---"
+
+	meta, body, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", true)
+	assert.NoError(t, err)
+	assert.Equal(t, "DOCS", meta.Space)
+	assert.Equal(t, "Test Page", meta.Title)
+	assert.Equal(t, "", string(body))
 }
 
 func TestExtractMeta_FolderHeaders(t *testing.T) {
@@ -203,7 +392,7 @@ func TestExtractMeta_FolderHeaders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			meta, _, err := ExtractMeta([]byte(tt.markdown), "", false, false, "", nil, false, "")
+			meta, _, err := ExtractMeta([]byte(tt.markdown), "", false, false, "", nil, false, "", false)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, meta)
 		})
@@ -219,7 +408,7 @@ func TestExtractMeta_FolderHeadersOrder(t *testing.T) {
 
 # Content`
 
-	meta, _, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "")
+	meta, _, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", false)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"First", "Second", "Third"}, meta.Folders)
 }
@@ -232,11 +421,10 @@ func TestExtractMeta_FolderHeadersWithCliParents(t *testing.T) {
 # Content`
 
 	cliParents := []string{"CLI Parent 1", "CLI Parent 2"}
-	meta, _, err := ExtractMeta([]byte(markdown), "", false, false, "", cliParents, false, "")
+	meta, _, err := ExtractMeta([]byte(markdown), "", false, false, "", cliParents, false, "", false)
 	assert.NoError(t, err)
 
 	// CLI parents should be prepended to any parents in the markdown, not folders
 	assert.Equal(t, cliParents, meta.Parents)
 	assert.Equal(t, []string{"API"}, meta.Folders)
 }
-

--- a/page/link.go
+++ b/page/link.go
@@ -38,6 +38,7 @@ func ResolveRelativeLinks(
 	titleFromFilename bool,
 	parents []string,
 	titleAppendGeneratedHash bool,
+	frontMatterEnabled bool,
 ) ([]LinkSubstitution, error) {
 	matches := parseLinks(string(markdown))
 
@@ -57,7 +58,7 @@ func ResolveRelativeLinks(
 				match.filename,
 				match.hash,
 			)
-		resolved, err := resolveLink(api, base, match, spaceForLinks, titleFromH1, titleFromFilename, parents, titleAppendGeneratedHash)
+		resolved, err := resolveLink(api, base, match, spaceForLinks, titleFromH1, titleFromFilename, parents, titleAppendGeneratedHash, frontMatterEnabled)
 		if err != nil {
 			return nil, fmt.Errorf("resolve link %q: %w", match.full, err)
 		}
@@ -84,6 +85,7 @@ func resolveLink(
 	titleFromFilename bool,
 	parents []string,
 	titleAppendGeneratedHash bool,
+	frontMatterEnabled bool,
 ) (string, error) {
 	var result string
 
@@ -120,7 +122,7 @@ func resolveLink(
 
 		// This helps to determine if found link points to file that's
 		// not markdown or have mark required metadata
-		linkMeta, _, err := metadata.ExtractMeta(linkContents, spaceForLinks, titleFromH1, titleFromFilename, filepath, parents, titleAppendGeneratedHash, "")
+		linkMeta, _, err := metadata.ExtractMeta(linkContents, spaceForLinks, titleFromH1, titleFromFilename, filepath, parents, titleAppendGeneratedHash, "", frontMatterEnabled)
 		if err != nil {
 			log.Error().
 				Err(err).

--- a/testdata/frontmatter-droph1.html
+++ b/testdata/frontmatter-droph1.html
@@ -1,0 +1,1 @@
+<p>Some body content.</p>

--- a/testdata/frontmatter.html
+++ b/testdata/frontmatter.html
@@ -1,0 +1,2 @@
+<h1 id="Page-Title">Page Title</h1>
+<p>Some body content.</p>

--- a/testdata/frontmatter.md
+++ b/testdata/frontmatter.md
@@ -1,0 +1,8 @@
+---
+space: DOCS
+title: Page Title
+parents: [ "Parent 1" ]
+---
+# Page Title
+
+Some body content.

--- a/util/flags.go
+++ b/util/flags.go
@@ -210,7 +210,7 @@ var Flags = []cli.Flag{
 	&cli.StringSliceFlag{
 		Name:    "features",
 		Value:   []string{"mermaid", "mention"},
-		Usage:   "Enables optional features. Current features: d2, mermaid, mention, mkdocsadmonitions, plantuml",
+		Usage:   "Enables optional features. Current features: d2, frontmatter, mermaid, mention, mkdocsadmonitions, plantuml",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_FEATURES"), altsrctoml.TOML("features", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.BoolFlag{


### PR DESCRIPTION
## Summary

This change adds YAML front matter as an alternative way to define Mark page metadata while preserving support for existing HTML metadata headers.

YAML front matter is opt-in through Mark's existing `--features` flag:

```shell
mark --features=mermaid --features=mention --features=frontmatter
```

Supported YAML fields include:

- Page location: `space`, `parent`, `parents`, `folder`, and `folders`
- Page identity: `title` and `type`
- Presentation: `layout`, `sidebar`, `emoji`, `content-appearance`, and `image-align`
- Publishing metadata: `attachment`, `attachments`, `label`, and `labels`

Singular fields accept scalar values and plural fields accept lists. Underscore aliases such as `content_appearance` and `image_align` are also accepted.

Unknown YAML fields are ignored, allowing repository-specific metadata to coexist with Mark metadata.

YAML front matter is parsed using `goldmark-frontmatter`, configured to use its built-in YAML format without enabling TOML front matter.

Front matter and existing HTML metadata headers are processed through a single Goldmark parse. Front matter is applied first when the feature is enabled, followed by legacy HTML headers. HTML headers override matching scalar front matter values, while repeatable parents, folders, attachments, and labels are appended.

Front matter is removed before Markdown compilation. Existing CLI fallbacks, title extraction, default page type, legacy HTML headers, attachments, and labels continue to work as before. The same feature setting is applied when Mark reads relatively linked Markdown documents to determine their Confluence title and space.

## Review Fixes

The implementation was updated in response to review feedback:

- Rebased the feature onto Mark's parser-based metadata extraction introduced by #808.
- Integrated front matter into the same Goldmark parse used for legacy HTML metadata and leading H1 extraction.
- Removed the standalone front matter parser and custom YAML unmarshaller.
- Uses `goldmark-frontmatter` with its built-in `frontmatter.YAML` format.
- Made YAML front matter opt-in through the existing `--features=frontmatter` mechanism.
- Configured the extension to recognize YAML without enabling TOML support.
- Applies front matter before legacy HTML headers so existing comment metadata can override matching scalar values.
- Preserves existing collection behavior by appending comment-based parents, folders, attachments, and labels to front matter values.
- Empty scalar and list values are trimmed and ignored.
- Front matter delimiters must begin at column zero. An indented `---` inside a YAML block scalar remains part of the scalar instead of prematurely closing the front matter.
- A non-empty YAML `sidebar` selects the `article` layout, ensuring sidebar content is rendered when `layout: plain` is also supplied.

## Validation

- Ran the complete local Go test suite, including the Chromium-based D2 and Mermaid tests.
- Ran race-enabled metadata and relative-link tests.
- Ran `go vet` and `golangci-lint` v2.12.2, matching the CI version, with zero issues.
- Compiled the same document using YAML front matter and equivalent legacy HTML headers, then verified that both produced byte-for-byte identical Confluence storage HTML.
- Verified that YAML front matter is parsed only when the `frontmatter` feature is enabled.
- Verified that disabled YAML front matter remains unchanged.
- Verified that enabling YAML front matter does not enable TOML parsing.
- Added regression coverage confirming that HTML metadata overrides matching scalar YAML values while labels are appended.
- Added regression coverage ensuring indented YAML delimiters remain part of block scalar content.
- Added regression coverage ensuring sidebar content selects the required article layout.
- Verified compatibility between YAML front matter and existing CLI fallbacks, title extraction, and relative-link resolution.
- Verified formatting and whitespace checks passed.