### PR TITLE
refactor: migrate metadata extraction to parser-based using goldmark

### DIFF
--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -94,7 +94,7 @@ func TestCompileMarkdownDropH1(t *testing.T) {
 		}
 		var variant string
 		switch filename {
-		case "testdata/quotes.md", "testdata/header.md", "testdata/admonitions.md", "testdata/plantuml.md":
+		case "testdata/quotes.md", "testdata/header.md", "testdata/admonitions.md", "testdata/plantuml.md", "testdata/codeblock-comments.md":
 			variant = "-droph1"
 		default:
 			variant = ""
@@ -137,7 +137,7 @@ func TestCompileMarkdownStripNewlines(t *testing.T) {
 		}
 		var variant string
 		switch filename {
-		case "testdata/quotes.md", "testdata/codes.md", "testdata/newlines.md", "testdata/macro-include.md", "testdata/admonitions.md", "testdata/mention.md":
+		case "testdata/quotes.md", "testdata/codes.md", "testdata/newlines.md", "testdata/macro-include.md", "testdata/admonitions.md", "testdata/mention.md", "testdata/codeblock-comments.md":
 			variant = "-stripnewlines"
 		default:
 			variant = ""

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -179,7 +179,7 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 		}
 
 		if titleFromH1 && meta.Title == "" {
-			meta.Title = ExtractDocumentLeadingH1(data)
+			meta.Title = ExtractDocumentLeadingH1(doc, data)
 		}
 		if titleFromFilename && meta.Title == "" && filename != "" {
 			setTitleFromFilename(meta, filename)
@@ -236,11 +236,7 @@ func setTitleFromFilename(meta *Meta, filename string) {
 }
 
 // ExtractDocumentLeadingH1 will extract leading H1 heading
-func ExtractDocumentLeadingH1(markdown []byte) string {
-	reader := text.NewReader(markdown)
-	parser := goldmark.DefaultParser()
-	doc := parser.Parse(reader)
-
+func ExtractDocumentLeadingH1(doc ast.Node, markdown []byte) string {
 	var h1Text string
 	// Walk the AST to find the first Level 1 Heading
 	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -52,10 +51,6 @@ const (
 	DefaultContentAppearance   = "default"
 )
 
-var (
-	reHeaderPatternV2 = regexp.MustCompile(`<!--\s*([^:]+):\s*(.*)\s*-->`)
-)
-
 func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFilename bool, filename string, parents []string, titleAppendGeneratedHash bool, defaultContentAppearance string) (*Meta, []byte, error) {
 	var (
 		meta   *Meta
@@ -82,8 +77,8 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 				lineSeg := lines.At(i)
 				line := string(lineSeg.Value(data))
 
-				matches := reHeaderPatternV2.FindStringSubmatch(line)
-				if matches == nil {
+				key, value, ok := parseHeaderComment(line)
+				if !ok {
 					shouldBreak = true
 					break
 				}
@@ -93,12 +88,7 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 					meta.Type = "page" // Default if not specified
 				}
 
-				header := cases.Title(language.English).String(matches[1])
-
-				var value string
-				if len(matches) > 2 {
-					value = strings.TrimSpace(matches[2])
-				}
+				header := cases.Title(language.English).String(key)
 
 				switch header {
 				case HeaderParent:
@@ -257,4 +247,25 @@ func ExtractDocumentLeadingH1(doc ast.Node, markdown []byte) string {
 	})
 
 	return h1Text
+}
+
+// parseHeaderComment checks if a line is a valid metadata header comment of the form "<!-- key: value -->".
+func parseHeaderComment(line string) (string, string, bool) {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "<!--") || !strings.HasSuffix(line, "-->") {
+		return "", "", false
+	}
+
+	// Strip "<!--" and "-->"
+	content := line[4 : len(line)-3]
+	content = strings.TrimSpace(content)
+
+	colonIdx := strings.Index(content, ":")
+	if colonIdx == -1 {
+		return "", "", false
+	}
+
+	key := strings.TrimSpace(content[:colonIdx])
+	value := strings.TrimSpace(content[colonIdx+1:])
+	return key, value, true
 }

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog/log"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -221,11 +224,28 @@ func setTitleFromFilename(meta *Meta, filename string) {
 
 // ExtractDocumentLeadingH1 will extract leading H1 heading
 func ExtractDocumentLeadingH1(markdown []byte) string {
-	h1 := regexp.MustCompile(`#[^#]\s*(.*)\s*\n`)
-	groups := h1.FindSubmatch(markdown)
-	if groups == nil {
-		return ""
-	} else {
-		return string(groups[1])
-	}
+	reader := text.NewReader(markdown)
+	parser := goldmark.DefaultParser()
+	doc := parser.Parse(reader)
+
+	var h1Text string
+	// Walk the AST to find the first Level 1 Heading
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering {
+			if heading, ok := n.(*ast.Heading); ok && heading.Level == 1 {
+				var buf strings.Builder
+				_ = ast.Walk(heading, func(child ast.Node, childEntering bool) (ast.WalkStatus, error) {
+					if childEntering && child.Kind() == ast.KindText {
+						buf.Write(child.(*ast.Text).Value(markdown))
+					}
+					return ast.WalkContinue, nil
+				})
+				h1Text = buf.String()
+				return ast.WalkStop, nil
+			}
+		}
+		return ast.WalkContinue, nil
+	})
+
+	return h1Text
 }

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -53,8 +53,7 @@ const (
 )
 
 var (
-	reHeaderPatternV2    = regexp.MustCompile(`<!--\s*([^:]+):\s*(.*)\s*-->`)
-	reHeaderPatternMacro = regexp.MustCompile(`<!-- Macro: .*`)
+	reHeaderPatternV2 = regexp.MustCompile(`<!--\s*([^:]+):\s*(.*)\s*-->`)
 )
 
 func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFilename bool, filename string, parents []string, titleAppendGeneratedHash bool, defaultContentAppearance string) (*Meta, []byte, error) {
@@ -85,7 +84,6 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 
 				matches := reHeaderPatternV2.FindStringSubmatch(line)
 				if matches == nil {
-					matches = reHeaderPatternMacro.FindStringSubmatch(line)
 					shouldBreak = true
 					break
 				}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -1,8 +1,6 @@
 package metadata
 
 import (
-	"bufio"
-	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"path/filepath"
@@ -65,96 +63,113 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 		offset int
 	)
 
-	scanner := bufio.NewScanner(bytes.NewBuffer(data))
-	for scanner.Scan() {
-		line := scanner.Text()
+	reader := text.NewReader(data)
+	parser := goldmark.DefaultParser()
+	doc := parser.Parse(reader)
 
-		offset += len(line) + 1
+	var lastStop int
+	shouldBreak := false
 
-		matches := reHeaderPatternV2.FindStringSubmatch(line)
-		if matches == nil {
-			matches = reHeaderPatternMacro.FindStringSubmatch(line)
-			// If we have a match, then we started reading a macro.
-			// We want to keep it in the document for it to be read by ExtractMacros
-			if matches != nil {
-				offset -= len(line) + 1
+	for child := doc.FirstChild(); child != nil; child = child.NextSibling() {
+		if htmlBlock, ok := child.(*ast.HTMLBlock); ok {
+			lines := htmlBlock.Lines()
+			if lines.Len() > 0 {
+				if lastStop > 0 && lines.At(0).Start != lastStop {
+					break
+				}
 			}
+
+			for i := 0; i < lines.Len(); i++ {
+				lineSeg := lines.At(i)
+				line := string(lineSeg.Value(data))
+
+				matches := reHeaderPatternV2.FindStringSubmatch(line)
+				if matches == nil {
+					matches = reHeaderPatternMacro.FindStringSubmatch(line)
+					shouldBreak = true
+					break
+				}
+
+				if meta == nil {
+					meta = &Meta{}
+					meta.Type = "page" // Default if not specified
+				}
+
+				header := cases.Title(language.English).String(matches[1])
+
+				var value string
+				if len(matches) > 2 {
+					value = strings.TrimSpace(matches[2])
+				}
+
+				switch header {
+				case HeaderParent:
+					meta.Parents = append(meta.Parents, value)
+
+				case HeaderFolder:
+					meta.Folders = append(meta.Folders, value)
+
+				case HeaderSpace:
+					meta.Space = strings.TrimSpace(value)
+
+				case HeaderType:
+					meta.Type = strings.TrimSpace(value)
+
+				case HeaderTitle:
+					meta.Title = strings.TrimSpace(value)
+
+				case HeaderLayout:
+					meta.Layout = strings.TrimSpace(value)
+
+				case HeaderSidebar:
+					meta.Layout = "article"
+					meta.Sidebar = strings.TrimSpace(value)
+
+				case HeaderEmoji:
+					meta.Emoji = strings.TrimSpace(value)
+
+				case HeaderAttachment:
+					meta.Attachments = append(meta.Attachments, value)
+
+				case HeaderLabel:
+					meta.Labels = append(meta.Labels, value)
+
+				case HeaderInclude:
+					// Includes are parsed by a different func
+					lastStop = lineSeg.Stop
+					continue
+
+				case ContentAppearance:
+					switch strings.TrimSpace(value) {
+					case FixedContentAppearance:
+						meta.ContentAppearance = FixedContentAppearance
+					case DefaultContentAppearance:
+						meta.ContentAppearance = DefaultContentAppearance
+					default:
+						meta.ContentAppearance = FullWidthContentAppearance
+					}
+
+				case HeaderImageAlign:
+					meta.ImageAlign = strings.ToLower(strings.TrimSpace(value))
+
+				default:
+					log.Error().
+						Err(nil).
+						Msgf(`encountered unknown header %q line: %#v`, header, line)
+				}
+
+				lastStop = lineSeg.Stop
+			}
+
+			if shouldBreak {
+				break
+			}
+		} else {
 			break
 		}
-
-		if meta == nil {
-			meta = &Meta{}
-			meta.Type = "page"                                  // Default if not specified
-		}
-
-		header := cases.Title(language.English).String(matches[1])
-
-		var value string
-		if len(matches) > 2 {
-			value = strings.TrimSpace(matches[2])
-		}
-
-		switch header {
-		case HeaderParent:
-			meta.Parents = append(meta.Parents, value)
-
-		case HeaderFolder:
-			meta.Folders = append(meta.Folders, value)
-
-		case HeaderSpace:
-			meta.Space = strings.TrimSpace(value)
-
-		case HeaderType:
-			meta.Type = strings.TrimSpace(value)
-
-		case HeaderTitle:
-			meta.Title = strings.TrimSpace(value)
-
-		case HeaderLayout:
-			meta.Layout = strings.TrimSpace(value)
-
-		case HeaderSidebar:
-			meta.Layout = "article"
-			meta.Sidebar = strings.TrimSpace(value)
-
-		case HeaderEmoji:
-			meta.Emoji = strings.TrimSpace(value)
-
-		case HeaderAttachment:
-			meta.Attachments = append(meta.Attachments, value)
-
-		case HeaderLabel:
-			meta.Labels = append(meta.Labels, value)
-
-		case HeaderInclude:
-			// Includes are parsed by a different func
-			continue
-
-		case ContentAppearance:
-			switch strings.TrimSpace(value) {
-			case FixedContentAppearance:
-				meta.ContentAppearance = FixedContentAppearance
-			case DefaultContentAppearance:
-				meta.ContentAppearance = DefaultContentAppearance
-			default:
-				meta.ContentAppearance = FullWidthContentAppearance
-			}
-
-		case HeaderImageAlign:
-			meta.ImageAlign = strings.ToLower(strings.TrimSpace(value))
-
-		default:
-			log.Error().
-				Err(nil).
-				Msgf(`encountered unknown header %q line: %#v`, header, line)
-
-			continue
-		}
 	}
 
-	if err := scanner.Err(); err != nil {
-		return nil, nil, err
-	}
+	offset = lastStop
 
 	if titleFromH1 || titleFromFilename || spaceFromCli != "" {
 		if meta == nil {

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/text"
 )
 
 func TestExtractDocumentLeadingH1(t *testing.T) {
@@ -24,7 +26,10 @@ func TestExtractDocumentLeadingH1(t *testing.T) {
 		panic(err)
 	}
 
-	actual := ExtractDocumentLeadingH1(markdown)
+	reader := text.NewReader(markdown)
+	parser := goldmark.DefaultParser()
+	doc := parser.Parse(reader)
+	actual := ExtractDocumentLeadingH1(doc, markdown)
 
 	assert.Equal(t, "a", actual)
 }
@@ -247,7 +252,10 @@ echo "Hello World"
 # Actual H1 Heading with **bold** formatting
 `)
 
-	actual := ExtractDocumentLeadingH1(markdown)
+	reader := text.NewReader(markdown)
+	parser := goldmark.DefaultParser()
+	doc := parser.Parse(reader)
+	actual := ExtractDocumentLeadingH1(doc, markdown)
 	assert.Equal(t, "Actual H1 Heading with bold formatting", actual)
 }
 

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -234,3 +234,20 @@ func TestExtractMeta_FolderHeadersWithCliParents(t *testing.T) {
 	assert.Equal(t, cliParents, meta.Parents)
 	assert.Equal(t, []string{"API"}, meta.Folders)
 }
+
+func TestExtractDocumentLeadingH1_WithCodeBlockComments(t *testing.T) {
+	markdown := []byte(`
+Some introductory text.
+
+` + "```" + `bash
+# This is a bash comment
+echo "Hello World"
+` + "```" + `
+
+# Actual H1 Heading with **bold** formatting
+`)
+
+	actual := ExtractDocumentLeadingH1(markdown)
+	assert.Equal(t, "Actual H1 Heading with bold formatting", actual)
+}
+

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -240,22 +240,3 @@ func TestExtractMeta_FolderHeadersWithCliParents(t *testing.T) {
 	assert.Equal(t, []string{"API"}, meta.Folders)
 }
 
-func TestExtractDocumentLeadingH1_WithCodeBlockComments(t *testing.T) {
-	markdown := []byte(`
-Some introductory text.
-
-` + "```" + `bash
-# This is a bash comment
-echo "Hello World"
-` + "```" + `
-
-# Actual H1 Heading with **bold** formatting
-`)
-
-	reader := text.NewReader(markdown)
-	parser := goldmark.DefaultParser()
-	doc := parser.Parse(reader)
-	actual := ExtractDocumentLeadingH1(doc, markdown)
-	assert.Equal(t, "Actual H1 Heading with bold formatting", actual)
-}
-

--- a/testdata/codeblock-comments-droph1.html
+++ b/testdata/codeblock-comments-droph1.html
@@ -1,0 +1,3 @@
+<p>Some introductory text.</p>
+<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">bash</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[# This is a bash comment
+echo "Hello World"]]></ac:plain-text-body></ac:structured-macro>

--- a/testdata/codeblock-comments-stripnewlines.html
+++ b/testdata/codeblock-comments-stripnewlines.html
@@ -1,0 +1,3 @@
+<p>Some introductory text.</p>
+<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">bash</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[# This is a bash comment
+echo "Hello World"]]></ac:plain-text-body></ac:structured-macro><h1 id="Actual-H1-Heading-with-bold-formatting">Actual H1 Heading with <strong>bold</strong> formatting</h1>

--- a/testdata/codeblock-comments.html
+++ b/testdata/codeblock-comments.html
@@ -1,0 +1,3 @@
+<p>Some introductory text.</p>
+<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">bash</ac:parameter><ac:parameter ac:name="collapse">false</ac:parameter><ac:plain-text-body><![CDATA[# This is a bash comment
+echo "Hello World"]]></ac:plain-text-body></ac:structured-macro><h1 id="Actual-H1-Heading-with-bold-formatting">Actual H1 Heading with <strong>bold</strong> formatting</h1>

--- a/testdata/codeblock-comments.md
+++ b/testdata/codeblock-comments.md
@@ -1,0 +1,8 @@
+Some introductory text.
+
+```bash
+# This is a bash comment
+echo "Hello World"
+```
+
+# Actual H1 Heading with **bold** formatting


### PR DESCRIPTION
This PR migrates metadata and H1 extraction from regular expressions to a parser-based implementation using Goldmark and clean string manipulations.

### Changes
1. **Parser-Based Metadata Extraction**: Replaced line-by-line regex scanning in `ExtractMeta` with Goldmark AST traversal of `ast.HTMLBlock` nodes.
2. **String Manipulation Header Parsing**: Completely removed `reHeaderPatternV2` and `reHeaderPatternMacro` regular expressions in favor of simple, fast, and robust string matching (`strings.HasPrefix`, `strings.HasSuffix`, `strings.Index`) to parse key-value pairs out of header comments.
3. **Robust H1 Extraction**: Replaced regex in `ExtractDocumentLeadingH1` with Goldmark AST traversal to prevent comments inside code blocks (e.g. bash, Python, YAML comments) from being identified as H1 headings.
4. **AST Node Reuse**: Optimized the H1 extraction to reuse the AST document parsed during metadata extraction, avoiding duplicate parsing of the document content.
5. **Integration Tests**: Added a new test case `codeblock-comments.md` under `testdata` with variants for `DropFirstH1` and `StripNewlines` configurations.
