### PR TITLE
feat(includes): key cached templates by normalized relative path in LoadTemplate

### DIFF
--- a/includes/templates.go
+++ b/includes/templates.go
@@ -93,9 +93,8 @@ func LoadTemplate(
 	right string,
 	templates *template.Template,
 ) (*template.Template, error) {
-	var (
-		name = strings.TrimSuffix(path, filepath.Ext(path))
-	)
+	cleanPath := filepath.ToSlash(filepath.Clean(path))
+	name := strings.TrimSuffix(cleanPath, filepath.Ext(cleanPath))
 
 	if template := templates.Lookup(name); template != nil {
 		return template, nil

--- a/includes/templates_test.go
+++ b/includes/templates_test.go
@@ -1,6 +1,7 @@
 package includes
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,4 +43,34 @@ func TestProcessIncludesCircularLoop(t *testing.T) {
 	_, _, _, err := ProcessIncludes(tempDir, "", input, template.New("test"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "circular include detected")
+}
+
+func TestLoadTemplateScopedBySubdirectory(t *testing.T) {
+	tempDir := t.TempDir()
+
+	dirA := filepath.Join(tempDir, "dirA")
+	dirB := filepath.Join(tempDir, "dirB")
+	require.NoError(t, os.MkdirAll(dirA, 0755))
+	require.NoError(t, os.MkdirAll(dirB, 0755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dirA, "header.md"), []byte("Header A"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dirB, "header.md"), []byte("Header B"), 0644))
+
+	tmpl := template.New("stdlib")
+
+	tmpl, err := LoadTemplate(tempDir, "", "dirA/header.md", "", "", tmpl)
+	require.NoError(t, err)
+
+	tmpl, err = LoadTemplate(tempDir, "", "dirB/header.md", "", "", tmpl)
+	require.NoError(t, err)
+
+	assert.NotNil(t, tmpl.Lookup("dirA/header"))
+	assert.NotNil(t, tmpl.Lookup("dirB/header"))
+
+	var bufA, bufB bytes.Buffer
+	require.NoError(t, tmpl.Lookup("dirA/header").Execute(&bufA, nil))
+	require.NoError(t, tmpl.Lookup("dirB/header").Execute(&bufB, nil))
+
+	assert.Equal(t, "Header A", bufA.String())
+	assert.Equal(t, "Header B", bufB.String())
 }


### PR DESCRIPTION
### Description

Currently,  names cached templates in Go's  lookup table using  (e.g. ).

If a documentation repository includes templates with identical filenames in different subdirectories (such as  and ),  returns  for both, resulting in incorrect content rendering for .

### Solution

- Updated  in  to compute template lookup names using normalized relative paths ().
-  is keyed as  and  is keyed as , eliminating cross-subdirectory template name collisions.
- Added  in  to verify distinct template contents are returned.