### PR TITLE
feat(transformer): include parent file path and directive line number in error logs

### DIFF
--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -173,8 +173,8 @@ func NewConfluenceExtension(stdlib *stdlib.Lib, path string, cfg types.MarkConfi
 		tmpl = stdlib.Templates
 	}
 	pipeline := ctransformer.NewPipelineTransformer(
-		ctransformer.NewMacroTransformer(path, cfg.IncludePath, tmpl),
-		ctransformer.NewIncludeTransformer(path, cfg.IncludePath, tmpl),
+		ctransformer.NewMacroTransformer(path, path, cfg.IncludePath, tmpl),
+		ctransformer.NewIncludeTransformer(path, path, cfg.IncludePath, tmpl),
 	)
 	return &ConfluenceExtension{
 		Config:      html.NewConfig(),

--- a/transformer/include.go
+++ b/transformer/include.go
@@ -15,6 +15,7 @@ import (
 // IncludeTransformer transforms <!-- Include: ... --> directives in the Goldmark AST
 // by reading, expanding, and inserting the parsed AST nodes of included templates.
 type IncludeTransformer struct {
+	FilePath    string
 	BaseDir     string
 	IncludePath string
 	Templates   *template.Template
@@ -22,11 +23,12 @@ type IncludeTransformer struct {
 }
 
 // NewIncludeTransformer creates a new IncludeTransformer instance.
-func NewIncludeTransformer(baseDir string, includePath string, tmpl *template.Template) *IncludeTransformer {
+func NewIncludeTransformer(filePath string, baseDir string, includePath string, tmpl *template.Template) *IncludeTransformer {
 	if tmpl == nil {
 		tmpl = template.New("stdlib")
 	}
 	return &IncludeTransformer{
+		FilePath:    filePath,
 		BaseDir:     baseDir,
 		IncludePath: includePath,
 		Templates:   tmpl,
@@ -49,6 +51,7 @@ func (t *IncludeTransformer) TransformWithModified(doc *ast.Document, reader tex
 		startNode      ast.Node
 		nodesToRemove  []ast.Node
 		fullRawContent []byte
+		lineNum        int
 	}
 
 	var targets []includeTarget
@@ -67,6 +70,7 @@ func (t *IncludeTransformer) TransformWithModified(doc *ast.Document, reader tex
 				startNode:      node,
 				nodesToRemove:  []ast.Node{node},
 				fullRawContent: rawContent,
+				lineNum:        getNodeLineNumber(node, reader.Source()),
 			}
 			visited[node] = true
 
@@ -100,7 +104,11 @@ func (t *IncludeTransformer) TransformWithModified(doc *ast.Document, reader tex
 		tmpl, expanded, _, err := includes.ProcessIncludes(t.BaseDir, t.IncludePath, target.fullRawContent, t.Templates)
 		if err != nil {
 			t.Err = err
-			log.Error().Err(err).Msg("unable to process include")
+			log.Error().
+				Str("file", t.FilePath).
+				Int("line", target.lineNum).
+				Err(err).
+				Msg("unable to process include")
 			return false
 		}
 		if bytes.Equal(expanded, target.fullRawContent) {

--- a/transformer/include_test.go
+++ b/transformer/include_test.go
@@ -23,7 +23,7 @@ func TestIncludeTransformer(t *testing.T) {
 
 	markdownInput := []byte("<!-- Include: header.md\nname: World -->\n\nMain content here.")
 
-	transformer := NewIncludeTransformer(tempDir, "", template.New("test"))
+	transformer := NewIncludeTransformer("test.md", tempDir, "", template.New("test"))
 
 	gm := goldmark.New(
 		goldmark.WithParserOptions(

--- a/transformer/macro.go
+++ b/transformer/macro.go
@@ -15,6 +15,7 @@ import (
 // MacroTransformer extracts macro directives from HTML comment blocks in the Goldmark AST,
 // removes the definition nodes, and expands matching document text nodes into sub-ASTs.
 type MacroTransformer struct {
+	FilePath    string
 	BaseDir     string
 	IncludePath string
 	Templates   *template.Template
@@ -22,11 +23,12 @@ type MacroTransformer struct {
 }
 
 // NewMacroTransformer creates a new MacroTransformer instance.
-func NewMacroTransformer(baseDir string, includePath string, tmpl *template.Template) *MacroTransformer {
+func NewMacroTransformer(filePath string, baseDir string, includePath string, tmpl *template.Template) *MacroTransformer {
 	if tmpl == nil {
 		tmpl = template.New("stdlib")
 	}
 	return &MacroTransformer{
+		FilePath:    filePath,
 		BaseDir:     baseDir,
 		IncludePath: includePath,
 		Templates:   tmpl,
@@ -49,6 +51,7 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 		startNode      ast.Node
 		nodesToRemove  []ast.Node
 		fullRawContent []byte
+		lineNum        int
 	}
 
 	var targets []macroTarget
@@ -67,6 +70,7 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 				startNode:      node,
 				nodesToRemove:  []ast.Node{node},
 				fullRawContent: rawContent,
+				lineNum:        getNodeLineNumber(node, reader.Source()),
 			}
 			visited[node] = true
 
@@ -98,7 +102,11 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 		macros, _, err := macro.ExtractMacros(t.BaseDir, t.IncludePath, target.fullRawContent, t.Templates)
 		if err != nil {
 			t.Err = err
-			log.Error().Err(err).Msg("unable to extract macro")
+			log.Error().
+				Str("file", t.FilePath).
+				Int("line", target.lineNum).
+				Err(err).
+				Msg("unable to extract macro")
 			return false
 		}
 		if len(macros) == 0 {
@@ -117,8 +125,9 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 
 	for _, m := range extractedMacros {
 		var textNodesToReplace []struct {
-			node ast.Node
-			val  []byte
+			node    ast.Node
+			val     []byte
+			lineNum int
 		}
 
 		_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
@@ -135,9 +144,14 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 			raw := extractNodeRawContent(node, reader.Source())
 			if len(raw) > 0 && m.Regexp.Match(raw) {
 				textNodesToReplace = append(textNodesToReplace, struct {
-					node ast.Node
-					val  []byte
-				}{node: node, val: raw})
+					node    ast.Node
+					val     []byte
+					lineNum int
+				}{
+					node:    node,
+					val:     raw,
+					lineNum: getNodeLineNumber(node, reader.Source()),
+				})
 			}
 			return ast.WalkContinue, nil
 		})
@@ -150,7 +164,11 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 			expanded, err := m.Apply(item.val)
 			if err != nil {
 				t.Err = err
-				log.Error().Err(err).Msg("unable to apply macro")
+				log.Error().
+					Str("file", t.FilePath).
+					Int("line", item.lineNum).
+					Err(err).
+					Msg("unable to apply macro")
 				return false
 			}
 			if bytes.Equal(expanded, item.val) {

--- a/transformer/macro_test.go
+++ b/transformer/macro_test.go
@@ -3,8 +3,8 @@ package transformer
 import (
 	"bytes"
 	"testing"
+	"text/template"
 
-	"github.com/kovetskiy/mark/v16/stdlib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/yuin/goldmark"
@@ -13,17 +13,14 @@ import (
 	"github.com/yuin/goldmark/util"
 )
 
-func TestMacroTransformer(t *testing.T) {
-	std, err := stdlib.New(nil)
-	require.NoError(t, err)
+func TestMacroTransformerInline(t *testing.T) {
+	markdownInput := []byte(`<!-- Macro: :hello:(?P<name>\w+):
+Template: #inline
+inline: "Hello ${1}!" -->
 
-	markdownInput := []byte(`<!-- Macro: MYJIRA-\d+
-Template: ac:jira:ticket
-Ticket: ${0} -->
+:hello:World:`)
 
-See task MYJIRA-123.`)
-
-	transformer := NewMacroTransformer(".", "", std.Templates)
+	transformer := NewMacroTransformer("test.md", "", "", template.New("test"))
 
 	gm := goldmark.New(
 		goldmark.WithParserOptions(
@@ -37,11 +34,10 @@ See task MYJIRA-123.`)
 	)
 
 	var buf bytes.Buffer
-	err = gm.Convert(markdownInput, &buf)
+	err := gm.Convert(markdownInput, &buf)
 	require.NoError(t, err)
 
 	output := buf.String()
-	assert.Contains(t, output, `jira`)
-	assert.Contains(t, output, `MYJIRA-123`)
-	assert.NotContains(t, output, `Macro:`)
+	assert.Contains(t, output, "Hello World!")
+	assert.NotContains(t, output, "Macro:")
 }

--- a/transformer/pipeline_test.go
+++ b/transformer/pipeline_test.go
@@ -36,8 +36,8 @@ Main body text.`)
 	std, err := stdlib.New(nil)
 	require.NoError(t, err)
 
-	macroTransformer := NewMacroTransformer(tempDir, "", std.Templates)
-	includeTransformer := NewIncludeTransformer(tempDir, "", std.Templates)
+	macroTransformer := NewMacroTransformer("test.md", tempDir, "", std.Templates)
+	includeTransformer := NewIncludeTransformer("test.md", tempDir, "", std.Templates)
 
 	pipeline := NewPipelineTransformer(macroTransformer, includeTransformer)
 
@@ -90,8 +90,8 @@ inline: "<!-- Include: inc3.md\ntext: ${1} -->" -->
 	std, err := stdlib.New(nil)
 	require.NoError(t, err)
 
-	macroTransformer := NewMacroTransformer(tempDir, "", std.Templates)
-	includeTransformer := NewIncludeTransformer(tempDir, "", std.Templates)
+	macroTransformer := NewMacroTransformer("test.md", tempDir, "", std.Templates)
+	includeTransformer := NewIncludeTransformer("test.md", tempDir, "", std.Templates)
 
 	pipeline := NewPipelineTransformer(macroTransformer, includeTransformer)
 
@@ -130,8 +130,8 @@ func TestCircularIncludeLoopErrorPipeline(t *testing.T) {
 	std, err := stdlib.New(nil)
 	require.NoError(t, err)
 
-	macroTransformer := NewMacroTransformer(tempDir, "", std.Templates)
-	includeTransformer := NewIncludeTransformer(tempDir, "", std.Templates)
+	macroTransformer := NewMacroTransformer("test.md", tempDir, "", std.Templates)
+	includeTransformer := NewIncludeTransformer("test.md", tempDir, "", std.Templates)
 
 	pipeline := NewPipelineTransformer(macroTransformer, includeTransformer)
 

--- a/transformer/util.go
+++ b/transformer/util.go
@@ -26,6 +26,26 @@ func putBuffer(buf *bytes.Buffer) {
 	}
 }
 
+func getNodeLineNumber(node ast.Node, source []byte) int {
+	var offset int = -1
+	switch t := node.(type) {
+	case *ast.HTMLBlock:
+		if t.Lines().Len() > 0 {
+			offset = t.Lines().At(0).Start
+		}
+	case *ast.Text:
+		offset = t.Segment.Start
+	case *ast.RawHTML:
+		if t.Segments.Len() > 0 {
+			offset = t.Segments.At(0).Start
+		}
+	}
+	if offset < 0 || offset >= len(source) {
+		return 1
+	}
+	return bytes.Count(source[:offset], []byte("\n")) + 1
+}
+
 func extractHTMLBlockBytes(t *ast.HTMLBlock, source []byte) []byte {
 	lines := t.Lines()
 	if lines.Len() == 1 && !t.HasClosure() {

--- a/transformer/util.go
+++ b/transformer/util.go
@@ -27,7 +27,7 @@ func putBuffer(buf *bytes.Buffer) {
 }
 
 func getNodeLineNumber(node ast.Node, source []byte) int {
-	var offset int = -1
+	offset := -1
 	switch t := node.(type) {
 	case *ast.HTMLBlock:
 		if t.Lines().Len() > 0 {


### PR DESCRIPTION
### Description

When AST transformation fails during Markdown compilation (e.g. an unreadable include file or malformed macro regex),  and  previously logged generic error messages without indicating which file or line number contained the failing directive.

### Enhancements

1. **AST Node Line Number Resolver ()**:
   - Added  in  to compute 1-indexed line numbers from AST segment offsets.

2. **File & Line Context in Loggers**:
   - Updated  and  to store  and attach  and  context to structured  error outputs:
     