### PR TITLE
perf: reuse headless Chrome session across diagram rendering blocks

### DIFF
--- a/d2/d2.go
+++ b/d2/d2.go
@@ -123,17 +123,21 @@ func getChromeCtx(ctx context.Context) (context.Context, error) {
 		)
 	}
 
-	allocCtx, _ := chromedp.NewExecAllocator(context.Background(), opts...)
+	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), opts...)
 	cCtx, cCancel := chromedp.NewContext(allocCtx)
 
 	err := chromedp.Run(cCtx)
 	if err != nil {
 		cCancel()
+		allocCancel()
 		return nil, err
 	}
 
 	chromeCtx = cCtx
-	chromeCtxCancel = cCancel
+	chromeCtxCancel = func() {
+		cCancel()
+		allocCancel()
+	}
 	return chromeCtx, nil
 }
 

--- a/d2/d2.go
+++ b/d2/d2.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/chromedp/cdproto/dom"
@@ -97,16 +98,22 @@ func ProcessD2(title string, d2Diagram []byte, scale float64) (attachment.Attach
 	}, nil
 }
 
-func convertSVGtoPNG(ctx context.Context, svg []byte, scale float64) (png []byte, m *dom.BoxModel, err error) {
-	var (
-		result []byte
-		model  *dom.BoxModel
-	)
+var (
+	chromeCtx       context.Context
+	chromeCtxCancel context.CancelFunc
+	chromeMutex     sync.Mutex
+)
 
-	// Create browser options - more conservative for CI environments
+func getChromeCtx(ctx context.Context) (context.Context, error) {
+	chromeMutex.Lock()
+	defer chromeMutex.Unlock()
+
+	if chromeCtx != nil {
+		return chromeCtx, nil
+	}
+
 	opts := chromedp.DefaultExecAllocatorOptions[:]
 	if os.Getenv("GITHUB_ACTIONS") == "true" {
-		// Enhanced options for CI environment
 		opts = append(opts,
 			chromedp.DisableGPU,
 			chromedp.NoSandbox,
@@ -116,13 +123,35 @@ func convertSVGtoPNG(ctx context.Context, svg []byte, scale float64) (png []byte
 		)
 	}
 
-	allocCtx, cancel1 := chromedp.NewExecAllocator(ctx, opts...)
-	defer cancel1()
+	allocCtx, _ := chromedp.NewExecAllocator(context.Background(), opts...)
+	cCtx, cCancel := chromedp.NewContext(allocCtx)
 
-	ctx, cancel := chromedp.NewContext(allocCtx)
-	defer cancel()
+	err := chromedp.Run(cCtx)
+	if err != nil {
+		cCancel()
+		return nil, err
+	}
 
-	err = chromedp.Run(ctx,
+	chromeCtx = cCtx
+	chromeCtxCancel = cCancel
+	return chromeCtx, nil
+}
+
+func convertSVGtoPNG(ctx context.Context, svg []byte, scale float64) (png []byte, m *dom.BoxModel, err error) {
+	var (
+		result []byte
+		model  *dom.BoxModel
+	)
+
+	cCtx, err := getChromeCtx(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	runCtx, runCancel := context.WithTimeout(cCtx, renderTimeout)
+	defer runCancel()
+
+	err = chromedp.Run(runCtx,
 		chromedp.Navigate(fmt.Sprintf("data:image/svg+xml;base64,%s", base64.StdEncoding.EncodeToString(svg))),
 		chromedp.ScreenshotScale(`document.querySelector("svg > svg")`, scale, &result, chromedp.ByJSPath),
 		chromedp.Dimensions(`document.querySelector("svg > svg")`, &model, chromedp.ByJSPath),
@@ -131,4 +160,15 @@ func convertSVGtoPNG(ctx context.Context, svg []byte, scale float64) (png []byte
 		return nil, nil, err
 	}
 	return result, model, err
+}
+
+func Cleanup() {
+	chromeMutex.Lock()
+	defer chromeMutex.Unlock()
+
+	if chromeCtxCancel != nil {
+		chromeCtxCancel()
+		chromeCtx = nil
+		chromeCtxCancel = nil
+	}
 }

--- a/mark.go
+++ b/mark.go
@@ -19,9 +19,11 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/kovetskiy/mark/v16/attachment"
 	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/d2"
 	"github.com/kovetskiy/mark/v16/includes"
 	"github.com/kovetskiy/mark/v16/macro"
 	markmd "github.com/kovetskiy/mark/v16/markdown"
+	"github.com/kovetskiy/mark/v16/mermaid"
 	"github.com/kovetskiy/mark/v16/metadata"
 	"github.com/kovetskiy/mark/v16/page"
 	"github.com/kovetskiy/mark/v16/stdlib"
@@ -898,4 +900,10 @@ func mergeComments(newBody string, oldBody string, comments *confluence.InlineCo
 	}
 
 	return newBody, nil
+}
+
+// Cleanup closes any shared resources (such as headless Chrome sessions).
+func Cleanup() {
+	d2.Cleanup()
+	mermaid.Cleanup()
 }

--- a/mermaid/mermaid.go
+++ b/mermaid/mermaid.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"fmt"
 	"math"
 	"strconv"
 	"sync"
+	"time"
 
 	mermaid "github.com/dreampuf/mermaid.go"
 	"github.com/kovetskiy/mark/v16/attachment"
@@ -35,6 +37,18 @@ func getMermaidEngine() (*mermaid.RenderEngine, error) {
 	return mermaidEngine, nil
 }
 
+var renderTimeout = 120 * time.Second
+
+func resetEngine() {
+	mermaidMutex.Lock()
+	defer mermaidMutex.Unlock()
+
+	if mermaidEngine != nil {
+		mermaidEngine.Cancel()
+		mermaidEngine = nil
+	}
+}
+
 func ProcessMermaidLocally(title string, mermaidDiagram []byte, scale float64) (attachment.Attachment, error) {
 	renderer, err := getMermaidEngine()
 	if err != nil {
@@ -42,9 +56,33 @@ func ProcessMermaidLocally(title string, mermaidDiagram []byte, scale float64) (
 	}
 
 	log.Debug().Msgf("Rendering: %q", title)
-	pngBytes, boxModel, err := renderer.RenderAsScaledPng(string(mermaidDiagram), scale)
-	if err != nil {
-		return attachment.Attachment{}, err
+
+	type renderResult struct {
+		pngBytes []byte
+		boxModel *mermaid.BoxModel
+		err      error
+	}
+
+	ch := make(chan renderResult, 1)
+	go func() {
+		pngBytes, boxModel, err := renderer.RenderAsScaledPng(string(mermaidDiagram), scale)
+		ch <- renderResult{pngBytes, boxModel, err}
+	}()
+
+	var pngBytes []byte
+	var boxModel *mermaid.BoxModel
+
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			return attachment.Attachment{}, res.err
+		}
+		pngBytes = res.pngBytes
+		boxModel = res.boxModel
+	case <-time.After(renderTimeout):
+		log.Error().Msgf("Mermaid rendering timed out after %v, resetting engine", renderTimeout)
+		resetEngine()
+		return attachment.Attachment{}, fmt.Errorf("mermaid rendering timed out after %v", renderTimeout)
 	}
 
 	scaleAsBytes := make([]byte, 8)

--- a/mermaid/mermaid.go
+++ b/mermaid/mermaid.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"math"
 	"strconv"
+	"sync"
 	"time"
 
 	mermaid "github.com/dreampuf/mermaid.go"
@@ -15,17 +16,33 @@ import (
 
 var renderTimeout = 120 * time.Second
 
+var (
+	mermaidEngine *mermaid.RenderEngine
+	mermaidMutex  sync.Mutex
+)
+
+func getMermaidEngine() (*mermaid.RenderEngine, error) {
+	mermaidMutex.Lock()
+	defer mermaidMutex.Unlock()
+
+	if mermaidEngine != nil {
+		return mermaidEngine, nil
+	}
+
+	log.Debug().Msg("Setting up global Mermaid renderer")
+	engine, err := mermaid.NewRenderEngine(context.Background(), nil)
+	if err != nil {
+		return nil, err
+	}
+	mermaidEngine = engine
+	return mermaidEngine, nil
+}
+
 func ProcessMermaidLocally(title string, mermaidDiagram []byte, scale float64) (attachment.Attachment, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), renderTimeout)
-	defer cancel()
-
-	log.Debug().Msgf("Setting up Mermaid renderer: %q", title)
-	renderer, err := mermaid.NewRenderEngine(ctx, nil)
-
+	renderer, err := getMermaidEngine()
 	if err != nil {
 		return attachment.Attachment{}, err
 	}
-	defer renderer.Cancel()
 
 	log.Debug().Msgf("Rendering: %q", title)
 	pngBytes, boxModel, err := renderer.RenderAsScaledPng(string(mermaidDiagram), scale)
@@ -61,4 +78,14 @@ func ProcessMermaidLocally(title string, mermaidDiagram []byte, scale float64) (
 		Width:     strconv.FormatInt(boxModel.Width, 10),
 		Height:    strconv.FormatInt(boxModel.Height, 10),
 	}, nil
+}
+
+func Cleanup() {
+	mermaidMutex.Lock()
+	defer mermaidMutex.Unlock()
+
+	if mermaidEngine != nil {
+		mermaidEngine.Cancel()
+		mermaidEngine = nil
+	}
 }

--- a/mermaid/mermaid.go
+++ b/mermaid/mermaid.go
@@ -7,14 +7,11 @@ import (
 	"math"
 	"strconv"
 	"sync"
-	"time"
 
 	mermaid "github.com/dreampuf/mermaid.go"
 	"github.com/kovetskiy/mark/v16/attachment"
 	"github.com/rs/zerolog/log"
 )
-
-var renderTimeout = 120 * time.Second
 
 var (
 	mermaidEngine *mermaid.RenderEngine

--- a/util/cli.go
+++ b/util/cli.go
@@ -128,6 +128,7 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 		Output: os.Stdout,
 	}
 
+	defer mark.Cleanup()
 	return mark.Run(config)
 }
 


### PR DESCRIPTION
This PR optimizes rendering performance for D2 and Mermaid diagram blocks by reusing a single headless Chrome session/context across all compiles rather than spawning new browser processes sequentially for every diagram.

### Problem
Previously:
1. **D2**: `convertSVGtoPNG` in `d2.go` spawned a new Chrome process via chromedp on every single D2 diagram render.
2. **Mermaid**: `ProcessMermaidLocally` in `mermaid.go` instantiated a new rendering engine (launching headless Puppeteer/Chrome underneath) on every single Mermaid render.

OS-level process initialization of Chrome is extremely heavy. Pages containing multiple diagrams would sequentially spawn and shut down multiple browser processes, adding several seconds or minutes to compilation times.

### Solution
* **D2**: Implemented a lazy-initialized global `chromeCtx` and `chromeCtxCancel` inside `d2.go`. Individual D2 block compiles derive child contexts with timeouts from this single parent context, preventing redundant Chrome startups.
* **Mermaid**: Implemented a lazy-initialized global `mermaidEngine` in `mermaid.go` using a persistent background context.
* **Cleanup**: Exposed a `Cleanup()` function in both modules, aggregated under `mark.Cleanup()` in `mark.go`. This is deferred in `RunMark` in `util/cli.go` to cleanly terminate browser instances on CLI exit.
