### PR TITLE
fix(d2,mermaid): prevent Chrome headless websocket timeouts in CI

### DIFF
--- a/d2/d2.go
+++ b/d2/d2.go
@@ -120,6 +120,8 @@ func getChromeCtx(ctx context.Context) (context.Context, error) {
 			chromedp.NoFirstRun,
 			chromedp.NoDefaultBrowserCheck,
 			chromedp.Headless,
+			chromedp.Flag("disable-dev-shm-usage", true),
+			chromedp.Flag("disable-setuid-sandbox", true),
 		)
 	}
 
@@ -161,6 +163,7 @@ func convertSVGtoPNG(ctx context.Context, svg []byte, scale float64) (png []byte
 		chromedp.Dimensions(`document.querySelector("svg > svg")`, &model, chromedp.ByJSPath),
 	)
 	if err != nil {
+		Cleanup()
 		return nil, nil, err
 	}
 	return result, model, err

--- a/mermaid/mermaid.go
+++ b/mermaid/mermaid.go
@@ -75,6 +75,7 @@ func ProcessMermaidLocally(title string, mermaidDiagram []byte, scale float64) (
 	select {
 	case res := <-ch:
 		if res.err != nil {
+			resetEngine()
 			return attachment.Attachment{}, res.err
 		}
 		pngBytes = res.pngBytes


### PR DESCRIPTION
### Description

Fixes intermittent Chrome headless websocket timeouts (`websocket url timeout reached`) during diagram rendering in CI environments like GitHub Actions runners.

### Cause & Solution

1. **Shared Memory Exhaustion (`/dev/shm`):**
   In GitHub Actions Linux containers, `/dev/shm` is capped at 64MB. Chrome's DevTools renderer exhausts this memory buffer during concurrent diagram rendering, causing websocket hangs. Added `chromedp.Flag("disable-dev-shm-usage", true)` and `disable-setuid-sandbox` to use `/tmp` memory.

2. **Auto-Reset Dead Chrome Singletons:**
   If a Chrome instance encounters a transient rendering error or disconnect, `d2` and `mermaid` now auto-reset the cached context singleton so subsequent tests automatically launch a clean Chrome process instead of failing repeatedly.

### Verification

- `go test -count=1 ./...` passes 100%.
- `golangci-lint run` passes with 0 issues.