### PR TITLE
refactor: completely remove legacy JSON-RPC API client and unify content restrictions

### DIFF
--- a/confluence/api.go
+++ b/confluence/api.go
@@ -10,6 +10,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"strings"
+	"sync"
 	"unicode/utf8"
 
 	"github.com/kovetskiy/gopencils"
@@ -847,9 +848,41 @@ func (api *API) GetCurrentUser() (*User, error) {
 	return &user, nil
 }
 
+var (
+	isCloudFlag    bool
+	isCloudChecked bool
+	isCloudMutex   sync.Mutex
+)
+
 func (api *API) IsCloud() bool {
+	isCloudMutex.Lock()
+	defer isCloudMutex.Unlock()
+
+	if isCloudChecked {
+		return isCloudFlag
+	}
+
+	// 1. Fast path: check default domain suffix
 	host := api.rest.Api.BaseUrl.Hostname()
-	return strings.HasSuffix(host, "jira.com") || strings.HasSuffix(host, "atlassian.net")
+	if strings.HasSuffix(host, "jira.com") || strings.HasSuffix(host, "atlassian.net") {
+		isCloudFlag = true
+		isCloudChecked = true
+		return isCloudFlag
+	}
+
+	// 2. Slow path: probe Cloud-only v2 API endpoint
+	var result any
+	request, err := api.restV2.Res("spaces", &result).Get(map[string]string{
+		"limit": "1",
+	})
+	if err == nil && (request.Raw.StatusCode == http.StatusOK || request.Raw.StatusCode == http.StatusForbidden) {
+		isCloudFlag = true
+	} else {
+		isCloudFlag = false
+	}
+
+	isCloudChecked = true
+	return isCloudFlag
 }
 
 func (api *API) RestrictPageUpdates(

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -29,6 +29,10 @@ type API struct {
 	// v2 API for newer endpoints like folders
 	restV2  *gopencils.Resource
 	BaseURL string
+
+	isCloudFlag    bool
+	isCloudChecked bool
+	isCloudMutex   sync.Mutex
 }
 
 type SpaceInfo struct {
@@ -848,26 +852,20 @@ func (api *API) GetCurrentUser() (*User, error) {
 	return &user, nil
 }
 
-var (
-	isCloudFlag    bool
-	isCloudChecked bool
-	isCloudMutex   sync.Mutex
-)
-
 func (api *API) IsCloud() bool {
-	isCloudMutex.Lock()
-	defer isCloudMutex.Unlock()
+	api.isCloudMutex.Lock()
+	defer api.isCloudMutex.Unlock()
 
-	if isCloudChecked {
-		return isCloudFlag
+	if api.isCloudChecked {
+		return api.isCloudFlag
 	}
 
 	// 1. Fast path: check default domain suffix
 	host := api.rest.Api.BaseUrl.Hostname()
 	if strings.HasSuffix(host, "jira.com") || strings.HasSuffix(host, "atlassian.net") {
-		isCloudFlag = true
-		isCloudChecked = true
-		return isCloudFlag
+		api.isCloudFlag = true
+		api.isCloudChecked = true
+		return api.isCloudFlag
 	}
 
 	// 2. Slow path: probe Cloud-only v2 API endpoint
@@ -876,13 +874,13 @@ func (api *API) IsCloud() bool {
 		"limit": "1",
 	})
 	if err == nil && (request.Raw.StatusCode == http.StatusOK || request.Raw.StatusCode == http.StatusForbidden) {
-		isCloudFlag = true
+		api.isCloudFlag = true
 	} else {
-		isCloudFlag = false
+		api.isCloudFlag = false
 	}
 
-	isCloudChecked = true
-	return isCloudFlag
+	api.isCloudChecked = true
+	return api.isCloudFlag
 }
 
 func (api *API) RestrictPageUpdates(
@@ -932,7 +930,10 @@ func (api *API) RestrictPageUpdates(
 		return err
 	}
 
-	if request.Raw.StatusCode != http.StatusOK {
+	if request.Raw.StatusCode != http.StatusOK && request.Raw.StatusCode != http.StatusNoContent {
+		if !api.IsCloud() && (request.Raw.StatusCode == http.StatusNotFound || request.Raw.StatusCode == http.StatusMethodNotAllowed) {
+			return fmt.Errorf("confluence server/datacenter version is too old to support page edit restrictions via REST API (requires Confluence 8.8.0 or newer; status: %d)", request.Raw.StatusCode)
+		}
 		return newErrorStatusNotOK(request)
 	}
 

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -20,14 +20,11 @@ import (
 type User struct {
 	AccountID string `json:"accountId,omitempty"`
 	UserKey   string `json:"userKey,omitempty"`
+	Username  string `json:"username,omitempty"`
 }
 
 type API struct {
 	rest *gopencils.Resource
-
-	// it's deprecated accordingly to Atlassian documentation,
-	// but it's only way to set permissions
-	json *gopencils.Resource
 	// v2 API for newer endpoints like folders
 	restV2  *gopencils.Resource
 	BaseURL string
@@ -190,18 +187,14 @@ func NewAPI(baseURL string, username string, password string, insecureSkipVerify
 		restV2.SetHeader("Authorization", fmt.Sprintf("Bearer %s", password))
 	}
 
-	json := gopencils.Api(baseURL+"/rpc/json-rpc/confluenceservice-v2", auth, httpClient, 3)
-
 	if zerolog.GlobalLevel() == zerolog.TraceLevel {
 		rest.Logger = &tracer{"rest:"}
 		restV2.Logger = &tracer{"rest-v2:"}
-		json.Logger = &tracer{"json-rpc:"}
 	}
 
 	return &API{
 		rest:    rest,
 		restV2:  restV2,
-		json:    json,
 		BaseURL: baseURL,
 	}
 }
@@ -854,15 +847,19 @@ func (api *API) GetCurrentUser() (*User, error) {
 	return &user, nil
 }
 
-func (api *API) RestrictPageUpdatesCloud(
+func (api *API) IsCloud() bool {
+	host := api.rest.Api.BaseUrl.Host
+	return strings.HasSuffix(host, "jira.com") || strings.HasSuffix(host, "atlassian.net")
+}
+
+func (api *API) RestrictPageUpdates(
 	page *PageInfo,
 	allowedUser string,
 ) error {
 	user, err := api.GetUserByName(allowedUser)
 	if err != nil {
 		// Fall back to the currently authenticated user if the specified
-		// user cannot be resolved by name (e.g. on Confluence Cloud where
-		// only accountId is accepted and name lookup may fail).
+		// user cannot be resolved by name.
 		currentUser, currentErr := api.GetCurrentUser()
 		if currentErr != nil {
 			return fmt.Errorf("unable to resolve user %q: %w", allowedUser, err)
@@ -870,8 +867,18 @@ func (api *API) RestrictPageUpdatesCloud(
 		user = currentUser
 	}
 
-	var result any
+	userMap := map[string]any{
+		"type": "known",
+	}
+	if user.AccountID != "" {
+		userMap["accountId"] = user.AccountID
+	} else if user.Username != "" {
+		userMap["username"] = user.Username
+	} else {
+		userMap["username"] = allowedUser
+	}
 
+	var result any
 	request, err := api.rest.
 		Res("content").
 		Id(page.ID).
@@ -881,10 +888,7 @@ func (api *API) RestrictPageUpdatesCloud(
 				"operation": "update",
 				"restrictions": map[string]any{
 					"user": []map[string]any{
-						{
-							"type":      "known",
-							"accountId": user.AccountID,
-						},
+						userMap,
 					},
 				},
 			},
@@ -898,64 +902,6 @@ func (api *API) RestrictPageUpdatesCloud(
 	}
 
 	return nil
-}
-
-func (api *API) RestrictPageUpdatesServer(
-	page *PageInfo,
-	allowedUser string,
-) error {
-	var (
-		err    error
-		result any
-	)
-
-	request, err := api.json.Res(
-		"setContentPermissions", &result,
-	).Post([]any{
-		page.ID,
-		"Edit",
-		[]map[string]any{
-			{
-				"userName": allowedUser,
-			},
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	if request.Raw.StatusCode != http.StatusOK {
-		return newErrorStatusNotOK(request)
-	}
-
-	if success, ok := result.(bool); !ok || !success {
-		return fmt.Errorf(
-			"'true' response expected, but '%v' encountered",
-			result,
-		)
-	}
-
-	return nil
-}
-
-func (api *API) IsCloud() bool {
-	host := api.rest.Api.BaseUrl.Host
-	return strings.HasSuffix(host, "jira.com") || strings.HasSuffix(host, "atlassian.net")
-}
-
-func (api *API) RestrictPageUpdates(
-	page *PageInfo,
-	allowedUser string,
-) error {
-	var err error
-
-	if api.IsCloud() {
-		err = api.RestrictPageUpdatesCloud(page, allowedUser)
-	} else {
-		err = api.RestrictPageUpdatesServer(page, allowedUser)
-	}
-
-	return err
 }
 
 // Folder API methods (Phase 2 implementation)

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -848,7 +848,7 @@ func (api *API) GetCurrentUser() (*User, error) {
 }
 
 func (api *API) IsCloud() bool {
-	host := api.rest.Api.BaseUrl.Host
+	host := api.rest.Api.BaseUrl.Hostname()
 	return strings.HasSuffix(host, "jira.com") || strings.HasSuffix(host, "atlassian.net")
 }
 
@@ -856,24 +856,26 @@ func (api *API) RestrictPageUpdates(
 	page *PageInfo,
 	allowedUser string,
 ) error {
-	user, err := api.GetUserByName(allowedUser)
-	if err != nil {
-		// Fall back to the currently authenticated user if the specified
-		// user cannot be resolved by name.
-		currentUser, currentErr := api.GetCurrentUser()
-		if currentErr != nil {
-			return fmt.Errorf("unable to resolve user %q: %w", allowedUser, err)
-		}
-		user = currentUser
-	}
-
 	userMap := map[string]any{
 		"type": "known",
 	}
-	if user.AccountID != "" {
+
+	if api.IsCloud() {
+		user, err := api.GetUserByName(allowedUser)
+		if err != nil {
+			// Fall back to the currently authenticated user if the specified
+			// user cannot be resolved by name.
+			currentUser, currentErr := api.GetCurrentUser()
+			if currentErr != nil {
+				return fmt.Errorf("unable to resolve user %q: %w", allowedUser, err)
+			}
+			user = currentUser
+		}
+
+		if user.AccountID == "" {
+			return fmt.Errorf("resolved user %q has no accountId", allowedUser)
+		}
 		userMap["accountId"] = user.AccountID
-	} else if user.Username != "" {
-		userMap["username"] = user.Username
 	} else {
 		userMap["username"] = allowedUser
 	}

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -10,7 +10,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"strings"
-	"sync"
 	"unicode/utf8"
 
 	"github.com/kovetskiy/gopencils"
@@ -32,7 +31,6 @@ type API struct {
 
 	isCloudFlag    bool
 	isCloudChecked bool
-	isCloudMutex   sync.Mutex
 }
 
 type SpaceInfo struct {
@@ -853,9 +851,6 @@ func (api *API) GetCurrentUser() (*User, error) {
 }
 
 func (api *API) IsCloud() bool {
-	api.isCloudMutex.Lock()
-	defer api.isCloudMutex.Unlock()
-
 	if api.isCloudChecked {
 		return api.isCloudFlag
 	}


### PR DESCRIPTION
This PR completely removes the deprecated and legacy JSON-RPC endpoint dependency and unifies all page content permission restrictions under standard REST API v1 endpoints.

### Problem
Previously, page edit restrictions for Confluence Server/Datacenter were set using a custom JSON-RPC call `setContentPermissions` via the legacy endpoint `/rpc/json-rpc/confluenceservice-v2`, requiring maintaining a separate `api.json` client. 

### Solution
1. **Removed JSON-RPC Dependency**: Completely removed `api.json` fields, custom tracer prefixes, and client initializations in `NewAPI` and `API` struct.
2. **Unified REST API Restrictions**:
   * Merged `RestrictPageUpdatesServer` and `RestrictPageUpdatesCloud` into a single, clean REST-based `RestrictPageUpdates` function.
   * This function targets the standard `/rest/api/content/{id}/restriction` endpoint for both Cloud and Server/Datacenter.
   * Auto-detects user configuration: populates `accountId` when target is Confluence Cloud, and falls back to `username` when syncing against Confluence Server/Datacenter.
3. **User Struct Mapping**: Added `username` to the `User` struct definition to allow transparent mapping from user details returned by Server endpoints.
