### PR TITLE
feat(renderer): add inline-link-card feature for Confluence smart-cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,6 +904,29 @@ f(x) = \int_{-\infty}^\infty \hat{f}(\xi)\,e^{2\pi i \xi x}\,d\xi
 \]
 ```
 
+### Inline Link Cards
+
+Optionally you can render bare URLs as Confluence Cloud **inline smart cards** via `--features="inline-link-card"`.
+
+When enabled, auto-detected URLs in markdown (e.g. `<https://example.com>` or
+a bare URL on its own line) are rendered with the `data-card-appearance="inline"`
+attribute, which Confluence Cloud uses as a hint to display the link as an
+inline card preview (page title, Jira issue summary, GitHub repo card, etc.)
+instead of a plain blue hyperlink.
+
+```text
+See <https://your-instance.atlassian.net/wiki/spaces/DOCS/pages/12345/Page+Title>
+for context.
+```
+
+Only **auto-detected URLs** (bare URLs / `<...>` autolinks) are affected.
+Markdown-explicit links (`[label](https://...)`) keep their author-chosen
+display text and render as regular hyperlinks, unchanged.
+
+*Note: Inline Smart Cards (`data-card-appearance="inline"`) are a **Confluence Cloud** feature. On Confluence Data Center / Server, the attribute is safely ignored and the link displays as a standard hyperlink.*
+
+**Note**: `mark` will read configuration from your environment variables or the configuration file.
+
 ## Installation
 
 ### Homebrew
@@ -985,7 +1008,7 @@ GLOBAL OPTIONS:
    --changes-only                           Avoids re-uploading pages that haven't changed since the last run. [$MARK_CHANGES_ONLY]
    --preserve-comments                      Fetch and preserve inline comments on existing Confluence pages. [$MARK_PRESERVE_COMMENTS]
    --d2-scale float                         defines the scaling factor for d2 renderings. (default: 1) [$MARK_D2_SCALE]
-   --features string [ --features string ]  Enables optional features. Current features: d2, details, frontmatter, mermaid, mention, mkdocsadmonitions, plantuml (default: "mermaid", "mention") [$MARK_FEATURES]
+   --features string [ --features string ]  Enables optional features. Current features: d2, details, frontmatter, inline-link-card, mermaid, mention, mkdocsadmonitions, plantuml (default: "mermaid", "mention") [$MARK_FEATURES]
    --insecure-skip-tls-verify               skip TLS certificate verification (useful for self-signed certificates) [$MARK_INSECURE_SKIP_TLS_VERIFY]
    --image-align string                     set image alignment (left, center, right). Can be overridden per-file via the Image-Align header. [$MARK_IMAGE_ALIGN]
    --help, -h                               show help

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -87,6 +87,12 @@ func (c *ConfluenceLegacyExtension) Extend(m goldmark.Markdown) {
 		))
 	}
 
+	if slices.Contains(c.MarkConfig.Features, "inline-link-card") {
+		m.Renderer().AddOptions(renderer.WithNodeRenderers(
+			util.Prioritized(crenderer.NewConfluenceAutoLinkRenderer(), 100),
+		))
+	}
+
 	m.Parser().AddOptions(parser.WithInlineParsers(
 		// Must be registered with a higher priority than goldmark's linkParser to make sure goldmark doesn't parse
 		// the <ac:*/> tags.
@@ -267,6 +273,15 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 		(&katex.Extender{}).Extend(m)
 	}
 
+	// Add inline-link-card support if requested · renders auto-detected bare
+	// URLs with the `data-card-appearance="inline"` hint, prompting Confluence
+	// Cloud to display them as inline smart cards (page mentions, Jira issues,
+	// GitHub references, etc.) instead of plain hyperlinks.
+	if slices.Contains(c.MarkConfig.Features, "inline-link-card") {
+		m.Renderer().AddOptions(renderer.WithNodeRenderers(
+			util.Prioritized(crenderer.NewConfluenceAutoLinkRenderer(), 100),
+		))
+	}
 	// Add confluence tag parser for <ac:*/> tags
 	m.Parser().AddOptions(parser.WithInlineParsers(
 		util.Prioritized(cparser.NewConfluenceTagParser(), 199),

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -222,6 +222,35 @@ func TestCompileMarkdownPlantumlOptIn(t *testing.T) {
 	test.EqualValues(strings.TrimSuffix(string(html), "\n"), strings.TrimSuffix(actual, "\n"), "plantuml without feature should render as regular code block")
 }
 
+func TestCompileMarkdownInlineLinkCard(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	dir := path.Join(path.Dir(filename), "..")
+	err := os.Chdir(dir)
+	if err != nil {
+		panic(err)
+	}
+
+	test := assert.New(t)
+
+	lib, err := stdlib.New(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	const fixture = "testdata/inline-link-card.md"
+	markdown, htmlname, html := loadData(t, fixture, "-inlinecard")
+
+	cfg := types.MarkConfig{
+		MermaidScale:  1.0,
+		D2Scale:       1.0,
+		DropFirstH1:   false,
+		StripNewlines: false,
+		Features:      []string{"mkdocsadmonitions", "mention", "inline-link-card"},
+	}
+
+	actual, _, _ := mark.CompileMarkdown(markdown, lib, fixture, cfg)
+	test.EqualValues(strings.TrimSuffix(string(html), "\n"), strings.TrimSuffix(actual, "\n"), fixture+" vs "+htmlname)
+}
 func TestContinueOnError(t *testing.T) {
 	cmd := &cli.Command{
 		Name:                  "temp-mark",

--- a/renderer/autolink.go
+++ b/renderer/autolink.go
@@ -1,0 +1,62 @@
+package renderer
+
+import (
+	"bytes"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/util"
+)
+
+// ConfluenceAutoLinkRenderer renders ast.KindAutoLink (bare URLs in markdown,
+// goldmark-autodetected) as anchor tags carrying the
+// `data-card-appearance="inline"` attribute. Confluence Cloud uses that hint
+// to render the URL as an inline smart card (page mention / Jira / GitHub /
+// etc.) instead of a plain hyperlink.
+//
+// Markdown-explicit links (`[text](url)`) are left to the existing
+// ConfluenceLinkRenderer so that author-chosen display text is preserved
+// unchanged as a regular hyperlink. Only bare/auto-detected URLs become
+// inline cards.
+type ConfluenceAutoLinkRenderer struct {
+	html.Config
+}
+
+// NewConfluenceAutoLinkRenderer creates an instance of the autolink renderer.
+func NewConfluenceAutoLinkRenderer(opts ...html.Option) renderer.NodeRenderer {
+	r := &ConfluenceAutoLinkRenderer{
+		Config: html.NewConfig(),
+	}
+	for _, opt := range opts {
+		opt.SetHTMLOption(&r.Config)
+	}
+	return r
+}
+
+// RegisterFuncs implements renderer.NodeRenderer.
+func (r *ConfluenceAutoLinkRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(ast.KindAutoLink, r.renderAutoLink)
+}
+
+func (r *ConfluenceAutoLinkRenderer) renderAutoLink(
+	w util.BufWriter, source []byte, node ast.Node, entering bool,
+) (ast.WalkStatus, error) {
+	n := node.(*ast.AutoLink)
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	url := util.URLEscape(n.URL(source), false)
+	label := n.Label(source)
+	_, _ = w.WriteString(`<a href="`)
+	if n.AutoLinkType == ast.AutoLinkEmail && !bytes.HasPrefix(bytes.ToLower(url), []byte("mailto:")) {
+		_, _ = w.WriteString("mailto:")
+	}
+	if r.Unsafe || !html.IsDangerousURL(url) {
+		_, _ = w.Write(util.EscapeHTML(url))
+	}
+	_, _ = w.WriteString(`" data-card-appearance="inline">`)
+	_, _ = w.Write(util.EscapeHTML(label))
+	_, _ = w.WriteString(`</a>`)
+	return ast.WalkContinue, nil
+}

--- a/testdata/inline-link-card-inlinecard.html
+++ b/testdata/inline-link-card-inlinecard.html
@@ -1,0 +1,4 @@
+<p>Bare URL autolink · <a href="https://example.com" data-card-appearance="inline">https://example.com</a></p>
+<p>Bare URL without brackets · <a href="https://example.com" data-card-appearance="inline">https://example.com</a></p>
+<p>Bare email autolink · <a href="mailto:user@example.com" data-card-appearance="inline">user@example.com</a></p>
+<p>Inline-explicit markdown link is unaffected by the feature · <a href="https://example.com">example</a></p>

--- a/testdata/inline-link-card.html
+++ b/testdata/inline-link-card.html
@@ -1,0 +1,4 @@
+<p>Bare URL autolink · <a href="https://example.com">https://example.com</a></p>
+<p>Bare URL without brackets · <a href="https://example.com">https://example.com</a></p>
+<p>Bare email autolink · <a href="mailto:user@example.com">user@example.com</a></p>
+<p>Inline-explicit markdown link is unaffected by the feature · <a href="https://example.com">example</a></p>

--- a/testdata/inline-link-card.md
+++ b/testdata/inline-link-card.md
@@ -1,0 +1,7 @@
+Bare URL autolink · <https://example.com>
+
+Bare URL without brackets · https://example.com
+
+Bare email autolink · <user@example.com>
+
+Inline-explicit markdown link is unaffected by the feature · [example](https://example.com)

--- a/util/flags.go
+++ b/util/flags.go
@@ -210,7 +210,7 @@ var Flags = []cli.Flag{
 	&cli.StringSliceFlag{
 		Name:    "features",
 		Value:   []string{"mermaid", "mention"},
-		Usage:   "Enables optional features. Current features: d2, details, frontmatter, mermaid, mention, mkdocsadmonitions, plantuml",
+		Usage:   "Enables optional features. Current features: d2, details, frontmatter, inline-link-card, mermaid, mention, mkdocsadmonitions, plantuml",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_FEATURES"), altsrctoml.TOML("features", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.BoolFlag{


### PR DESCRIPTION
### Description

Adds an opt-in `inline-link-card` feature to render auto-detected bare URLs as Confluence Cloud inline smart cards by emitting `data-card-appearance="inline"` on generated `<a>` tags.

### Changes

- Introduces `ConfluenceAutoLinkRenderer` and conditionally registers it when `inline-link-card` is enabled.
- Bare URLs (`<https://...>` and GFM linkify URLs) render as inline smart cards (`<a href="..." data-card-appearance="inline">...\</a>`).
- Markdown-explicit links (`[label](url)`) retain their author-chosen display text and render as standard hyperlinks without smart card transformation.
- Adds test fixtures under `testdata/` and dedicated unit test `TestCompileMarkdownInlineLinkCard`.
- Updates CLI `--features` help text in `util/flags.go` and `README.md`.

### Verification

- Rebased onto latest `upstream/master`.
- `go test -count=1 ./...` passes 100%.
- `golangci-lint run` passes with 0 issues.