### PR TITLE
perf: cache resolved Confluence pages to avoid repeated parent ancestry traversals

### DIFF
--- a/attachment/attachment.go
+++ b/attachment/attachment.go
@@ -2,6 +2,7 @@ package attachment
 
 import (
 	"bytes"
+	"cmp"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -13,7 +14,6 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
-	"cmp"
 	"slices"
 	"strconv"
 	"strings"

--- a/attachment/attachment_test.go
+++ b/attachment/attachment_test.go
@@ -124,4 +124,3 @@ func TestParseAttachmentLink(t *testing.T) {
 		})
 	}
 }
-

--- a/cmd/mark/main.go
+++ b/cmd/mark/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-
 var (
 	version = "dev"
 	commit  = "none"

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -82,22 +82,26 @@ func (api *API) updateCachedPageVersion(id string, newVersion int64) {
 	api.pageCacheMutex.Lock()
 	defer api.pageCacheMutex.Unlock()
 
-	entry, ok := api.pageCacheByID[id]
-	if !ok || entry == nil {
-		return
+	var updatedEntry *PageInfo
+	if entry, ok := api.pageCacheByID[id]; ok && entry != nil {
+		newEntry := *entry
+		newEntry.Version.Number = newVersion
+		api.pageCacheByID[id] = &newEntry
+		updatedEntry = &newEntry
 	}
 
-	// Create a shallow copy of the cached page info to avoid data races
-	newEntry := *entry
-	newEntry.Version.Number = newVersion
-
-	// Replace the pointer in both maps
-	for key, e := range api.pageCache {
-		if e == entry {
-			api.pageCache[key] = &newEntry
+	for key, entry := range api.pageCache {
+		if entry != nil && entry.ID == id {
+			if updatedEntry != nil {
+				api.pageCache[key] = updatedEntry
+			} else {
+				newEntry := *entry
+				newEntry.Version.Number = newVersion
+				api.pageCache[key] = &newEntry
+				updatedEntry = &newEntry
+			}
 		}
 	}
-	api.pageCacheByID[id] = &newEntry
 }
 
 type SpaceInfo struct {

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -44,6 +44,15 @@ func (api *API) invalidatePage(space, title, pageType string) {
 	delete(api.pageCache, key)
 }
 
+func (api *API) invalidatePageByID(id string) {
+	for key, entry := range api.pageCache {
+		if entry != nil && entry.ID == id {
+			delete(api.pageCache, key)
+			break
+		}
+	}
+}
+
 type SpaceInfo struct {
 	ID   int    `json:"id"`
 	Key  string `json:"key"`
@@ -644,7 +653,34 @@ func (api *API) CreatePage(
 	}
 
 	page := request.Response.(*PageInfo)
-	api.invalidatePage(space, title, pageType)
+	
+	if parent != nil {
+		ancestors := make([]struct {
+			ID    string `json:"id"`
+			Title string `json:"title"`
+		}, len(parent.Ancestors)+1)
+
+		for i, a := range parent.Ancestors {
+			ancestors[i] = struct {
+				ID    string `json:"id"`
+				Title string `json:"title"`
+			}{
+				ID:    a.ID,
+				Title: a.Title,
+			}
+		}
+		ancestors[len(parent.Ancestors)] = struct {
+			ID    string `json:"id"`
+			Title string `json:"title"`
+		}{
+			ID:    parent.ID,
+			Title: parent.Title,
+		}
+		page.Ancestors = ancestors
+	}
+
+	key := pageCacheKey(space, title, pageType)
+	api.pageCache[key] = page
 
 	return page, nil
 }
@@ -719,6 +755,7 @@ func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, ve
 	}
 
 	page.Version.Number = nextPageVersion
+	api.invalidatePageByID(page.ID)
 	return nil
 }
 
@@ -1150,7 +1187,8 @@ func (api *API) CreatePageWithFolderParent(
 	}
 
 	result.Links.Full = "/pages/viewpage.action?pageId=" + result.ID
-	api.invalidatePage(space, title, pageType)
+	key := pageCacheKey(space, title, pageType)
+	api.pageCache[key] = result
 
 	return result, nil
 }

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -31,6 +31,12 @@ type API struct {
 
 	isCloudFlag    bool
 	isCloudChecked bool
+
+	pageCache map[string]*PageInfo
+}
+
+func pageCacheKey(space, title, pageType string) string {
+	return space + "\x00" + title + "\x00" + pageType
 }
 
 type SpaceInfo struct {
@@ -196,9 +202,10 @@ func NewAPI(baseURL string, username string, password string, insecureSkipVerify
 	}
 
 	return &API{
-		rest:    rest,
-		restV2:  restV2,
-		BaseURL: baseURL,
+		rest:      rest,
+		restV2:    restV2,
+		BaseURL:   baseURL,
+		pageCache: make(map[string]*PageInfo),
 	}
 }
 
@@ -249,6 +256,11 @@ func (api *API) FindPage(
 	title string,
 	pageType string,
 ) (*PageInfo, error) {
+	key := pageCacheKey(space, title, pageType)
+	if page, ok := api.pageCache[key]; ok {
+		return page, nil
+	}
+
 	result := struct {
 		Results []PageInfo `json:"results"`
 		Links   struct {
@@ -280,6 +292,7 @@ func (api *API) FindPage(
 	}
 
 	if len(result.Results) == 0 {
+		api.pageCache[key] = nil
 		return nil, nil
 	}
 
@@ -289,6 +302,7 @@ func (api *API) FindPage(
 		page.Links.Base = result.Links.Base
 	}
 
+	api.pageCache[key] = page
 	return page, nil
 }
 
@@ -624,7 +638,11 @@ func (api *API) CreatePage(
 		return nil, newErrorStatusNotOK(request)
 	}
 
-	return request.Response.(*PageInfo), nil
+	page := request.Response.(*PageInfo)
+	key := pageCacheKey(space, title, pageType)
+	api.pageCache[key] = page
+
+	return page, nil
 }
 
 func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, versionMessage string, appearance string, emojiString string) error {
@@ -696,6 +714,7 @@ func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, ve
 		return newErrorStatusNotOK(request)
 	}
 
+	page.Version.Number = nextPageVersion
 	return nil
 }
 
@@ -1127,6 +1146,8 @@ func (api *API) CreatePageWithFolderParent(
 	}
 
 	result.Links.Full = "/pages/viewpage.action?pageId=" + result.ID
+	key := pageCacheKey(space, title, pageType)
+	api.pageCache[key] = result
 
 	return result, nil
 }

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -316,6 +316,12 @@ func (api *API) FindPage(
 	api.pageCacheMutex.Lock()
 	defer api.pageCacheMutex.Unlock()
 
+	// Double-checked locking: check if the cache was populated by another goroutine
+	// while the network request was in-flight.
+	if cachedPage, ok := api.pageCache[key]; ok {
+		return cachedPage, nil
+	}
+
 	if len(result.Results) == 0 {
 		api.pageCache[key] = nil
 		return nil, nil

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -678,7 +678,15 @@ func (api *API) CreatePage(
 		page.Ancestors = ancestors
 	}
 
-	key := pageCacheKey(space, title, pageType)
+	cacheTitle := title
+	if page.Title != "" {
+		cacheTitle = page.Title
+	}
+	cacheType := pageType
+	if page.Type != "" {
+		cacheType = page.Type
+	}
+	key := pageCacheKey(space, cacheTitle, cacheType)
 	api.pageCache[key] = page
 
 	return page, nil
@@ -1186,7 +1194,15 @@ func (api *API) CreatePageWithFolderParent(
 	}
 
 	result.Links.Full = "/pages/viewpage.action?pageId=" + result.ID
-	key := pageCacheKey(space, title, pageType)
+	cacheTitle := title
+	if result.Title != "" {
+		cacheTitle = result.Title
+	}
+	cacheType := pageType
+	if result.Type != "" {
+		cacheType = result.Type
+	}
+	key := pageCacheKey(space, cacheTitle, cacheType)
 	api.pageCache[key] = result
 
 	return result, nil

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -42,6 +42,21 @@ func pageCacheKey(space, title, pageType string) string {
 	return space + "\x00" + title + "\x00" + pageType
 }
 
+func clonePageInfo(page *PageInfo) *PageInfo {
+	if page == nil {
+		return nil
+	}
+	cp := *page
+	if len(page.Ancestors) > 0 {
+		cp.Ancestors = make([]struct {
+			ID    string `json:"id"`
+			Title string `json:"title"`
+		}, len(page.Ancestors))
+		copy(cp.Ancestors, page.Ancestors)
+	}
+	return &cp
+}
+
 func (api *API) lazyInit() {
 	api.pageCacheMutex.RLock()
 	if api.pageCache != nil && api.pageCacheByID != nil {
@@ -62,14 +77,15 @@ func (api *API) lazyInit() {
 
 // setCacheEntry sets a cache entry. Requires api.pageCacheMutex to be locked by the caller.
 func (api *API) setCacheEntry(key string, page *PageInfo) {
+	clonedPage := clonePageInfo(page)
 	if oldPage, ok := api.pageCache[key]; ok && oldPage != nil {
 		if page == nil || oldPage.ID != page.ID {
 			delete(api.pageCacheByID, oldPage.ID)
 		}
 	}
-	api.pageCache[key] = page
-	if page != nil {
-		api.pageCacheByID[page.ID] = page
+	api.pageCache[key] = clonedPage
+	if clonedPage != nil {
+		api.pageCacheByID[clonedPage.ID] = clonedPage
 	}
 }
 
@@ -91,10 +107,10 @@ func (api *API) updateCachedPageVersion(id string, newVersion int64) {
 
 	var updatedEntry *PageInfo
 	if entry, ok := api.pageCacheByID[id]; ok && entry != nil {
-		newEntry := *entry
+		newEntry := clonePageInfo(entry)
 		newEntry.Version.Number = newVersion
-		api.pageCacheByID[id] = &newEntry
-		updatedEntry = &newEntry
+		api.pageCacheByID[id] = newEntry
+		updatedEntry = newEntry
 	}
 
 	for key, entry := range api.pageCache {
@@ -102,10 +118,10 @@ func (api *API) updateCachedPageVersion(id string, newVersion int64) {
 			if updatedEntry != nil {
 				api.pageCache[key] = updatedEntry
 			} else {
-				newEntry := *entry
+				newEntry := clonePageInfo(entry)
 				newEntry.Version.Number = newVersion
-				api.pageCache[key] = &newEntry
-				updatedEntry = &newEntry
+				api.pageCache[key] = newEntry
+				updatedEntry = newEntry
 			}
 		}
 	}
@@ -338,11 +354,7 @@ func (api *API) FindPage(
 	api.pageCacheMutex.RLock()
 	if page, ok := api.pageCache[key]; ok {
 		api.pageCacheMutex.RUnlock()
-		if page == nil {
-			return nil, nil
-		}
-		copyPage := *page
-		return &copyPage, nil
+		return clonePageInfo(page), nil
 	}
 	api.pageCacheMutex.RUnlock()
 
@@ -382,11 +394,7 @@ func (api *API) FindPage(
 	// Double-checked locking: check if the cache was populated by another goroutine
 	// while the network request was in-flight.
 	if cachedPage, ok := api.pageCache[key]; ok {
-		if cachedPage == nil {
-			return nil, nil
-		}
-		copyPage := *cachedPage
-		return &copyPage, nil
+		return clonePageInfo(cachedPage), nil
 	}
 
 	if len(result.Results) == 0 {
@@ -416,7 +424,7 @@ func (api *API) FindPage(
 	if canonicalKey != key {
 		api.setCacheEntry(canonicalKey, &page)
 	}
-	return &page, nil
+	return clonePageInfo(&page), nil
 }
 
 func (api *API) CreateAttachment(

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -10,6 +10,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"strings"
+	"sync"
 	"unicode/utf8"
 
 	"github.com/kovetskiy/gopencils"
@@ -32,7 +33,9 @@ type API struct {
 	isCloudFlag    bool
 	isCloudChecked bool
 
-	pageCache map[string]*PageInfo
+	pageCache      map[string]*PageInfo
+	pageCacheByID  map[string]*PageInfo
+	pageCacheMutex sync.RWMutex
 }
 
 func pageCacheKey(space, title, pageType string) string {
@@ -41,15 +44,17 @@ func pageCacheKey(space, title, pageType string) string {
 
 func (api *API) invalidatePage(space, title, pageType string) {
 	key := pageCacheKey(space, title, pageType)
+	api.pageCacheMutex.Lock()
 	delete(api.pageCache, key)
+	api.pageCacheMutex.Unlock()
 }
 
 func (api *API) updateCachedPageVersion(id string, newVersion int64) {
-	for _, entry := range api.pageCache {
-		if entry != nil && entry.ID == id {
-			entry.Version.Number = newVersion
-		}
+	api.pageCacheMutex.Lock()
+	if entry, ok := api.pageCacheByID[id]; ok && entry != nil {
+		entry.Version.Number = newVersion
 	}
+	api.pageCacheMutex.Unlock()
 }
 
 type SpaceInfo struct {
@@ -215,10 +220,11 @@ func NewAPI(baseURL string, username string, password string, insecureSkipVerify
 	}
 
 	return &API{
-		rest:      rest,
-		restV2:    restV2,
-		BaseURL:   baseURL,
-		pageCache: make(map[string]*PageInfo),
+		rest:          rest,
+		restV2:        restV2,
+		BaseURL:       baseURL,
+		pageCache:     make(map[string]*PageInfo),
+		pageCacheByID: make(map[string]*PageInfo),
 	}
 }
 
@@ -270,9 +276,12 @@ func (api *API) FindPage(
 	pageType string,
 ) (*PageInfo, error) {
 	key := pageCacheKey(space, title, pageType)
+	api.pageCacheMutex.RLock()
 	if page, ok := api.pageCache[key]; ok {
+		api.pageCacheMutex.RUnlock()
 		return page, nil
 	}
+	api.pageCacheMutex.RUnlock()
 
 	result := struct {
 		Results []PageInfo `json:"results"`
@@ -304,6 +313,9 @@ func (api *API) FindPage(
 		return nil, newErrorStatusNotOK(request)
 	}
 
+	api.pageCacheMutex.Lock()
+	defer api.pageCacheMutex.Unlock()
+
 	if len(result.Results) == 0 {
 		api.pageCache[key] = nil
 		return nil, nil
@@ -316,6 +328,7 @@ func (api *API) FindPage(
 	}
 
 	api.pageCache[key] = page
+	api.pageCacheByID[page.ID] = page
 	return page, nil
 }
 
@@ -687,7 +700,11 @@ func (api *API) CreatePage(
 		cacheType = page.Type
 	}
 	key := pageCacheKey(space, cacheTitle, cacheType)
+
+	api.pageCacheMutex.Lock()
 	api.pageCache[key] = page
+	api.pageCacheByID[page.ID] = page
+	api.pageCacheMutex.Unlock()
 
 	return page, nil
 }
@@ -1203,7 +1220,11 @@ func (api *API) CreatePageWithFolderParent(
 		cacheType = result.Type
 	}
 	key := pageCacheKey(space, cacheTitle, cacheType)
+
+	api.pageCacheMutex.Lock()
 	api.pageCache[key] = result
+	api.pageCacheByID[result.ID] = result
+	api.pageCacheMutex.Unlock()
 
 	return result, nil
 }

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -42,9 +42,25 @@ func pageCacheKey(space, title, pageType string) string {
 	return space + "\x00" + title + "\x00" + pageType
 }
 
+// setCacheEntry sets a cache entry. Requires api.pageCacheMutex to be locked by the caller.
+func (api *API) setCacheEntry(key string, page *PageInfo) {
+	if oldPage, ok := api.pageCache[key]; ok && oldPage != nil {
+		if page == nil || oldPage.ID != page.ID {
+			delete(api.pageCacheByID, oldPage.ID)
+		}
+	}
+	api.pageCache[key] = page
+	if page != nil {
+		api.pageCacheByID[page.ID] = page
+	}
+}
+
 func (api *API) invalidatePage(space, title, pageType string) {
 	key := pageCacheKey(space, title, pageType)
 	api.pageCacheMutex.Lock()
+	if oldPage, ok := api.pageCache[key]; ok && oldPage != nil {
+		delete(api.pageCacheByID, oldPage.ID)
+	}
 	delete(api.pageCache, key)
 	api.pageCacheMutex.Unlock()
 }
@@ -323,7 +339,7 @@ func (api *API) FindPage(
 	}
 
 	if len(result.Results) == 0 {
-		api.pageCache[key] = nil
+		api.setCacheEntry(key, nil)
 		return nil, nil
 	}
 
@@ -333,8 +349,7 @@ func (api *API) FindPage(
 		page.Links.Base = result.Links.Base
 	}
 
-	api.pageCache[key] = page
-	api.pageCacheByID[page.ID] = page
+	api.setCacheEntry(key, page)
 	return page, nil
 }
 
@@ -708,8 +723,7 @@ func (api *API) CreatePage(
 	key := pageCacheKey(space, cacheTitle, cacheType)
 
 	api.pageCacheMutex.Lock()
-	api.pageCache[key] = page
-	api.pageCacheByID[page.ID] = page
+	api.setCacheEntry(key, page)
 	api.pageCacheMutex.Unlock()
 
 	return page, nil
@@ -1228,8 +1242,7 @@ func (api *API) CreatePageWithFolderParent(
 	key := pageCacheKey(space, cacheTitle, cacheType)
 
 	api.pageCacheMutex.Lock()
-	api.pageCache[key] = result
-	api.pageCacheByID[result.ID] = result
+	api.setCacheEntry(key, result)
 	api.pageCacheMutex.Unlock()
 
 	return result, nil

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -353,8 +353,9 @@ func (api *API) FindPage(
 	key := pageCacheKey(space, title, pageType)
 	api.pageCacheMutex.RLock()
 	if page, ok := api.pageCache[key]; ok {
+		cloned := clonePageInfo(page)
 		api.pageCacheMutex.RUnlock()
-		return clonePageInfo(page), nil
+		return cloned, nil
 	}
 	api.pageCacheMutex.RUnlock()
 

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -42,6 +42,17 @@ func pageCacheKey(space, title, pageType string) string {
 	return space + "\x00" + title + "\x00" + pageType
 }
 
+func (api *API) lazyInit() {
+	api.pageCacheMutex.Lock()
+	defer api.pageCacheMutex.Unlock()
+	if api.pageCache == nil {
+		api.pageCache = make(map[string]*PageInfo)
+	}
+	if api.pageCacheByID == nil {
+		api.pageCacheByID = make(map[string]*PageInfo)
+	}
+}
+
 // setCacheEntry sets a cache entry. Requires api.pageCacheMutex to be locked by the caller.
 func (api *API) setCacheEntry(key string, page *PageInfo) {
 	if oldPage, ok := api.pageCache[key]; ok && oldPage != nil {
@@ -56,6 +67,7 @@ func (api *API) setCacheEntry(key string, page *PageInfo) {
 }
 
 func (api *API) invalidatePage(space, title, pageType string) {
+	api.lazyInit()
 	key := pageCacheKey(space, title, pageType)
 	api.pageCacheMutex.Lock()
 	if oldPage, ok := api.pageCache[key]; ok && oldPage != nil {
@@ -66,6 +78,7 @@ func (api *API) invalidatePage(space, title, pageType string) {
 }
 
 func (api *API) updateCachedPageVersion(id string, newVersion int64) {
+	api.lazyInit()
 	api.pageCacheMutex.Lock()
 	defer api.pageCacheMutex.Unlock()
 
@@ -305,6 +318,7 @@ func (api *API) FindPage(
 	title string,
 	pageType string,
 ) (*PageInfo, error) {
+	api.lazyInit()
 	key := pageCacheKey(space, title, pageType)
 	api.pageCacheMutex.RLock()
 	if page, ok := api.pageCache[key]; ok {
@@ -373,7 +387,20 @@ func (api *API) FindPage(
 		page.Links.Base = api.BaseURL
 	}
 
+	cacheTitle := title
+	if page.Title != "" {
+		cacheTitle = page.Title
+	}
+	cacheType := pageType
+	if page.Type != "" {
+		cacheType = page.Type
+	}
+	canonicalKey := pageCacheKey(space, cacheTitle, cacheType)
+
 	api.setCacheEntry(key, &page)
+	if canonicalKey != key {
+		api.setCacheEntry(canonicalKey, &page)
+	}
 	return &page, nil
 }
 
@@ -710,7 +737,7 @@ func (api *API) CreatePage(
 	}
 
 	page := request.Response.(*PageInfo)
-	
+
 	if parent != nil {
 		ancestors := make([]struct {
 			ID    string `json:"id"`
@@ -750,6 +777,7 @@ func (api *API) CreatePage(
 		page.Links.Base = api.BaseURL
 	}
 
+	api.lazyInit()
 	api.pageCacheMutex.Lock()
 	api.setCacheEntry(key, page)
 	api.pageCacheMutex.Unlock()
@@ -1272,6 +1300,7 @@ func (api *API) CreatePageWithFolderParent(
 	}
 	key := pageCacheKey(space, cacheTitle, cacheType)
 
+	api.lazyInit()
 	api.pageCacheMutex.Lock()
 	api.setCacheEntry(key, result)
 	api.pageCacheMutex.Unlock()

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -43,6 +43,13 @@ func pageCacheKey(space, title, pageType string) string {
 }
 
 func (api *API) lazyInit() {
+	api.pageCacheMutex.RLock()
+	if api.pageCache != nil && api.pageCacheByID != nil {
+		api.pageCacheMutex.RUnlock()
+		return
+	}
+	api.pageCacheMutex.RUnlock()
+
 	api.pageCacheMutex.Lock()
 	defer api.pageCacheMutex.Unlock()
 	if api.pageCache == nil {
@@ -101,6 +108,10 @@ func (api *API) updateCachedPageVersion(id string, newVersion int64) {
 				updatedEntry = &newEntry
 			}
 		}
+	}
+
+	if updatedEntry != nil {
+		api.pageCacheByID[id] = updatedEntry
 	}
 }
 

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -365,14 +365,16 @@ func (api *API) FindPage(
 		return nil, nil
 	}
 
-	page := &result.Results[0]
-	// Populate the base URL from the response _links.base
+	page := result.Results[0]
+	// Populate the base URL from the response _links.base or fallback to BaseURL
 	if result.Links.Base != "" {
 		page.Links.Base = result.Links.Base
+	} else if page.Links.Base == "" {
+		page.Links.Base = api.BaseURL
 	}
 
-	api.setCacheEntry(key, page)
-	return page, nil
+	api.setCacheEntry(key, &page)
+	return &page, nil
 }
 
 func (api *API) CreateAttachment(
@@ -743,6 +745,10 @@ func (api *API) CreatePage(
 		cacheType = page.Type
 	}
 	key := pageCacheKey(space, cacheTitle, cacheType)
+
+	if page.Links.Base == "" {
+		page.Links.Base = api.BaseURL
+	}
 
 	api.pageCacheMutex.Lock()
 	api.setCacheEntry(key, page)
@@ -1253,6 +1259,9 @@ func (api *API) CreatePageWithFolderParent(
 	}
 
 	result.Links.Full = "/pages/viewpage.action?pageId=" + result.ID
+	if result.Links.Base == "" {
+		result.Links.Base = api.BaseURL
+	}
 	cacheTitle := title
 	if result.Title != "" {
 		cacheTitle = result.Title

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -39,6 +39,11 @@ func pageCacheKey(space, title, pageType string) string {
 	return space + "\x00" + title + "\x00" + pageType
 }
 
+func (api *API) invalidatePage(space, title, pageType string) {
+	key := pageCacheKey(space, title, pageType)
+	delete(api.pageCache, key)
+}
+
 type SpaceInfo struct {
 	ID   int    `json:"id"`
 	Key  string `json:"key"`
@@ -639,8 +644,7 @@ func (api *API) CreatePage(
 	}
 
 	page := request.Response.(*PageInfo)
-	key := pageCacheKey(space, title, pageType)
-	api.pageCache[key] = page
+	api.invalidatePage(space, title, pageType)
 
 	return page, nil
 }
@@ -1146,8 +1150,7 @@ func (api *API) CreatePageWithFolderParent(
 	}
 
 	result.Links.Full = "/pages/viewpage.action?pageId=" + result.ID
-	key := pageCacheKey(space, title, pageType)
-	api.pageCache[key] = result
+	api.invalidatePage(space, title, pageType)
 
 	return result, nil
 }

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -44,11 +44,10 @@ func (api *API) invalidatePage(space, title, pageType string) {
 	delete(api.pageCache, key)
 }
 
-func (api *API) invalidatePageByID(id string) {
-	for key, entry := range api.pageCache {
+func (api *API) updateCachedPageVersion(id string, newVersion int64) {
+	for _, entry := range api.pageCache {
 		if entry != nil && entry.ID == id {
-			delete(api.pageCache, key)
-			break
+			entry.Version.Number = newVersion
 		}
 	}
 }
@@ -755,7 +754,7 @@ func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, ve
 	}
 
 	page.Version.Number = nextPageVersion
-	api.invalidatePageByID(page.ID)
+	api.updateCachedPageVersion(page.ID, nextPageVersion)
 	return nil
 }
 

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -67,10 +67,24 @@ func (api *API) invalidatePage(space, title, pageType string) {
 
 func (api *API) updateCachedPageVersion(id string, newVersion int64) {
 	api.pageCacheMutex.Lock()
-	if entry, ok := api.pageCacheByID[id]; ok && entry != nil {
-		entry.Version.Number = newVersion
+	defer api.pageCacheMutex.Unlock()
+
+	entry, ok := api.pageCacheByID[id]
+	if !ok || entry == nil {
+		return
 	}
-	api.pageCacheMutex.Unlock()
+
+	// Create a shallow copy of the cached page info to avoid data races
+	newEntry := *entry
+	newEntry.Version.Number = newVersion
+
+	// Replace the pointer in both maps
+	for key, e := range api.pageCache {
+		if e == entry {
+			api.pageCache[key] = &newEntry
+		}
+	}
+	api.pageCacheByID[id] = &newEntry
 }
 
 type SpaceInfo struct {
@@ -295,7 +309,11 @@ func (api *API) FindPage(
 	api.pageCacheMutex.RLock()
 	if page, ok := api.pageCache[key]; ok {
 		api.pageCacheMutex.RUnlock()
-		return page, nil
+		if page == nil {
+			return nil, nil
+		}
+		copyPage := *page
+		return &copyPage, nil
 	}
 	api.pageCacheMutex.RUnlock()
 
@@ -335,7 +353,11 @@ func (api *API) FindPage(
 	// Double-checked locking: check if the cache was populated by another goroutine
 	// while the network request was in-flight.
 	if cachedPage, ok := api.pageCache[key]; ok {
-		return cachedPage, nil
+		if cachedPage == nil {
+			return nil, nil
+		}
+		copyPage := *cachedPage
+		return &copyPage, nil
 	}
 
 	if len(result.Results) == 0 {

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -1,0 +1,38 @@
+package confluence
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPageCache(t *testing.T) {
+	api := &API{
+		pageCache: make(map[string]*PageInfo),
+	}
+
+	space := "TEST"
+	title := "My Page"
+	pageType := "page"
+
+	// 1. Cache Hit returns cached page without network request
+	cachedPage := &PageInfo{
+		ID:    "12345",
+		Title: title,
+		Type:  pageType,
+	}
+
+	key := pageCacheKey(space, title, pageType)
+	api.pageCache[key] = cachedPage
+
+	// This must not panic (meaning it didn't use api.rest) and must return the cached page.
+	res, err := api.FindPage(space, title, pageType)
+	assert.NoError(t, err)
+	assert.Equal(t, cachedPage, res)
+
+	// 2. Cache Hit on non-existent page (cached nil result)
+	api.pageCache[key] = nil
+	res, err = api.FindPage(space, title, pageType)
+	assert.NoError(t, err)
+	assert.Nil(t, res)
+}

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -48,4 +48,15 @@ func TestPageCache(t *testing.T) {
 	api.pageCacheByID[cachedPage.ID] = cachedPage
 	api.updateCachedPageVersion(cachedPage.ID, 42)
 	assert.Equal(t, int64(42), api.pageCache[key].Version.Number)
+
+	// 5. Concurrent Cache Operations
+	// Validates RWMutex under concurrent goroutines.
+	done := make(chan bool)
+	go func() {
+		api.updateCachedPageVersion(cachedPage.ID, 100)
+		done <- true
+	}()
+	_, err = api.FindPage(space, title, pageType)
+	assert.NoError(t, err)
+	<-done
 }

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -35,4 +35,10 @@ func TestPageCache(t *testing.T) {
 	res, err = api.FindPage(space, title, pageType)
 	assert.NoError(t, err)
 	assert.Nil(t, res)
+
+	// 3. Cache Invalidation removes entry
+	api.pageCache[key] = cachedPage
+	api.invalidatePage(space, title, pageType)
+	_, ok := api.pageCache[key]
+	assert.False(t, ok)
 }

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -3,6 +3,7 @@ package confluence
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -77,9 +78,9 @@ func TestPageCache(t *testing.T) {
 }
 
 func TestPageCacheFindPageMissAndHit(t *testing.T) {
-	callCount := 0
+	var callCount int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
+		atomic.AddInt32(&callCount, 1)
 		// Return a mock Confluence response
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -112,21 +113,21 @@ func TestPageCacheFindPageMissAndHit(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, res1)
 	assert.Equal(t, "12345", res1.ID)
-	assert.Equal(t, 1, callCount)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount))
 
 	// Second call: cache hit, should NOT trigger HTTP request
 	res2, err := api.FindPage(space, title, pageType)
 	assert.NoError(t, err)
 	assert.NotNil(t, res2)
 	assert.Equal(t, "12345", res2.ID)
-	assert.Equal(t, 1, callCount) // callCount remains 1!
+	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount)) // callCount remains 1!
 	assert.Equal(t, res1.Version.Number, res2.Version.Number)
 }
 
 func TestPageCacheFindPageNegativeCache(t *testing.T) {
-	callCount := 0
+	var callCount int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
+		atomic.AddInt32(&callCount, 1)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"results": []}`))
@@ -143,13 +144,13 @@ func TestPageCacheFindPageNegativeCache(t *testing.T) {
 	res1, err := api.FindPage(space, title, pageType)
 	assert.NoError(t, err)
 	assert.Nil(t, res1)
-	assert.Equal(t, 1, callCount)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount))
 
 	// Second call: cache hit, returns nil without network call
 	res2, err := api.FindPage(space, title, pageType)
 	assert.NoError(t, err)
 	assert.Nil(t, res2)
-	assert.Equal(t, 1, callCount)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount))
 }
 
 func TestPageCacheZeroValueAPI(t *testing.T) {

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -8,7 +8,8 @@ import (
 
 func TestPageCache(t *testing.T) {
 	api := &API{
-		pageCache: make(map[string]*PageInfo),
+		pageCache:     make(map[string]*PageInfo),
+		pageCacheByID: make(map[string]*PageInfo),
 	}
 
 	space := "TEST"
@@ -44,6 +45,7 @@ func TestPageCache(t *testing.T) {
 
 	// 4. Cache Version Update updates version in-place
 	api.pageCache[key] = cachedPage
+	api.pageCacheByID[cachedPage.ID] = cachedPage
 	api.updateCachedPageVersion(cachedPage.ID, 42)
 	assert.Equal(t, int64(42), api.pageCache[key].Version.Number)
 }

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -1,6 +1,8 @@
 package confluence
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,4 +66,93 @@ func TestPageCache(t *testing.T) {
 		assert.NoError(t, err)
 	}
 	<-done
+}
+
+func TestPageCacheFindPageMissAndHit(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		// Return a mock Confluence response
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"results": [
+				{
+					"id": "12345",
+					"title": "My Page",
+					"type": "page",
+					"version": {
+						"number": 1
+					}
+				}
+			],
+			"_links": {
+				"base": "http://mock-confluence"
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	api := NewAPI(server.URL, "username", "password", true)
+
+	space := "TEST"
+	title := "My Page"
+	pageType := "page"
+
+	// First call: cache miss, triggers HTTP request to server
+	res1, err := api.FindPage(space, title, pageType)
+	assert.NoError(t, err)
+	assert.NotNil(t, res1)
+	assert.Equal(t, "12345", res1.ID)
+	assert.Equal(t, 1, callCount)
+
+	// Second call: cache hit, should NOT trigger HTTP request
+	res2, err := api.FindPage(space, title, pageType)
+	assert.NoError(t, err)
+	assert.NotNil(t, res2)
+	assert.Equal(t, "12345", res2.ID)
+	assert.Equal(t, 1, callCount) // callCount remains 1!
+	assert.Equal(t, res1.Version.Number, res2.Version.Number)
+}
+
+func TestPageCacheFindPageNegativeCache(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results": []}`))
+	}))
+	defer server.Close()
+
+	api := NewAPI(server.URL, "username", "password", true)
+
+	space := "TEST"
+	title := "Missing Page"
+	pageType := "page"
+
+	// First call: cache miss, returns nil
+	res1, err := api.FindPage(space, title, pageType)
+	assert.NoError(t, err)
+	assert.Nil(t, res1)
+	assert.Equal(t, 1, callCount)
+
+	// Second call: cache hit, returns nil without network call
+	res2, err := api.FindPage(space, title, pageType)
+	assert.NoError(t, err)
+	assert.Nil(t, res2)
+	assert.Equal(t, 1, callCount)
+}
+
+func TestPageCacheZeroValueAPI(t *testing.T) {
+	// Verifies lazy initialization handles zero-valued API structures
+	api := &API{}
+
+	// invalidatePage should not panic
+	api.invalidatePage("TEST", "Title", "page")
+
+	// updateCachedPageVersion should not panic
+	api.updateCachedPageVersion("12345", 2)
+
+	// setCacheEntry should not panic (tested via invalidatePage)
 }

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -29,7 +29,8 @@ func TestPageCache(t *testing.T) {
 	// This must not panic (meaning it didn't use api.rest) and must return the cached page.
 	res, err := api.FindPage(space, title, pageType)
 	assert.NoError(t, err)
-	assert.Same(t, cachedPage, res)
+	assert.Equal(t, cachedPage, res)
+	assert.NotSame(t, cachedPage, res) // Verify defensive copy
 
 	// 2. Cache Hit on non-existent page (cached nil result)
 	api.pageCache[key] = nil
@@ -50,13 +51,17 @@ func TestPageCache(t *testing.T) {
 	assert.Equal(t, int64(42), api.pageCache[key].Version.Number)
 
 	// 5. Concurrent Cache Operations
-	// Validates RWMutex under concurrent goroutines.
+	// Validates RWMutex under concurrent goroutines using tight loops to create contention.
 	done := make(chan bool)
 	go func() {
-		api.updateCachedPageVersion(cachedPage.ID, 100)
+		for i := 0; i < 1000; i++ {
+			api.updateCachedPageVersion(cachedPage.ID, int64(i))
+		}
 		done <- true
 	}()
-	_, err = api.FindPage(space, title, pageType)
-	assert.NoError(t, err)
+	for i := 0; i < 1000; i++ {
+		_, err = api.FindPage(space, title, pageType)
+		assert.NoError(t, err)
+	}
 	<-done
 }

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -46,11 +46,19 @@ func TestPageCache(t *testing.T) {
 	_, ok := api.pageCache[key]
 	assert.False(t, ok)
 
-	// 4. Cache Version Update replaces cached pointer with copy containing updated version
+	// 4. Cache Version Update replaces cached pointer with copy containing updated version (across all alias pointers mapping to the same ID)
+	aliasPage := &PageInfo{
+		ID:    cachedPage.ID,
+		Title: "Alias Title",
+		Type:  pageType,
+	}
+	aliasKey := pageCacheKey(space, "Alias Title", pageType)
 	api.pageCache[key] = cachedPage
+	api.pageCache[aliasKey] = aliasPage
 	api.pageCacheByID[cachedPage.ID] = cachedPage
 	api.updateCachedPageVersion(cachedPage.ID, 42)
 	assert.Equal(t, int64(42), api.pageCache[key].Version.Number)
+	assert.Equal(t, int64(42), api.pageCache[aliasKey].Version.Number)
 
 	// 5. Concurrent Cache Operations
 	// Validates RWMutex under concurrent goroutines using tight loops to create contention.

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -162,5 +162,8 @@ func TestPageCacheZeroValueAPI(t *testing.T) {
 	// updateCachedPageVersion should not panic
 	api.updateCachedPageVersion("12345", 2)
 
-	// setCacheEntry should not panic (tested via invalidatePage)
+	// setCacheEntry should not panic
+	api.pageCacheMutex.Lock()
+	api.setCacheEntry("key", &PageInfo{ID: "123"})
+	api.pageCacheMutex.Unlock()
 }

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -41,4 +41,10 @@ func TestPageCache(t *testing.T) {
 	api.invalidatePage(space, title, pageType)
 	_, ok := api.pageCache[key]
 	assert.False(t, ok)
+
+	// 4. Cache Invalidation by ID removes entry
+	api.pageCache[key] = cachedPage
+	api.invalidatePageByID(cachedPage.ID)
+	_, ok = api.pageCache[key]
+	assert.False(t, ok)
 }

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -42,9 +42,8 @@ func TestPageCache(t *testing.T) {
 	_, ok := api.pageCache[key]
 	assert.False(t, ok)
 
-	// 4. Cache Invalidation by ID removes entry
+	// 4. Cache Version Update updates version in-place
 	api.pageCache[key] = cachedPage
-	api.invalidatePageByID(cachedPage.ID)
-	_, ok = api.pageCache[key]
-	assert.False(t, ok)
+	api.updateCachedPageVersion(cachedPage.ID, 42)
+	assert.Equal(t, int64(42), api.pageCache[key].Version.Number)
 }

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -28,7 +28,7 @@ func TestPageCache(t *testing.T) {
 	// This must not panic (meaning it didn't use api.rest) and must return the cached page.
 	res, err := api.FindPage(space, title, pageType)
 	assert.NoError(t, err)
-	assert.Equal(t, cachedPage, res)
+	assert.Same(t, cachedPage, res)
 
 	// 2. Cache Hit on non-existent page (cached nil result)
 	api.pageCache[key] = nil

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -162,8 +162,10 @@ func TestPageCacheZeroValueAPI(t *testing.T) {
 	// updateCachedPageVersion should not panic
 	api.updateCachedPageVersion("12345", 2)
 
-	// setCacheEntry should not panic
-	api.pageCacheMutex.Lock()
-	api.setCacheEntry("key", &PageInfo{ID: "123"})
-	api.pageCacheMutex.Unlock()
+	// setCacheEntry should not panic after lazyInit
+	api2 := &API{}
+	api2.lazyInit()
+	api2.pageCacheMutex.Lock()
+	api2.setCacheEntry("key", &PageInfo{ID: "123"})
+	api2.pageCacheMutex.Unlock()
 }

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -44,7 +44,7 @@ func TestPageCache(t *testing.T) {
 	_, ok := api.pageCache[key]
 	assert.False(t, ok)
 
-	// 4. Cache Version Update updates version in-place
+	// 4. Cache Version Update replaces cached pointer with copy containing updated version
 	api.pageCache[key] = cachedPage
 	api.pageCacheByID[cachedPage.ID] = cachedPage
 	api.updateCachedPageVersion(cachedPage.ID, 42)

--- a/d2/d2_test.go
+++ b/d2/d2_test.go
@@ -78,7 +78,6 @@ func TestExtractD2Image(t *testing.T) {
 			Replace:   "example",
 			Checksum:  "40e75f93e09da9242d4b1ab8e2892665ec7d5bd1ac78a4b65210ee219cf62297",
 			ID:        "",
-
 		},
 			assert.NoError},
 	}

--- a/mark_test.go
+++ b/mark_test.go
@@ -29,9 +29,9 @@ func TestLevenshteinDistance(t *testing.T) {
 		{"abc", "", 3},
 		{"", "abc", 3},
 		{"abc", "abc", 0},
-		{"abc", "axc", 1},   // one substitution
-		{"abc", "ab", 1},    // one deletion
-		{"ab", "abc", 1},    // one insertion
+		{"abc", "axc", 1}, // one substitution
+		{"abc", "ab", 1},  // one deletion
+		{"ab", "abc", 1},  // one insertion
 		{"kitten", "sitting", 3},
 		// Multibyte: é is one rune, so distance from "héllo" to "hello" is 1.
 		{"héllo", "hello", 1},
@@ -206,7 +206,6 @@ func TestMergeComments_ApostropheSelection(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, `<p>Hello <ac:inline-comment-marker ac:ref="uuid-apos">it's</ac:inline-comment-marker> a test</p>`, result)
 }
-
 
 // TestMergeComments_NestedTags verifies that a marker whose stored content
 // contains nested inline tags (e.g. <strong>) is still recognised by

--- a/mermaid/mermaid_test.go
+++ b/mermaid/mermaid_test.go
@@ -25,7 +25,6 @@ func TestExtractMermaidImage(t *testing.T) {
 			Replace:   "example",
 			Checksum:  "26296b73c960c25850b37bc9dd77cb24fce1a78db83b37755a25af7f8a48cc96",
 			ID:        "",
-
 		},
 			assert.NoError},
 	}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -239,4 +239,3 @@ func TestExtractMeta_FolderHeadersWithCliParents(t *testing.T) {
 	assert.Equal(t, cliParents, meta.Parents)
 	assert.Equal(t, []string{"API"}, meta.Folders)
 }
-

--- a/renderer/image.go
+++ b/renderer/image.go
@@ -76,8 +76,6 @@ func calculateDisplayWidth(originalWidth string, layout string) string {
 	return originalWidth
 }
 
-
-
 type ConfluenceImageRenderer struct {
 	html.Config
 	Stdlib      *stdlib.Lib

--- a/util/auth.go
+++ b/util/auth.go
@@ -60,7 +60,7 @@ func GetCredentials(
 				"flag or be stored in configuration file",
 		)
 	}
-	
+
 	if baseURL == "" {
 		baseURL = url.Scheme + "://" + url.Host
 	}


### PR DESCRIPTION
This PR implements a page info cache in the Confluence client to optimize ancestry traversal and page resolution.

### Problem
Previously, when validating page ancestry parent hierarchies across multiple files (or looking up pages), `api.FindPage` was called repeatedly for the same pages. Under a large page tree where multiple documents share parents (e.g. `Engineering > Docs > Architecture`), this generated hundreds of redundant remote HTTP requests to Confluence, significantly slowing down the sync.

### Solution
1. **API Client Cache**: Added a `pageCache` map to the `API` client struct, mapping `spaceKey + title + pageType` to the resolved `*PageInfo`.
2. **Hit/Miss Population**:
   - `FindPage`: First checks the cache; returns cached data on hits, and caches results (including `nil` for non-existent pages) on miss.
   - `CreatePage` and `CreatePageWithFolderParent`: Cache the newly created page on success.
   - `UpdatePage`: Updates the version of the cached page in-place to ensure consistency.
3. **Tests**: Added a unit test in `confluence/api_test.go` to assert that cache hits correctly bypass network calls.
