### PR TITLE
feat: auto-convert HTML details/summary to Confluence expand macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,6 +863,19 @@ When enabled, this renders note, warning, tip, info admonitions as Confluence al
 !!! note
 ```
 
+### HTML Details/Summary Macro
+
+Optionally you can enable auto-conversion of standard HTML `<details>` and `<summary>` tags to native Confluence `expand` macros via `--features="details"`.
+
+When enabled, this maps standard HTML details blocks directly to Confluence expand macros:
+
+```markdown
+<details>
+<summary>Click to expand</summary>
+This is the hidden content.
+</details>
+```
+
 ## Installation
 
 ### Homebrew
@@ -944,7 +957,7 @@ GLOBAL OPTIONS:
    --changes-only                           Avoids re-uploading pages that haven't changed since the last run. [$MARK_CHANGES_ONLY]
    --preserve-comments                      Fetch and preserve inline comments on existing Confluence pages. [$MARK_PRESERVE_COMMENTS]
    --d2-scale float                         defines the scaling factor for d2 renderings. (default: 1) [$MARK_D2_SCALE]
-   --features string [ --features string ]  Enables optional features. Current features: d2, frontmatter, mermaid, mention, mkdocsadmonitions, plantuml (default: "mermaid", "mention") [$MARK_FEATURES]
+   --features string [ --features string ]  Enables optional features. Current features: d2, details, frontmatter, mermaid, mention, mkdocsadmonitions, plantuml (default: "mermaid", "mention") [$MARK_FEATURES]
    --insecure-skip-tls-verify               skip TLS certificate verification (useful for self-signed certificates) [$MARK_INSECURE_SKIP_TLS_VERIFY]
    --image-align string                     set image alignment (left, center, right). Can be overridden per-file via the Image-Align header. [$MARK_IMAGE_ALIGN]
    --help, -h                               show help

--- a/markdown/details.go
+++ b/markdown/details.go
@@ -1,0 +1,134 @@
+package mark
+
+import (
+	"bytes"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// convertDetailsToExpand parses the html string, finds standard HTML <details> and <summary> tags,
+// and maps them directly to native Confluence expand macro elements:
+//
+//	<ac:structured-macro ac:name="expand">
+//	  <ac:parameter ac:name="title">Summary Title</ac:parameter>
+//	  <ac:rich-text-body>
+//	    Body Content
+//	  </ac:rich-text-body>
+//	</ac:structured-macro>
+func convertDetailsToExpand(htmlStr string) (string, error) {
+	doc, err := html.Parse(strings.NewReader(htmlStr))
+	if err != nil {
+		return "", err
+	}
+
+	var transform func(*html.Node)
+	transform = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "details" {
+			// Find summary node
+			var summaryNode *html.Node
+			for c := n.FirstChild; c != nil; c = c.NextSibling {
+				if c.Type == html.ElementNode && c.Data == "summary" {
+					summaryNode = c
+					break
+				}
+			}
+
+			var summaryText string
+			if summaryNode != nil {
+				summaryText = strings.TrimSpace(extractText(summaryNode))
+			}
+
+			// Create replacement macro node
+			macroNode := &html.Node{
+				Type: html.ElementNode,
+				Data: "ac:structured-macro",
+				Attr: []html.Attribute{
+					{Key: "ac:name", Val: "expand"},
+				},
+			}
+
+			if summaryText != "" {
+				paramNode := &html.Node{
+					Type: html.ElementNode,
+					Data: "ac:parameter",
+					Attr: []html.Attribute{
+						{Key: "ac:name", Val: "title"},
+					},
+				}
+				paramNode.AppendChild(&html.Node{
+					Type: html.TextNode,
+					Data: summaryText,
+				})
+				macroNode.AppendChild(paramNode)
+			}
+
+			bodyNode := &html.Node{
+				Type: html.ElementNode,
+				Data: "ac:rich-text-body",
+			}
+
+			// Move all children of details except the summaryNode to the bodyNode
+			var next *html.Node
+			for c := n.FirstChild; c != nil; c = next {
+				next = c.NextSibling
+				if c != summaryNode {
+					n.RemoveChild(c)
+					bodyNode.AppendChild(c)
+				}
+			}
+
+			macroNode.AppendChild(bodyNode)
+
+			// Replace details node with macro node in the parent
+			if n.Parent != nil {
+				n.Parent.InsertBefore(macroNode, n)
+				n.Parent.RemoveChild(n)
+			}
+
+			// Continue transforming the children of the newly created body node
+			for c := bodyNode.FirstChild; c != nil; c = c.NextSibling {
+				transform(c)
+			}
+			return
+		}
+
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			transform(c)
+		}
+	}
+
+	transform(doc)
+
+	var buf bytes.Buffer
+	err = html.Render(&buf, doc)
+	if err != nil {
+		return "", err
+	}
+
+	res := buf.String()
+	if strings.Contains(htmlStr, "<html") {
+		return res, nil
+	}
+
+	// html.Parse wraps nodes in <html><head></head><body>...</body></html>.
+	// We extract only the inner HTML from the <body> tag to preserve fragment structure.
+	if idx := strings.Index(res, "<body>"); idx != -1 {
+		res = res[idx+len("<body>"):]
+		if idxEnd := strings.LastIndex(res, "</body>"); idxEnd != -1 {
+			res = res[:idxEnd]
+		}
+	}
+	return res, nil
+}
+
+func extractText(n *html.Node) string {
+	if n.Type == html.TextNode {
+		return n.Data
+	}
+	var buf strings.Builder
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		buf.WriteString(extractText(c))
+	}
+	return buf.String()
+}

--- a/markdown/details_test.go
+++ b/markdown/details_test.go
@@ -1,0 +1,70 @@
+package mark
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertDetailsToExpand(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "basic details and summary",
+			input: `<details>
+<summary>Click to expand</summary>
+<p>Some hidden text</p>
+</details>`,
+			expected: `<ac:structured-macro ac:name="expand"><ac:parameter ac:name="title">Click to expand</ac:parameter><ac:rich-text-body>
+<p>Some hidden text</p>
+</ac:rich-text-body></ac:structured-macro>`,
+		},
+		{
+			name: "details without summary",
+			input: `<details>
+<p>Some hidden text</p>
+</details>`,
+			expected: `<ac:structured-macro ac:name="expand"><ac:rich-text-body>
+<p>Some hidden text</p>
+</ac:rich-text-body></ac:structured-macro>`,
+		},
+		{
+			name: "summary with html tags inside",
+			input: `<details>
+<summary>Click <b>to</b> <i>expand</i></summary>
+<p>Some hidden text</p>
+</details>`,
+			expected: `<ac:structured-macro ac:name="expand"><ac:parameter ac:name="title">Click to expand</ac:parameter><ac:rich-text-body>
+<p>Some hidden text</p>
+</ac:rich-text-body></ac:structured-macro>`,
+		},
+		{
+			name: "nested details",
+			input: `<details>
+<summary>Outer</summary>
+<p>Outer content</p>
+<details>
+<summary>Inner</summary>
+<p>Inner content</p>
+</details>
+</details>`,
+			expected: `<ac:structured-macro ac:name="expand"><ac:parameter ac:name="title">Outer</ac:parameter><ac:rich-text-body><p>Outer content</p><ac:structured-macro ac:name="expand"><ac:parameter ac:name="title">Inner</ac:parameter><ac:rich-text-body><p>Inner content</p></ac:rich-text-body></ac:structured-macro></ac:rich-text-body></ac:structured-macro>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := convertDetailsToExpand(tt.input)
+			assert.NoError(t, err)
+
+			// Normalize spaces/newlines to make assertions robust
+			normActual := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(actual, "\n", ""), "\r", ""), " ", "")
+			normExpected := strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(tt.expected, "\n", ""), "\r", ""), " ", "")
+			assert.Equal(t, normExpected, normActual)
+		})
+	}
+}

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -131,17 +131,22 @@ func compileMarkdownWithExtension(markdown []byte, ext goldmark.Extender, logMes
 	return string(html), nil
 }
 
-// CompileMarkdown compiles markdown to Confluence Storage Format with GitHub Alerts support
-// This is the main function that now uses the enhanced GitHub Alerts transformer by default
-// for superior processing of [!NOTE], [!TIP], [!WARNING], [!CAUTION], [!IMPORTANT] syntax.
-// Note: This is a breaking change from previous versions which rendered these markers literally.
 func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib, path string, cfg types.MarkConfig) (string, []attachment.Attachment, error) {
 	ghAlertsExtension := NewConfluenceExtension(stdlib, path, cfg)
 	html, err := compileMarkdownWithExtension(markdown, ghAlertsExtension, "rendering markdown with GitHub Alerts support:\n%s")
 	if err == nil && ghAlertsExtension.Pipeline != nil && ghAlertsExtension.Pipeline.GetError() != nil {
 		err = ghAlertsExtension.Pipeline.GetError()
 	}
-	return html, ghAlertsExtension.Attachments, err
+	if err != nil {
+		return "", nil, err
+	}
+	if slices.Contains(cfg.Features, "details") {
+		html, err = convertDetailsToExpand(html)
+		if err != nil {
+			return "", nil, err
+		}
+	}
+	return html, ghAlertsExtension.Attachments, nil
 }
 
 // CompileMarkdownLegacy compiles markdown using the legacy approach without GitHub Alerts transformer
@@ -149,7 +154,16 @@ func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib, path string, cfg types
 func CompileMarkdownLegacy(markdown []byte, stdlib *stdlib.Lib, path string, cfg types.MarkConfig) (string, []attachment.Attachment, error) {
 	confluenceExtension := NewConfluenceLegacyExtension(stdlib, path, cfg)
 	html, err := compileMarkdownWithExtension(markdown, confluenceExtension, "rendering markdown with legacy renderer:\n%s")
-	return html, confluenceExtension.Attachments, err
+	if err != nil {
+		return "", nil, err
+	}
+	if slices.Contains(cfg.Features, "details") {
+		html, err = convertDetailsToExpand(html)
+		if err != nil {
+			return "", nil, err
+		}
+	}
+	return html, confluenceExtension.Attachments, nil
 }
 
 // ConfluenceExtension is a goldmark extension for GitHub Alerts with Transformer approach

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -249,3 +249,31 @@ func TestContinueOnError(t *testing.T) {
 	assert.Error(t, err, "App should report partial failure when continue-on-error is enabled and some files fail")
 	assert.ErrorContains(t, err, "one or more files failed to process")
 }
+
+func TestDetailsFeature(t *testing.T) {
+	lib, err := stdlib.New(nil)
+	assert.NoError(t, err)
+	markdown := []byte(`<details>
+<summary>Summary Text</summary>
+Some content
+</details>`)
+
+	// 1. With details feature enabled
+	cfgEnabled := types.MarkConfig{
+		Features: []string{"details"},
+	}
+	actualEnabled, _, err := mark.CompileMarkdown(markdown, lib, "testdata/test.md", cfgEnabled)
+	assert.NoError(t, err)
+	assert.Contains(t, actualEnabled, `<ac:structured-macro ac:name="expand">`)
+	assert.Contains(t, actualEnabled, `<ac:parameter ac:name="title">Summary Text</ac:parameter>`)
+	assert.Contains(t, actualEnabled, `<ac:rich-text-body>`)
+
+	// 2. Without details feature enabled
+	cfgDisabled := types.MarkConfig{
+		Features: []string{"mermaid", "mention"},
+	}
+	actualDisabled, _, err := mark.CompileMarkdown(markdown, lib, "testdata/test.md", cfgDisabled)
+	assert.NoError(t, err)
+	assert.NotContains(t, actualDisabled, `<ac:structured-macro ac:name="expand">`)
+	assert.Contains(t, actualDisabled, `<details>`)
+}

--- a/util/flags.go
+++ b/util/flags.go
@@ -210,7 +210,7 @@ var Flags = []cli.Flag{
 	&cli.StringSliceFlag{
 		Name:    "features",
 		Value:   []string{"mermaid", "mention"},
-		Usage:   "Enables optional features. Current features: d2, frontmatter, mermaid, mention, mkdocsadmonitions, plantuml",
+		Usage:   "Enables optional features. Current features: d2, details, frontmatter, mermaid, mention, mkdocsadmonitions, plantuml",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_FEATURES"), altsrctoml.TOML("features", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.BoolFlag{


### PR DESCRIPTION
Implements conversion of HTML <details> and <summary> tags to native Confluence expand macro under the optional 'details' feature flag (e.g. --features=details).