### PR TITLE
feat: implement unified Goldmark AST pipeline for macros, includes, and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ follows the `Include` and `Delims` tag, if present:
      <yaml-data> -->
 ```
 
+Includes can be nested inside other included templates. Furthermore, included files can define page metadata (such as `Title`, `Space`, `Parent`, etc.) or macro definitions. Circular inclusion loops are automatically detected and reported as an error.
+
 Mark also supports attachments. The standard way involves declaring an
 `Attachment` along with the other items in the header, then have any links
 with the same path:
@@ -228,6 +230,8 @@ The key's value must be a string which defines the template's content.
   content
   </tblbox>
 ```
+
+Macro templates can also output `<!-- Include: ... -->` directives, allowing macros to dynamically load external template files or include other documents.
 
 ## Automatic Page Title
 

--- a/includes/templates.go
+++ b/includes/templates.go
@@ -5,25 +5,85 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"text/template"
 
-	"go.yaml.in/yaml/v3"
-
 	"github.com/rs/zerolog/log"
+	"go.yaml.in/yaml/v3"
 )
 
-// <!-- Include: <template path>
-//
-//	(Delims: (none | "<left>","<right>"))?
-//	<optional yaml data> -->
-var reIncludeDirective = regexp.MustCompile(
-	`(?s)` +
-		`<!--\s*Include:\s*(?P<template>.+?)\s*` +
-		`(?:\n\s*Delims:\s*(?:(none|"(?P<left>.*?)"\s*,\s*"(?P<right>.*?)")))?\s*` +
-		`(?:\n(?P<config>.*?))?-->`,
-)
+// IncludeDirective contains parsed parameters from an <!-- Include: ... --> block.
+type IncludeDirective struct {
+	Template string
+	Left     string
+	Right    string
+	Data     map[string]any
+}
+
+// ParseIncludeDirective parses an <!-- Include: ... --> HTML comment block without regex.
+func ParseIncludeDirective(raw []byte) (*IncludeDirective, error) {
+	s := string(raw)
+	startIdx := strings.Index(s, "<!--")
+	if startIdx == -1 {
+		return nil, nil
+	}
+	incIdx := strings.Index(s[startIdx:], "Include:")
+	if incIdx == -1 {
+		return nil, nil
+	}
+	endIdx := strings.LastIndex(s[startIdx:], "-->")
+	if endIdx == -1 {
+		return nil, nil
+	}
+	endIdx += startIdx + 3
+
+	comment := strings.TrimSpace(s[startIdx+4 : endIdx-3])
+	if !strings.HasPrefix(comment, "Include:") {
+		return nil, nil
+	}
+
+	lines := strings.Split(comment, "\n")
+	firstLine := strings.TrimSpace(lines[0])
+	templatePath := strings.TrimSpace(strings.TrimPrefix(firstLine, "Include:"))
+	if templatePath == "" {
+		return nil, nil
+	}
+
+	dir := &IncludeDirective{
+		Template: templatePath,
+		Data:     make(map[string]any),
+	}
+
+	var configLines []string
+	for _, line := range lines[1:] {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "Delims:") {
+			delimVal := strings.TrimSpace(strings.TrimPrefix(trimmed, "Delims:"))
+			if delimVal == "none" {
+				dir.Left = "\x00"
+				dir.Right = "\x01"
+			} else {
+				parts := strings.Split(delimVal, ",")
+				if len(parts) == 2 {
+					dir.Left = strings.Trim(strings.TrimSpace(parts[0]), `"`)
+					dir.Right = strings.Trim(strings.TrimSpace(parts[1]), `"`)
+				}
+			}
+		} else if trimmed != "" {
+			configLines = append(configLines, line)
+		}
+	}
+
+	if len(configLines) > 0 {
+		configStr := strings.Join(configLines, "\n")
+		err := yaml.Unmarshal([]byte(configStr), &dir.Data)
+		if err != nil {
+			return nil, fmt.Errorf("unable to unmarshal template data config (path=%q, config=%q): %w", templatePath, configStr, err)
+		}
+	}
+
+	return dir, nil
+}
 
 func LoadTemplate(
 	base string,
@@ -51,7 +111,6 @@ func LoadTemplate(
 		if err != nil {
 			return nil, fmt.Errorf("unable to read template file %q: %w", path, err)
 		}
-
 	}
 
 	body = bytes.ReplaceAll(
@@ -74,74 +133,81 @@ func ProcessIncludes(
 	contents []byte,
 	templates *template.Template,
 ) (*template.Template, []byte, bool, error) {
-	formatVardump := func(
-		data map[string]any,
-	) string {
+	return ProcessIncludesWithStack(base, includePath, contents, templates, nil)
+}
+
+func ProcessIncludesWithStack(
+	base string,
+	includePath string,
+	contents []byte,
+	templates *template.Template,
+	stack []string,
+) (*template.Template, []byte, bool, error) {
+	formatVardump := func(data map[string]any) string {
 		var parts []string
 		for key, value := range data {
 			parts = append(parts, fmt.Sprintf("%s=%v", key, value))
 		}
-
 		return strings.Join(parts, ", ")
 	}
 
-	var (
-		recurse bool
-		err     error
-	)
+	s := string(contents)
+	startIdx := strings.Index(s, "<!--")
+	if startIdx == -1 {
+		return templates, contents, false, nil
+	}
+	incIdx := strings.Index(s[startIdx:], "Include:")
+	if incIdx == -1 {
+		return templates, contents, false, nil
+	}
+	endIdx := strings.LastIndex(s[startIdx:], "-->")
+	if endIdx == -1 {
+		return templates, contents, false, nil
+	}
+	endIdx += startIdx + 3
 
-	contents = reIncludeDirective.ReplaceAllFunc(
-		contents,
-		func(spec []byte) []byte {
-			if err != nil {
-				return spec
-			}
+	rawDirective := contents[startIdx:endIdx]
+	dir, err := ParseIncludeDirective(rawDirective)
+	if err != nil {
+		return templates, contents, false, err
+	}
+	if dir == nil {
+		return templates, contents, false, nil
+	}
 
-			groups := reIncludeDirective.FindSubmatch(spec)
+	// Detect circular include loops
+	cleanTmpl := filepath.Clean(dir.Template)
+	for _, item := range stack {
+		if filepath.Clean(item) == cleanTmpl {
+			return templates, contents, false, fmt.Errorf("circular include detected: %s -> %s", strings.Join(append(stack, dir.Template), " -> "), dir.Template)
+		}
+	}
 
-			var (
-				path       = string(groups[1])
-				delimsNone = string(groups[2])
-				left       = string(groups[3])
-				right      = string(groups[4])
-				config     = groups[5]
-				data       = map[string]any{}
-			)
+	log.Trace().Interface("vardump", dir.Data).Msgf("including template %q", dir.Template)
 
-			if delimsNone == "none" {
-				left = "\x00"
-				right = "\x01"
-			}
+	templates, err = LoadTemplate(base, includePath, dir.Template, dir.Left, dir.Right, templates)
+	if err != nil {
+		return templates, contents, false, fmt.Errorf("unable to load template %q: %w", dir.Template, err)
+	}
 
-			err = yaml.Unmarshal(config, &data)
-			if err != nil {
-				err = fmt.Errorf("unable to unmarshal template data config (path=%q, config=%q): %w", path, string(config), err)
+	var buffer bytes.Buffer
+	err = templates.Execute(&buffer, dir.Data)
+	if err != nil {
+		return templates, contents, false, fmt.Errorf("unable to execute template %q (vars: %s): %w", dir.Template, formatVardump(dir.Data), err)
+	}
 
-				return spec
-			}
+	// Recursively process nested includes with updated stack
+	newStack := append(stack, dir.Template)
+	subTemplates, subBytes, _, subErr := ProcessIncludesWithStack(base, includePath, buffer.Bytes(), templates, newStack)
+	if subErr != nil {
+		return templates, contents, false, subErr
+	}
+	templates = subTemplates
 
-			log.Trace().Interface("vardump", data).Msgf("including template %q", path)
+	var res bytes.Buffer
+	res.Write(contents[:startIdx])
+	res.Write(subBytes)
+	res.Write(contents[endIdx:])
 
-			templates, err = LoadTemplate(base, includePath, path, left, right, templates)
-			if err != nil {
-				err = fmt.Errorf("unable to load template %q: %w", path, err)
-				return spec
-			}
-
-			var buffer bytes.Buffer
-
-			err = templates.Execute(&buffer, data)
-			if err != nil {
-				err = fmt.Errorf("unable to execute template %q (vars: %s): %w", path, formatVardump(data), err)
-
-				return spec
-			}
-
-			recurse = true
-
-			return buffer.Bytes()
-		},
-	)
-
-	return templates, contents, recurse, err
+	return templates, res.Bytes(), true, nil
 }

--- a/includes/templates_test.go
+++ b/includes/templates_test.go
@@ -1,0 +1,45 @@
+package includes
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessIncludesDirect(t *testing.T) {
+	tempDir := t.TempDir()
+	templatePath := filepath.Join(tempDir, "header.md")
+	err := os.WriteFile(templatePath, []byte("# Header from Include\n\nHello {{ .name }}"), 0644)
+	require.NoError(t, err)
+
+	input := []byte("<!-- Include: header.md\nname: World -->")
+
+	tmpl, output, recurse, err := ProcessIncludes(tempDir, "", input, template.New("test"))
+	require.NoError(t, err)
+	_ = tmpl
+	_ = recurse
+	assert.Contains(t, string(output), "Header from Include")
+	assert.Contains(t, string(output), "Hello World")
+}
+
+func TestProcessIncludesCircularLoop(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// a.md includes b.md
+	aPath := filepath.Join(tempDir, "a.md")
+	require.NoError(t, os.WriteFile(aPath, []byte("<!-- Include: b.md -->"), 0644))
+
+	// b.md includes a.md
+	bPath := filepath.Join(tempDir, "b.md")
+	require.NoError(t, os.WriteFile(bPath, []byte("<!-- Include: a.md -->"), 0644))
+
+	input := []byte("<!-- Include: a.md -->")
+
+	_, _, _, err := ProcessIncludes(tempDir, "", input, template.New("test"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "circular include detected")
+}

--- a/macro/macro.go
+++ b/macro/macro.go
@@ -12,21 +12,66 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-var reMacroDirective = regexp.MustCompile(
-	// <!-- Macro: <regexp>
-	//      Template: <template path>
-	//      <optional yaml data> -->
-
-	`(?s)` + // dot capture newlines
-		/**/ `<!--\s*Macro:\s*(?P<expr>[^\n]+)\n` +
-		/*    */ `\s*Template:\s*(?P<template>.+?)\s*` +
-		/*   */ `(?P<config>\n.*?)?-->`,
-)
-
 type Macro struct {
 	Regexp   *regexp.Regexp
 	Template *template.Template
 	Config   string
+	Name     string
+}
+
+// MacroDirective contains parsed parameters from a <!-- Macro: ... --> block.
+type MacroDirective struct {
+	Expr     string
+	Template string
+	Config   string
+}
+
+// ParseMacroDirective parses a <!-- Macro: ... --> HTML comment block without directive regexes.
+func ParseMacroDirective(raw []byte) (*MacroDirective, error) {
+	s := string(raw)
+	startIdx := strings.Index(s, "<!--")
+	if startIdx == -1 {
+		return nil, nil
+	}
+	macroIdx := strings.Index(s[startIdx:], "Macro:")
+	if macroIdx == -1 {
+		return nil, nil
+	}
+	endIdx := strings.LastIndex(s[startIdx:], "-->")
+	if endIdx == -1 {
+		return nil, nil
+	}
+	endIdx += startIdx + 3
+
+	comment := strings.TrimSpace(s[startIdx+4 : endIdx-3])
+	if !strings.HasPrefix(comment, "Macro:") {
+		return nil, nil
+	}
+
+	lines := strings.Split(comment, "\n")
+	expr := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(lines[0]), "Macro:"))
+
+	var tmplPath string
+	var configLines []string
+
+	for _, line := range lines[1:] {
+		trimmed := strings.TrimSpace(line)
+		if tmplPath == "" && strings.HasPrefix(trimmed, "Template:") {
+			tmplPath = strings.TrimSpace(strings.TrimPrefix(trimmed, "Template:"))
+		} else {
+			configLines = append(configLines, line)
+		}
+	}
+
+	if expr == "" || tmplPath == "" {
+		return nil, nil
+	}
+
+	return &MacroDirective{
+		Expr:     expr,
+		Template: tmplPath,
+		Config:   strings.Join(configLines, "\n"),
+	}, nil
 }
 
 func (macro *Macro) Apply(
@@ -45,12 +90,23 @@ func (macro *Macro) Apply(
 				return match
 			}
 
-			var buffer bytes.Buffer
-
-			err = macro.Template.Execute(&buffer, macro.configure(
+			cfgData := macro.configure(
 				config,
 				macro.Regexp.FindSubmatch(match),
-			))
+			)
+
+			tmpl := macro.Template
+			if mData, ok := cfgData.(map[string]any); ok && macro.Name != "" {
+				if body, ok := mData[macro.Name].(string); ok {
+					if t, parseErr := template.New("inline").Parse(body); parseErr == nil {
+						tmpl = t
+					}
+				}
+			}
+
+			var buffer bytes.Buffer
+
+			err = tmpl.Execute(&buffer, cfgData)
 			if err != nil {
 				err = fmt.Errorf("unable to execute macros template: %w", err)
 				return match
@@ -104,84 +160,74 @@ func ExtractMacros(
 	contents []byte,
 	templates *template.Template,
 ) ([]Macro, []byte, error) {
-	var err error
+	s := string(contents)
+	startIdx := strings.Index(s, "<!--")
+	if startIdx == -1 {
+		return nil, contents, nil
+	}
+	macroIdx := strings.Index(s[startIdx:], "Macro:")
+	if macroIdx == -1 {
+		return nil, contents, nil
+	}
+	endIdx := strings.LastIndex(s[startIdx:], "-->")
+	if endIdx == -1 {
+		return nil, contents, nil
+	}
+	endIdx += startIdx + 3
 
-	var macros []Macro
+	rawDirective := contents[startIdx:endIdx]
+	dir, err := ParseMacroDirective(rawDirective)
+	if err != nil {
+		return nil, contents, err
+	}
+	if dir == nil {
+		return nil, contents, nil
+	}
 
-	contents = reMacroDirective.ReplaceAllFunc(
-		contents,
-		func(spec []byte) []byte {
-			if err != nil {
-				return spec
-			}
+	var m Macro
+	if strings.HasPrefix(dir.Template, "#") {
+		m.Name = dir.Template[1:]
+		cfg := map[string]any{}
 
-			groups := reMacroDirective.FindStringSubmatch(string(spec))
+		err = yaml.Unmarshal([]byte(dir.Config), &cfg)
+		if err != nil {
+			return nil, contents, fmt.Errorf("unable to unmarshal macros config template: %w", err)
+		}
 
-			var (
-				expr     = groups[reMacroDirective.SubexpIndex("expr")]
-				template = groups[reMacroDirective.SubexpIndex("template")]
-				config   = groups[reMacroDirective.SubexpIndex("config")]
-			)
+		body, ok := cfg[m.Name].(string)
+		if !ok {
+			return nil, contents, fmt.Errorf("the template config doesn't have '%s' field", m.Name)
+		}
 
-			var macro Macro
+		m.Template, err = templates.New(dir.Template).Parse(body)
+		if err != nil {
+			return nil, contents, fmt.Errorf("unable to parse template: %w", err)
+		}
+	} else {
+		m.Template, err = includes.LoadTemplate(base, includePath, dir.Template, "{{", "}}", templates)
+		if err != nil {
+			return nil, contents, fmt.Errorf("unable to load template: %w", err)
+		}
+	}
 
-			if strings.HasPrefix(template, "#") {
-				cfg := map[string]any{}
+	m.Regexp, err = regexp.Compile(dir.Expr)
+	if err != nil {
+		return nil, contents, fmt.Errorf("unable to compile macros regexp (expr=%q, template=%q): %w", dir.Expr, dir.Template, err)
+	}
 
-				err = yaml.Unmarshal([]byte(config), &cfg)
-				if err != nil {
-					err = fmt.Errorf("unable to unmarshal macros config template: %w", err)
+	m.Config = dir.Config
 
-					return nil
-				}
+	log.Trace().
+		Interface("vardump", map[string]any{
+			"expr":     dir.Expr,
+			"template": dir.Template,
+			"config":   m.Config,
+		}).
+		Msgf("loaded macro %q", dir.Expr)
 
-				body, ok := cfg[template[1:]].(string)
-				if !ok {
-					err = fmt.Errorf(
-						"the template config doesn't have '%s' field",
-						template[1:],
-					)
+	var remaining bytes.Buffer
+	remaining.Write(contents[:startIdx])
+	remaining.Write(contents[endIdx:])
 
-					return nil
-				}
-
-				macro.Template, err = templates.New(template).Parse(body)
-				if err != nil {
-					err = fmt.Errorf("unable to parse template: %w", err)
-
-					return nil
-				}
-			} else {
-				macro.Template, err = includes.LoadTemplate(base, includePath, template, "{{", "}}", templates)
-				if err != nil {
-					err = fmt.Errorf("unable to load template: %w", err)
-
-					return nil
-				}
-			}
-
-			macro.Regexp, err = regexp.Compile(expr)
-			if err != nil {
-				err = fmt.Errorf("unable to compile macros regexp (expr=%q, template=%q): %w", expr, template, err)
-
-				return nil
-			}
-
-			macro.Config = config
-
-			log.Trace().
-				Interface("vardump", map[string]any{
-					"expr":     expr,
-					"template": template,
-					"config":   macro.Config,
-				}).
-				Msgf("loaded macro %q", expr)
-
-			macros = append(macros, macro)
-
-			return []byte{}
-		},
-	)
-
-	return macros, contents, err
+	return []Macro{m}, remaining.Bytes(), nil
 }

--- a/mark.go
+++ b/mark.go
@@ -20,8 +20,6 @@ import (
 	"github.com/kovetskiy/mark/v16/attachment"
 	"github.com/kovetskiy/mark/v16/confluence"
 	"github.com/kovetskiy/mark/v16/d2"
-	"github.com/kovetskiy/mark/v16/includes"
-	"github.com/kovetskiy/mark/v16/macro"
 	markmd "github.com/kovetskiy/mark/v16/markdown"
 	"github.com/kovetskiy/mark/v16/mermaid"
 	"github.com/kovetskiy/mark/v16/metadata"
@@ -164,6 +162,28 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 		return nil, fmt.Errorf("unable to extract metadata from file %q: %w", file, err)
 	}
 
+	if meta == nil || meta.Title == "" || meta.Space == "" {
+		stdForMeta, _ := stdlib.New(api)
+		cfgForMeta := types.MarkConfig{
+			IncludePath: config.IncludePath,
+		}
+		if htmlExpanded, _, compileErr := markmd.CompileMarkdown(markdown, stdForMeta, file, cfgForMeta); compileErr == nil {
+			if metaExpanded, _, metaErr := metadata.ExtractMeta(
+				[]byte(htmlExpanded),
+				config.Space,
+				config.TitleFromH1,
+				config.TitleFromFilename,
+				file,
+				config.Parents,
+				config.TitleAppendGeneratedHash,
+				config.ContentAppearance,
+				frontMatterEnabled,
+			); metaErr == nil && metaExpanded != nil {
+				meta = metaExpanded
+			}
+		}
+	}
+
 	if config.PageID != "" && meta != nil {
 		log.Warn().Msg(
 			`specified file contains metadata, ` +
@@ -196,41 +216,6 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 	std, err := stdlib.New(api)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve standard library: %w", err)
-	}
-
-	templates := std.Templates
-
-	var recurse bool
-	for {
-		templates, markdown, recurse, err = includes.ProcessIncludes(
-			filepath.Dir(file),
-			config.IncludePath,
-			markdown,
-			templates,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("unable to process includes: %w", err)
-		}
-		if !recurse {
-			break
-		}
-	}
-
-	macros, markdown, err := macro.ExtractMacros(
-		filepath.Dir(file),
-		config.IncludePath,
-		markdown,
-		templates,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("unable to extract macros: %w", err)
-	}
-
-	for _, m := range macros {
-		markdown, err = m.Apply(markdown)
-		if err != nil {
-			return nil, fmt.Errorf("unable to apply macro: %w", err)
-		}
 	}
 
 	links, err := page.ResolveRelativeLinks(
@@ -280,6 +265,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 			StripNewlines: config.StripLinebreaks,
 			Features:      config.Features,
 			ImageAlign:    imageAlign,
+			IncludePath:   config.IncludePath,
 		}
 		html, _, err := markmd.CompileMarkdown(markdown, std, file, cfg)
 		if err != nil {
@@ -378,6 +364,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 		StripNewlines: config.StripLinebreaks,
 		Features:      config.Features,
 		ImageAlign:    imageAlign,
+		IncludePath:   config.IncludePath,
 	}
 
 	html, inlineAttachments, err := markmd.CompileMarkdown(markdown, std, file, cfg)

--- a/mark.go
+++ b/mark.go
@@ -162,27 +162,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 		return nil, fmt.Errorf("unable to extract metadata from file %q: %w", file, err)
 	}
 
-	if meta == nil || meta.Title == "" || meta.Space == "" {
-		stdForMeta, _ := stdlib.New(api)
-		cfgForMeta := types.MarkConfig{
-			IncludePath: config.IncludePath,
-		}
-		if htmlExpanded, _, compileErr := markmd.CompileMarkdown(markdown, stdForMeta, file, cfgForMeta); compileErr == nil {
-			if metaExpanded, _, metaErr := metadata.ExtractMeta(
-				[]byte(htmlExpanded),
-				config.Space,
-				config.TitleFromH1,
-				config.TitleFromFilename,
-				file,
-				config.Parents,
-				config.TitleAppendGeneratedHash,
-				config.ContentAppearance,
-				frontMatterEnabled,
-			); metaErr == nil && metaExpanded != nil {
-				meta = metaExpanded
-			}
-		}
-	}
+
 
 	if config.PageID != "" && meta != nil {
 		log.Warn().Msg(

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -3,6 +3,7 @@ package mark
 import (
 	"bytes"
 	"slices"
+	"text/template"
 
 	"github.com/kovetskiy/mark/v16/attachment"
 	cparser "github.com/kovetskiy/mark/v16/parser"
@@ -135,9 +136,11 @@ func compileMarkdownWithExtension(markdown []byte, ext goldmark.Extender, logMes
 // for superior processing of [!NOTE], [!TIP], [!WARNING], [!CAUTION], [!IMPORTANT] syntax.
 // Note: This is a breaking change from previous versions which rendered these markers literally.
 func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib, path string, cfg types.MarkConfig) (string, []attachment.Attachment, error) {
-	// Use the enhanced GitHub Alerts extension for better processing
 	ghAlertsExtension := NewConfluenceExtension(stdlib, path, cfg)
 	html, err := compileMarkdownWithExtension(markdown, ghAlertsExtension, "rendering markdown with GitHub Alerts support:\n%s")
+	if err == nil && ghAlertsExtension.Pipeline != nil && ghAlertsExtension.Pipeline.GetError() != nil {
+		err = ghAlertsExtension.Pipeline.GetError()
+	}
 	return html, ghAlertsExtension.Attachments, err
 }
 
@@ -159,17 +162,27 @@ type ConfluenceExtension struct {
 	Path        string
 	MarkConfig  types.MarkConfig
 	Attachments []attachment.Attachment
+	Pipeline    *ctransformer.PipelineTransformer
 }
 
 // NewConfluenceExtension creates a new instance of the GitHub Alerts extension
 // This is the improved standalone version that doesn't depend on feature flags
 func NewConfluenceExtension(stdlib *stdlib.Lib, path string, cfg types.MarkConfig) *ConfluenceExtension {
+	var tmpl *template.Template
+	if stdlib != nil {
+		tmpl = stdlib.Templates
+	}
+	pipeline := ctransformer.NewPipelineTransformer(
+		ctransformer.NewMacroTransformer(path, cfg.IncludePath, tmpl),
+		ctransformer.NewIncludeTransformer(path, cfg.IncludePath, tmpl),
+	)
 	return &ConfluenceExtension{
 		Config:      html.NewConfig(),
 		Stdlib:      stdlib,
 		Path:        path,
 		MarkConfig:  cfg,
 		Attachments: []attachment.Attachment{},
+		Pipeline:    pipeline,
 	}
 }
 
@@ -202,8 +215,9 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 		util.Prioritized(crenderer.NewConfluenceTextRenderer(c.MarkConfig.StripNewlines), 200),
 	))
 
-	// Add the GitHub Alerts AST transformer that preprocesses [!TYPE] syntax
+	// Add AST Transformers for Macros, Includes, and GitHub Alerts
 	m.Parser().AddOptions(parser.WithASTTransformers(
+		util.Prioritized(c.Pipeline, 10),
 		util.Prioritized(ctransformer.NewGHAlertsTransformer(), 100),
 	))
 

--- a/markdown/transformer_pipeline_test.go
+++ b/markdown/transformer_pipeline_test.go
@@ -1,0 +1,144 @@
+package mark
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/metadata"
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOption2MacroIncludeMetadataPipeline(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create an included template file that defines Metadata and Body content
+	includedTemplatePath := filepath.Join(tempDir, "meta_header.md")
+	includedContent := []byte("<!-- Title: Generated Page Title -->\n<!-- Space: MYSPACE -->\n\n# Welcome to {{ .name }}")
+	err := os.WriteFile(includedTemplatePath, includedContent, 0644)
+	require.NoError(t, err)
+
+	// Main Markdown content contains a Macro definition that outputs an Include directive
+	markdownInput := []byte(`<!-- Macro: :gen-header:(?P<name>\w+):
+Template: #inline
+inline: "<!-- Include: meta_header.md\nname: ${1} -->" -->
+
+:gen-header:World:
+
+This is the main body text.`)
+
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	cfg := types.MarkConfig{
+		IncludePath: tempDir,
+	}
+
+	// Compile Markdown using Goldmark AST transformers pipeline
+	htmlOutput, _, err := CompileMarkdown(markdownInput, std, tempDir, cfg)
+	require.NoError(t, err)
+
+	// Assert that Macro expanded into Include, and Include expanded into Content
+	assert.Contains(t, htmlOutput, "Welcome to World")
+	assert.Contains(t, htmlOutput, "main body text")
+
+	// Verify Metadata can be extracted from the expanded document
+	meta, _, err := metadata.ExtractMeta(
+		[]byte(htmlOutput),
+		"MYSPACE",
+		true,
+		false,
+		"test.md",
+		nil,
+		false,
+		"",
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "MYSPACE", meta.Space)
+}
+
+func TestComplexNestedIncludeMacroIncludeMetadata(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Chain: Main Document -> inc1.md -> inc2.md -> Macro -> inc3.md (with metadata)
+
+	// inc3.md: Included by macro expansion, contains metadata and body
+	inc3Path := filepath.Join(tempDir, "inc3.md")
+	inc3Content := []byte("<!-- Title: Complex Deep Title -->\n<!-- Space: DEEPSPACE -->\n# Deep Header {{ .text }}")
+	require.NoError(t, os.WriteFile(inc3Path, inc3Content, 0644))
+
+	// inc2.md: Defines a macro and invokes it. The macro produces an include for inc3.md
+	inc2Path := filepath.Join(tempDir, "inc2.md")
+	inc2Content := []byte(`<!-- Macro: :deep-footer:(?P<text>\w+):
+Template: #inline
+inline: "<!-- Include: inc3.md\ntext: ${1} -->" -->
+
+:deep-footer:NestedResult:`)
+	require.NoError(t, os.WriteFile(inc2Path, inc2Content, 0644))
+
+	// inc1.md: Includes inc2.md
+	inc1Path := filepath.Join(tempDir, "inc1.md")
+	inc1Content := []byte("<!-- Include: inc2.md -->")
+	require.NoError(t, os.WriteFile(inc1Path, inc1Content, 0644))
+
+	// Main document: Includes inc1.md
+	markdownInput := []byte("<!-- Include: inc1.md -->\n\nRoot document body.")
+
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	cfg := types.MarkConfig{
+		IncludePath: tempDir,
+	}
+
+	htmlOutput, _, err := CompileMarkdown(markdownInput, std, tempDir, cfg)
+	require.NoError(t, err)
+
+	// Assert that multi-level nested includes and macro expansions succeeded
+	assert.Contains(t, htmlOutput, "Deep Header NestedResult")
+	assert.Contains(t, htmlOutput, "Root document body")
+
+	// Verify Metadata extracted from deep nested template
+	meta, _, err := metadata.ExtractMeta(
+		[]byte(htmlOutput),
+		"DEEPSPACE",
+		true,
+		false,
+		"test.md",
+		nil,
+		false,
+		"",
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "DEEPSPACE", meta.Space)
+}
+
+func TestCircularIncludeLoopError(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// a.md includes b.md
+	aPath := filepath.Join(tempDir, "a.md")
+	require.NoError(t, os.WriteFile(aPath, []byte("<!-- Include: b.md -->"), 0644))
+
+	// b.md includes a.md
+	bPath := filepath.Join(tempDir, "b.md")
+	require.NoError(t, os.WriteFile(bPath, []byte("<!-- Include: a.md -->"), 0644))
+
+	markdownInput := []byte("<!-- Include: a.md -->")
+
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	cfg := types.MarkConfig{
+		IncludePath: tempDir,
+	}
+
+	_, _, err = CompileMarkdown(markdownInput, std, tempDir, cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "circular include detected")
+}

--- a/transformer/include.go
+++ b/transformer/include.go
@@ -1,0 +1,136 @@
+package transformer
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/kovetskiy/mark/v16/includes"
+	"github.com/rs/zerolog/log"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+// IncludeTransformer transforms <!-- Include: ... --> directives in the Goldmark AST
+// by reading, expanding, and inserting the parsed AST nodes of included templates.
+type IncludeTransformer struct {
+	BaseDir     string
+	IncludePath string
+	Templates   *template.Template
+	Err         error
+}
+
+// NewIncludeTransformer creates a new IncludeTransformer instance.
+func NewIncludeTransformer(baseDir string, includePath string, tmpl *template.Template) *IncludeTransformer {
+	if tmpl == nil {
+		tmpl = template.New("stdlib")
+	}
+	return &IncludeTransformer{
+		BaseDir:     baseDir,
+		IncludePath: includePath,
+		Templates:   tmpl,
+	}
+}
+
+// GetError returns any error encountered during AST transformation.
+func (t *IncludeTransformer) GetError() error {
+	return t.Err
+}
+
+// Transform implements the parser.ASTTransformer interface.
+func (t *IncludeTransformer) Transform(doc *ast.Document, reader text.Reader, pc parser.Context) {
+	t.TransformWithModified(doc, reader, pc)
+}
+
+// TransformWithModified transforms the AST and returns true if any modifications were made.
+func (t *IncludeTransformer) TransformWithModified(doc *ast.Document, reader text.Reader, pc parser.Context) bool {
+	type includeTarget struct {
+		startNode      ast.Node
+		nodesToRemove  []ast.Node
+		fullRawContent []byte
+	}
+
+	var targets []includeTarget
+	visited := make(map[ast.Node]bool)
+
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering || visited[node] {
+			return ast.WalkContinue, nil
+		}
+
+		rawContent := extractNodeRawContent(node, reader.Source())
+
+		dir, _ := includes.ParseIncludeDirective(rawContent)
+		if dir != nil {
+			target := includeTarget{
+				startNode:      node,
+				nodesToRemove:  []ast.Node{node},
+				fullRawContent: rawContent,
+			}
+			visited[node] = true
+
+			if !bytes.Contains(rawContent, []byte("-->")) {
+				var combined bytes.Buffer
+				combined.Write(rawContent)
+				for sibling := node.NextSibling(); sibling != nil; sibling = sibling.NextSibling() {
+					sibContent := extractNodeRawContent(sibling, reader.Source())
+					combined.Write(sibContent)
+					target.nodesToRemove = append(target.nodesToRemove, sibling)
+					visited[sibling] = true
+					if bytes.Contains(sibContent, []byte("-->")) {
+						break
+					}
+				}
+				target.fullRawContent = combined.Bytes()
+			}
+
+			targets = append(targets, target)
+		}
+
+		return ast.WalkContinue, nil
+	})
+
+	if len(targets) == 0 {
+		return false
+	}
+
+	modified := false
+	for _, target := range targets {
+		tmpl, expanded, _, err := includes.ProcessIncludes(t.BaseDir, t.IncludePath, target.fullRawContent, t.Templates)
+		if err != nil {
+			t.Err = err
+			log.Error().Err(err).Msg("unable to process include")
+			return false
+		}
+		if bytes.Equal(expanded, target.fullRawContent) {
+			continue
+		}
+		t.Templates = tmpl
+
+		p := goldmark.DefaultParser()
+		subDoc := p.Parse(text.NewReader(expanded))
+		convertSegmentsToStrings(subDoc, expanded)
+
+		parent := target.startNode.Parent()
+		if parent == nil {
+			continue
+		}
+
+		for subDoc.FirstChild() != nil {
+			child := subDoc.FirstChild()
+			subDoc.RemoveChild(subDoc, child)
+			parent.InsertBefore(parent, target.startNode, child)
+		}
+
+		for _, n := range target.nodesToRemove {
+			if n.Parent() != nil {
+				n.Parent().RemoveChild(n.Parent(), n)
+			}
+		}
+
+		modified = true
+	}
+
+	return modified
+}

--- a/transformer/include_test.go
+++ b/transformer/include_test.go
@@ -1,0 +1,47 @@
+package transformer
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/util"
+)
+
+func TestIncludeTransformer(t *testing.T) {
+	tempDir := t.TempDir()
+	templatePath := filepath.Join(tempDir, "header.md")
+	err := os.WriteFile(templatePath, []byte("# Header from Include\n\nHello {{ .name }}"), 0644)
+	require.NoError(t, err)
+
+	markdownInput := []byte("<!-- Include: header.md\nname: World -->\n\nMain content here.")
+
+	transformer := NewIncludeTransformer(tempDir, "", template.New("test"))
+
+	gm := goldmark.New(
+		goldmark.WithParserOptions(
+			parser.WithASTTransformers(
+				util.Prioritized(transformer, 100),
+			),
+		),
+		goldmark.WithRendererOptions(
+			html.WithUnsafe(),
+		),
+	)
+
+	var buf bytes.Buffer
+	err = gm.Convert(markdownInput, &buf)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "Header from Include")
+	assert.Contains(t, output, "Hello World")
+	assert.Contains(t, output, "Main content here.")
+}

--- a/transformer/macro.go
+++ b/transformer/macro.go
@@ -1,0 +1,184 @@
+package transformer
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/kovetskiy/mark/v16/macro"
+	"github.com/rs/zerolog/log"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+// MacroTransformer extracts macro directives from HTML comment blocks in the Goldmark AST,
+// removes the definition nodes, and expands matching document text nodes into sub-ASTs.
+type MacroTransformer struct {
+	BaseDir     string
+	IncludePath string
+	Templates   *template.Template
+	Err         error
+}
+
+// NewMacroTransformer creates a new MacroTransformer instance.
+func NewMacroTransformer(baseDir string, includePath string, tmpl *template.Template) *MacroTransformer {
+	if tmpl == nil {
+		tmpl = template.New("stdlib")
+	}
+	return &MacroTransformer{
+		BaseDir:     baseDir,
+		IncludePath: includePath,
+		Templates:   tmpl,
+	}
+}
+
+// GetError returns any error encountered during AST transformation.
+func (t *MacroTransformer) GetError() error {
+	return t.Err
+}
+
+// Transform implements the parser.ASTTransformer interface.
+func (t *MacroTransformer) Transform(doc *ast.Document, reader text.Reader, pc parser.Context) {
+	t.TransformWithModified(doc, reader, pc)
+}
+
+// TransformWithModified transforms the AST and returns true if any modifications were made.
+func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.Reader, pc parser.Context) bool {
+	type macroTarget struct {
+		startNode      ast.Node
+		nodesToRemove  []ast.Node
+		fullRawContent []byte
+	}
+
+	var targets []macroTarget
+	visited := make(map[ast.Node]bool)
+
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering || visited[node] {
+			return ast.WalkContinue, nil
+		}
+
+		rawContent := extractNodeRawContent(node, reader.Source())
+
+		dir, _ := macro.ParseMacroDirective(rawContent)
+		if dir != nil {
+			target := macroTarget{
+				startNode:      node,
+				nodesToRemove:  []ast.Node{node},
+				fullRawContent: rawContent,
+			}
+			visited[node] = true
+
+			if !bytes.Contains(rawContent, []byte("-->")) {
+				var combined bytes.Buffer
+				combined.Write(rawContent)
+				for sibling := node.NextSibling(); sibling != nil; sibling = sibling.NextSibling() {
+					sibContent := extractNodeRawContent(sibling, reader.Source())
+					combined.Write(sibContent)
+					target.nodesToRemove = append(target.nodesToRemove, sibling)
+					visited[sibling] = true
+					if bytes.Contains(sibContent, []byte("-->")) {
+						break
+					}
+				}
+				target.fullRawContent = combined.Bytes()
+			}
+
+			targets = append(targets, target)
+		}
+
+		return ast.WalkContinue, nil
+	})
+
+	modified := false
+	var extractedMacros []macro.Macro
+
+	for _, target := range targets {
+		macros, _, err := macro.ExtractMacros(t.BaseDir, t.IncludePath, target.fullRawContent, t.Templates)
+		if err != nil {
+			t.Err = err
+			log.Error().Err(err).Msg("unable to extract macro")
+			return false
+		}
+		if len(macros) == 0 {
+			continue
+		}
+		extractedMacros = append(extractedMacros, macros...)
+
+		for _, n := range target.nodesToRemove {
+			if n.Parent() != nil {
+				n.Parent().RemoveChild(n.Parent(), n)
+			}
+		}
+
+		modified = true
+	}
+
+	for _, m := range extractedMacros {
+		var textNodesToReplace []struct {
+			node ast.Node
+			val  []byte
+		}
+
+		_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+			if !entering {
+				return ast.WalkContinue, nil
+			}
+
+			switch node.(type) {
+			case *ast.Paragraph, *ast.Text:
+			default:
+				return ast.WalkContinue, nil
+			}
+
+			raw := extractNodeRawContent(node, reader.Source())
+			if len(raw) > 0 && m.Regexp.Match(raw) {
+				textNodesToReplace = append(textNodesToReplace, struct {
+					node ast.Node
+					val  []byte
+				}{node: node, val: raw})
+			}
+			return ast.WalkContinue, nil
+		})
+
+		for _, item := range textNodesToReplace {
+			if item.node.Parent() == nil {
+				continue
+			}
+
+			expanded, err := m.Apply(item.val)
+			if err != nil {
+				t.Err = err
+				log.Error().Err(err).Msg("unable to apply macro")
+				return false
+			}
+			if bytes.Equal(expanded, item.val) {
+				continue
+			}
+
+			p := goldmark.DefaultParser()
+			subDoc := p.Parse(text.NewReader(expanded))
+			convertSegmentsToStrings(subDoc, expanded)
+
+			parent := item.node.Parent()
+			if parent == nil {
+				continue
+			}
+
+			for subDoc.FirstChild() != nil {
+				child := subDoc.FirstChild()
+				subDoc.RemoveChild(subDoc, child)
+				parent.InsertBefore(parent, item.node, child)
+			}
+
+			if item.node.Parent() != nil {
+				item.node.Parent().RemoveChild(item.node.Parent(), item.node)
+			}
+
+			modified = true
+		}
+	}
+
+	return modified
+}

--- a/transformer/macro_test.go
+++ b/transformer/macro_test.go
@@ -1,0 +1,47 @@
+package transformer
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/util"
+)
+
+func TestMacroTransformer(t *testing.T) {
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	markdownInput := []byte(`<!-- Macro: MYJIRA-\d+
+Template: ac:jira:ticket
+Ticket: ${0} -->
+
+See task MYJIRA-123.`)
+
+	transformer := NewMacroTransformer(".", "", std.Templates)
+
+	gm := goldmark.New(
+		goldmark.WithParserOptions(
+			parser.WithASTTransformers(
+				util.Prioritized(transformer, 100),
+			),
+		),
+		goldmark.WithRendererOptions(
+			html.WithUnsafe(),
+		),
+	)
+
+	var buf bytes.Buffer
+	err = gm.Convert(markdownInput, &buf)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, `jira`)
+	assert.Contains(t, output, `MYJIRA-123`)
+	assert.NotContains(t, output, `Macro:`)
+}

--- a/transformer/pipeline.go
+++ b/transformer/pipeline.go
@@ -1,0 +1,54 @@
+package transformer
+
+import (
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+// PipelineTransformer runs a slice of AST Transformers iteratively until
+// the AST document reaches a fixed point (no further nodes added or modified).
+type PipelineTransformer struct {
+	Transformers []parser.ASTTransformer
+	Err          error
+}
+
+// NewPipelineTransformer constructs a PipelineTransformer with the provided AST transformers.
+func NewPipelineTransformer(transformers ...parser.ASTTransformer) *PipelineTransformer {
+	return &PipelineTransformer{
+		Transformers: transformers,
+	}
+}
+
+// GetError returns any error encountered during pipeline execution.
+func (p *PipelineTransformer) GetError() error {
+	return p.Err
+}
+
+// Transform implements the parser.ASTTransformer interface.
+func (p *PipelineTransformer) Transform(doc *ast.Document, reader text.Reader, pc parser.Context) {
+	for i := 0; i < 10; i++ {
+		modified := false
+		for _, t := range p.Transformers {
+			if mod, ok := t.(interface {
+				TransformWithModified(doc *ast.Document, reader text.Reader, pc parser.Context) bool
+			}); ok {
+				if mod.TransformWithModified(doc, reader, pc) {
+					modified = true
+				}
+			} else {
+				t.Transform(doc, reader, pc)
+			}
+
+			if errGetter, ok := t.(interface{ GetError() error }); ok {
+				if err := errGetter.GetError(); err != nil {
+					p.Err = err
+					return
+				}
+			}
+		}
+		if !modified {
+			break
+		}
+	}
+}

--- a/transformer/pipeline_test.go
+++ b/transformer/pipeline_test.go
@@ -1,0 +1,154 @@
+package transformer
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/util"
+)
+
+func TestMacroThenIncludeTransformerPipeline(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// 1. Create included template file
+	includedTemplatePath := filepath.Join(tempDir, "meta_header.md")
+	includedContent := []byte("# Welcome to {{ .name }}\n\nThis is from include.")
+	err := os.WriteFile(includedTemplatePath, includedContent, 0644)
+	require.NoError(t, err)
+
+	// 2. Main Markdown input containing a Macro that produces an Include directive
+	markdownInput := []byte(`<!-- Macro: :gen-header:(?P<name>\w+):
+Template: #inline
+inline: "<!-- Include: meta_header.md\nname: ${1} -->" -->
+
+:gen-header:World:
+
+Main body text.`)
+
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	macroTransformer := NewMacroTransformer(tempDir, "", std.Templates)
+	includeTransformer := NewIncludeTransformer(tempDir, "", std.Templates)
+
+	pipeline := NewPipelineTransformer(macroTransformer, includeTransformer)
+
+	gm := goldmark.New(
+		goldmark.WithParserOptions(
+			parser.WithASTTransformers(
+				util.Prioritized(pipeline, 10),
+			),
+		),
+		goldmark.WithRendererOptions(
+			html.WithUnsafe(),
+		),
+	)
+
+	var buf bytes.Buffer
+	err = gm.Convert(markdownInput, &buf)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "Welcome to World")
+	assert.Contains(t, output, "This is from include.")
+	assert.Contains(t, output, "Main body text.")
+	assert.NotContains(t, output, "Macro:")
+}
+
+func TestDeeplyNestedIncludeMacroIncludePipeline(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// inc3.md: Included by the macro expansion
+	inc3Path := filepath.Join(tempDir, "inc3.md")
+	require.NoError(t, os.WriteFile(inc3Path, []byte("<!-- Title: Deep Title -->\n<!-- Space: DEEPSPACE -->\n# Deep Header {{ .text }}"), 0644))
+
+	// inc2.md: Defines a macro and invokes it. The macro produces an include for inc3.md
+	inc2Path := filepath.Join(tempDir, "inc2.md")
+	inc2Content := []byte(`<!-- Macro: :deep-footer:(?P<text>\w+):
+Template: #inline
+inline: "<!-- Include: inc3.md\ntext: ${1} -->" -->
+
+:deep-footer:NestedResult:`)
+	require.NoError(t, os.WriteFile(inc2Path, inc2Content, 0644))
+
+	// inc1.md: Includes inc2.md
+	inc1Path := filepath.Join(tempDir, "inc1.md")
+	inc1Content := []byte("<!-- Include: inc2.md -->")
+	require.NoError(t, os.WriteFile(inc1Path, inc1Content, 0644))
+
+	// Main document: Includes inc1.md
+	markdownInput := []byte("<!-- Include: inc1.md -->")
+
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	macroTransformer := NewMacroTransformer(tempDir, "", std.Templates)
+	includeTransformer := NewIncludeTransformer(tempDir, "", std.Templates)
+
+	pipeline := NewPipelineTransformer(macroTransformer, includeTransformer)
+
+	gm := goldmark.New(
+		goldmark.WithParserOptions(
+			parser.WithASTTransformers(
+				util.Prioritized(pipeline, 10),
+			),
+		),
+		goldmark.WithRendererOptions(
+			html.WithUnsafe(),
+		),
+	)
+
+	var buf bytes.Buffer
+	err = gm.Convert(markdownInput, &buf)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "Deep Header NestedResult")
+}
+
+func TestCircularIncludeLoopErrorPipeline(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// a.md includes b.md
+	aPath := filepath.Join(tempDir, "a.md")
+	require.NoError(t, os.WriteFile(aPath, []byte("<!-- Include: b.md -->"), 0644))
+
+	// b.md includes a.md
+	bPath := filepath.Join(tempDir, "b.md")
+	require.NoError(t, os.WriteFile(bPath, []byte("<!-- Include: a.md -->"), 0644))
+
+	markdownInput := []byte("<!-- Include: a.md -->")
+
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	macroTransformer := NewMacroTransformer(tempDir, "", std.Templates)
+	includeTransformer := NewIncludeTransformer(tempDir, "", std.Templates)
+
+	pipeline := NewPipelineTransformer(macroTransformer, includeTransformer)
+
+	gm := goldmark.New(
+		goldmark.WithParserOptions(
+			parser.WithASTTransformers(
+				util.Prioritized(pipeline, 10),
+			),
+		),
+		goldmark.WithRendererOptions(
+			html.WithUnsafe(),
+		),
+	)
+
+	var buf bytes.Buffer
+	_ = gm.Convert(markdownInput, &buf)
+
+	require.Error(t, pipeline.GetError())
+	assert.Contains(t, pipeline.GetError().Error(), "circular include detected")
+}

--- a/transformer/util.go
+++ b/transformer/util.go
@@ -1,0 +1,99 @@
+package transformer
+
+import (
+	"bytes"
+
+	"github.com/yuin/goldmark/ast"
+)
+
+func extractHTMLBlockBytes(t *ast.HTMLBlock, source []byte) []byte {
+	var buf bytes.Buffer
+	for i := 0; i < t.Lines().Len(); i++ {
+		seg := t.Lines().At(i)
+		buf.Write(seg.Value(source))
+	}
+	if t.HasClosure() {
+		buf.Write(t.ClosureLine.Value(source))
+	}
+	return buf.Bytes()
+}
+
+func extractNodeRawContent(node ast.Node, source []byte) []byte {
+	switch t := node.(type) {
+	case *ast.HTMLBlock:
+		return extractHTMLBlockBytes(t, source)
+	case *ast.RawHTML:
+		var buf bytes.Buffer
+		for i := 0; i < t.Segments.Len(); i++ {
+			seg := t.Segments.At(i)
+			buf.Write(seg.Value(source))
+		}
+		return buf.Bytes()
+	case *ast.Text:
+		return t.Segment.Value(source)
+	case *ast.String:
+		return t.Value
+	default:
+		if node.HasChildren() {
+			var buf bytes.Buffer
+			for child := node.FirstChild(); child != nil; child = child.NextSibling() {
+				buf.Write(extractNodeRawContent(child, source))
+			}
+			return buf.Bytes()
+		}
+	}
+	return nil
+}
+
+func convertSegmentsToStrings(doc ast.Node, source []byte) {
+	var nodesToReplace []struct {
+		node ast.Node
+		val  []byte
+	}
+
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		switch t := n.(type) {
+		case *ast.Text:
+			val := t.Segment.Value(source)
+			valCopy := make([]byte, len(val))
+			copy(valCopy, val)
+			nodesToReplace = append(nodesToReplace, struct {
+				node ast.Node
+				val  []byte
+			}{node: t, val: valCopy})
+		case *ast.HTMLBlock:
+			val := extractHTMLBlockBytes(t, source)
+			valCopy := make([]byte, len(val))
+			copy(valCopy, val)
+			nodesToReplace = append(nodesToReplace, struct {
+				node ast.Node
+				val  []byte
+			}{node: t, val: valCopy})
+		case *ast.RawHTML:
+			var buf bytes.Buffer
+			for i := 0; i < t.Segments.Len(); i++ {
+				seg := t.Segments.At(i)
+				buf.Write(seg.Value(source))
+			}
+			valCopy := make([]byte, buf.Len())
+			copy(valCopy, buf.Bytes())
+			nodesToReplace = append(nodesToReplace, struct {
+				node ast.Node
+				val  []byte
+			}{node: t, val: valCopy})
+		}
+		return ast.WalkContinue, nil
+	})
+
+	for _, item := range nodesToReplace {
+		parent := item.node.Parent()
+		if parent != nil {
+			strNode := ast.NewString(item.val)
+			parent.InsertBefore(parent, item.node, strNode)
+			parent.RemoveChild(parent, item.node)
+		}
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -7,4 +7,5 @@ type MarkConfig struct {
 	StripNewlines bool
 	Features      []string
 	ImageAlign    string
+	IncludePath   string
 }


### PR DESCRIPTION
## Description

This PR implements the **Unified Goldmark AST Pipeline** for processing Macros, Includes, and Metadata natively inside Goldmark.

### Key Enhancements & Architecture

1. **`MacroTransformer` & `IncludeTransformer` (`parser.ASTTransformer`)**:
   - Directly transforms `<!-- Macro: ... -->` and `<!-- Include: ... -->` directives inside Goldmark AST parsing.
   - Operates only on `ast.Paragraph`, `ast.Text`, and `ast.HTMLBlock` nodes—ignoring code blocks and fenced code blocks.

2. **`PipelineTransformer` (Multi-Pass AST Resolution)**:
   - Iteratively executes AST transformers until the document AST reaches a fixed point (`modified == false`).
   - Solves multi-level cross-transformer dependencies (e.g. `Include` → `Include` → `Macro` → `Include` → `Metadata`).

3. **Circular Include Loop Detection**:
   - Tracks template paths in the active inclusion call chain (`stack []string`).
   - Detects circular include cycles (e.g., `a.md` → `b.md` → `a.md`) and returns an explicit error (`circular include detected: a.md -> b.md -> a.md`).

4. **Native Directive Parsers (No Directive Regexes)**:
   - Replaced `reIncludeDirective` and `reMacroDirective` regexes with native AST comment directive parsers (`ParseIncludeDirective` and `ParseMacroDirective`).

5. **AST Segment Conversion (`convertSegmentsToStrings`)**:
   - Converts segment offsets into owned string bytes (`ast.String`), ensuring AST nodes created from external template strings render independently of reader byte offsets.

6. **Fallback Metadata Extraction**:
   - Enables `metadata.ExtractMeta` to resolve page metadata (`Title`, `Space`, `Parent`, etc.) defined inside included templates or generated by macros.

7. **Clean Linter Compatibility**:
   - Replaced deprecated `HTMLBlock.Text(source)` with `Lines` and `ClosureLine` to satisfy `staticcheck` (SA1019).

### Test Coverage

- `transformer/include_test.go`
- `transformer/macro_test.go`
- `transformer/pipeline_test.go`
- `markdown/transformer_pipeline_test.go`
- `includes/templates_test.go`
