### PR TITLE
feat(transformer): convert HTML <img> tags into ac:image via AST transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,16 @@ The width will be the commented html after the image (in this case 300px).
 
 Currently this is not compatible with the automated upload of inline images.
 
+### Use HTML img tags for sizing
+
+Standard HTML `<img>` tags (inline, block, single-line, or multi-line) can be converted into `<ac:image>` macros by enabling the `--features html-img-tag` flag. This allows you to specify sizing while keeping the document readable in standard Markdown renderers like GitHub:
+
+```markdown
+<img src="../images/example.png" width="300" alt="Example" title="An Example" />
+```
+
+Standard attributes (`width`, `alt`, and `title`) are supported and carried over directly. Local image files are uploaded as attachments, and remote image URLs are linked directly.
+
 ### Render Mermaid Diagram
 
 Confluence doesn't provide [mermaid.js](https://github.com/mermaid-js/mermaid) support natively. Mark provides a convenient way to enable the feature like [GitHub does](https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/).
@@ -1008,7 +1018,7 @@ GLOBAL OPTIONS:
    --changes-only                           Avoids re-uploading pages that haven't changed since the last run. [$MARK_CHANGES_ONLY]
    --preserve-comments                      Fetch and preserve inline comments on existing Confluence pages. [$MARK_PRESERVE_COMMENTS]
    --d2-scale float                         defines the scaling factor for d2 renderings. (default: 1) [$MARK_D2_SCALE]
-   --features string [ --features string ]  Enables optional features. Current features: d2, details, frontmatter, inline-link-card, mermaid, mention, mkdocsadmonitions, plantuml (default: "mermaid", "mention") [$MARK_FEATURES]
+   --features string [ --features string ]  Enables optional features. Current features: d2, details, frontmatter, html-img-tag, inline-link-card, math, mention, mermaid, mkdocsadmonitions, plantuml (default: "mermaid", "mention") [$MARK_FEATURES]
    --insecure-skip-tls-verify               skip TLS certificate verification (useful for self-signed certificates) [$MARK_INSECURE_SKIP_TLS_VERIFY]
    --image-align string                     set image alignment (left, center, right). Can be overridden per-file via the Image-Align header. [$MARK_IMAGE_ALIGN]
    --help, -h                               show help

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -55,7 +55,7 @@ func (c *ConfluenceLegacyExtension) Extend(m goldmark.Markdown) {
 		util.Prioritized(crenderer.NewConfluenceBlockQuoteRenderer(), 100),
 		util.Prioritized(crenderer.NewConfluenceCodeBlockRenderer(c.Stdlib, c.Path), 100),
 		util.Prioritized(crenderer.NewConfluenceFencedCodeBlockRenderer(c.Stdlib, c, c.MarkConfig), 100),
-		util.Prioritized(crenderer.NewConfluenceHTMLBlockRenderer(c.Stdlib), 100),
+		util.Prioritized(crenderer.NewConfluenceHTMLBlockRenderer(c.Stdlib, c, c.Path, c.MarkConfig.ImageAlign), 100),
 		util.Prioritized(crenderer.NewConfluenceHeadingRenderer(c.MarkConfig.DropFirstH1), 100),
 		util.Prioritized(crenderer.NewConfluenceImageRenderer(c.Stdlib, c, c.Path, c.MarkConfig.ImageAlign), 100),
 		util.Prioritized(crenderer.NewConfluenceParagraphRenderer(), 100),
@@ -221,7 +221,7 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 	m.Renderer().AddOptions(renderer.WithNodeRenderers(
 		util.Prioritized(crenderer.NewConfluenceCodeBlockRenderer(c.Stdlib, c.Path), 100),
 		util.Prioritized(crenderer.NewConfluenceFencedCodeBlockRenderer(c.Stdlib, c, c.MarkConfig), 100),
-		util.Prioritized(crenderer.NewConfluenceHTMLBlockRenderer(c.Stdlib), 100),
+		util.Prioritized(crenderer.NewConfluenceHTMLBlockRenderer(c.Stdlib, c, c.Path, c.MarkConfig.ImageAlign), 100),
 		util.Prioritized(crenderer.NewConfluenceHeadingRenderer(c.MarkConfig.DropFirstH1), 100),
 		util.Prioritized(crenderer.NewConfluenceImageRenderer(c.Stdlib, c, c.Path, c.MarkConfig.ImageAlign), 100),
 		util.Prioritized(crenderer.NewConfluenceParagraphRenderer(), 100),
@@ -241,6 +241,13 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 		util.Prioritized(c.Pipeline, 10),
 		util.Prioritized(ctransformer.NewGHAlertsTransformer(), 100),
 	))
+
+	// Add html-img-tag transformer support if requested
+	if slices.Contains(c.MarkConfig.Features, "html-img-tag") {
+		m.Parser().AddOptions(parser.WithASTTransformers(
+			util.Prioritized(ctransformer.NewHTMLImgTransformer(), 110),
+		))
+	}
 
 	// Add mkdocsadmonitions support if requested
 	if slices.Contains(c.MarkConfig.Features, "mkdocsadmonitions") {

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -306,3 +306,27 @@ Some content
 	assert.NotContains(t, actualDisabled, `<ac:structured-macro ac:name="expand">`)
 	assert.Contains(t, actualDisabled, `<details>`)
 }
+
+func TestHTMLImgTagFeature(t *testing.T) {
+	lib, err := stdlib.New(nil)
+	assert.NoError(t, err)
+	markdown := []byte(`<img src="https://example.com/image.png" width="300" alt="Test Image">`)
+
+	// 1. With html-img-tag feature enabled
+	cfgEnabled := types.MarkConfig{
+		Features: []string{"html-img-tag"},
+	}
+	actualEnabled, _, err := mark.CompileMarkdown(markdown, lib, "testdata/test.md", cfgEnabled)
+	assert.NoError(t, err)
+	assert.Contains(t, actualEnabled, `<ac:image`)
+	assert.Contains(t, actualEnabled, `ri:value="https://example.com/image.png"`)
+	assert.Contains(t, actualEnabled, `ac:width="300"`)
+
+	// 2. Without html-img-tag feature enabled
+	cfgDisabled := types.MarkConfig{
+		Features: []string{"mermaid", "mention"},
+	}
+	actualDisabled, _, err := mark.CompileMarkdown(markdown, lib, "testdata/test.md", cfgDisabled)
+	assert.NoError(t, err)
+	assert.NotContains(t, actualDisabled, `<ac:image`)
+}

--- a/renderer/htmlblock.go
+++ b/renderer/htmlblock.go
@@ -3,6 +3,7 @@ package renderer
 import (
 	"strings"
 
+	"github.com/kovetskiy/mark/v16/attachment"
 	"github.com/kovetskiy/mark/v16/stdlib"
 
 	"github.com/yuin/goldmark/ast"
@@ -13,13 +14,25 @@ import (
 
 type ConfluenceHTMLBlockRenderer struct {
 	html.Config
+	Stdlib      *stdlib.Lib
+	Attachments attachment.Attacher
+	Path        string
+	ImageAlign  string
 }
 
-// NewConfluenceRenderer creates a new instance of the ConfluenceRenderer
-func NewConfluenceHTMLBlockRenderer(stdlib *stdlib.Lib, opts ...html.Option) renderer.NodeRenderer {
-	return &ConfluenceHTMLBlockRenderer{
-		Config: html.NewConfig(),
+// NewConfluenceHTMLBlockRenderer creates a new instance of the ConfluenceHTMLBlockRenderer
+func NewConfluenceHTMLBlockRenderer(stdlib *stdlib.Lib, attachments attachment.Attacher, path string, imageAlign string, opts ...html.Option) renderer.NodeRenderer {
+	r := &ConfluenceHTMLBlockRenderer{
+		Config:      html.NewConfig(),
+		Stdlib:      stdlib,
+		Attachments: attachments,
+		Path:        path,
+		ImageAlign:  imageAlign,
 	}
+	for _, opt := range opts {
+		opt.SetHTMLOption(&r.Config)
+	}
+	return r
 }
 
 // RegisterFuncs implements NodeRenderer.RegisterFuncs .
@@ -36,8 +49,9 @@ func (r *ConfluenceHTMLBlockRenderer) renderHTMLBlock(w util.BufWriter, source [
 	l := n.Lines().Len()
 	for i := 0; i < l; i++ {
 		line := n.Lines().At(i)
+		lineStr := strings.Trim(string(line.Value(source)), "\n")
 
-		switch strings.Trim(string(line.Value(source)), "\n") {
+		switch lineStr {
 		case "<!-- ac:layout -->":
 			_, _ = w.WriteString("<ac:layout>\n")
 			return ast.WalkContinue, nil
@@ -77,11 +91,10 @@ func (r *ConfluenceHTMLBlockRenderer) renderHTMLBlock(w util.BufWriter, source [
 		case "<!-- ac:placeholder end -->":
 			_, _ = w.WriteString("</ac:placeholder>\n")
 			return ast.WalkContinue, nil
-
 		}
 	}
-	return r.goldmarkRenderHTMLBlock(w, source, node, entering)
 
+	return r.goldmarkRenderHTMLBlock(w, source, node, entering)
 }
 
 func (r *ConfluenceHTMLBlockRenderer) goldmarkRenderHTMLBlock(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {

--- a/renderer/htmlblock_test.go
+++ b/renderer/htmlblock_test.go
@@ -1,0 +1,77 @@
+package renderer
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/attachment"
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+// fakeAttacher records calls to Attach for inspection in tests.
+type fakeAttacher struct {
+	attached []attachment.Attachment
+}
+
+func (f *fakeAttacher) Attach(a attachment.Attachment) {
+	f.attached = append(f.attached, a)
+}
+
+func newHTMLBlockFromSource(source []byte) *ast.HTMLBlock {
+	node := ast.NewHTMLBlock(ast.HTMLBlockType6)
+	start := 0
+	for start < len(source) {
+		offset := bytes.IndexByte(source[start:], '\n')
+		if offset < 0 {
+			node.Lines().Append(text.NewSegment(start, len(source)))
+			break
+		}
+		end := start + offset
+		node.Lines().Append(text.NewSegment(start, end))
+		start = end + 1
+	}
+	return node
+}
+
+// bufWriter wraps bytes.Buffer to satisfy util.BufWriter.
+type bufWriter struct{ bytes.Buffer }
+
+func (b *bufWriter) Buffered() int { return b.Len() }
+func (b *bufWriter) Flush() error  { return nil }
+
+func newTestRenderer(t *testing.T, imageAlign string, attachments attachment.Attacher, path string) *ConfluenceHTMLBlockRenderer {
+	t.Helper()
+	lib, err := stdlib.New(nil)
+	if err != nil {
+		t.Fatalf("stdlib.New: %v", err)
+	}
+	renderer := NewConfluenceHTMLBlockRenderer(lib, attachments, path, imageAlign)
+	htmlBlockRenderer, ok := renderer.(*ConfluenceHTMLBlockRenderer)
+	if !ok {
+		t.Fatalf("renderer = %T, want *ConfluenceHTMLBlockRenderer", renderer)
+	}
+	return htmlBlockRenderer
+}
+
+func TestHTMLBlock_NonImgTagFallback(t *testing.T) {
+	r := newTestRenderer(t, "left", &fakeAttacher{}, "/docs/page.md")
+	r.Unsafe = true
+
+	var buf bufWriter
+	source := []byte(`<p>Hello World</p>`)
+	node := newHTMLBlockFromSource(source)
+	status, err := r.renderHTMLBlock(&buf, source, node, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != ast.WalkContinue {
+		t.Errorf("status = %v, want WalkContinue", status)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "<p>Hello World</p>") {
+		t.Errorf("expected fallback output to contain original HTML, got: %s", out)
+	}
+}

--- a/renderer/image.go
+++ b/renderer/image.go
@@ -3,6 +3,7 @@ package renderer
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -76,6 +77,23 @@ func calculateDisplayWidth(originalWidth string, layout string) string {
 	return originalWidth
 }
 
+// resolveWidth calculates the effective pixel width if explicitWidth is a percentage (e.g. "50%")
+// and originalWidth is known. Otherwise returns explicitWidth or originalWidth.
+func resolveWidth(explicitWidth string, originalWidth string) string {
+	if explicitWidth == "" {
+		return originalWidth
+	}
+	if strings.HasSuffix(explicitWidth, "%") && originalWidth != "" {
+		percentStr := strings.TrimSuffix(explicitWidth, "%")
+		if percent, err := strconv.ParseFloat(percentStr, 64); err == nil {
+			if origWidth, err := strconv.ParseFloat(originalWidth, 64); err == nil {
+				return strconv.Itoa(int(math.Round((percent / 100.0) * origWidth)))
+			}
+		}
+	}
+	return explicitWidth
+}
+
 type ConfluenceImageRenderer struct {
 	html.Config
 	Stdlib      *stdlib.Lib
@@ -107,12 +125,42 @@ func (r *ConfluenceImageRenderer) renderImage(writer util.BufWriter, source []by
 	}
 	n := node.(*ast.Image)
 
+	if !r.Unsafe && html.IsDangerousURL(n.Destination) {
+		return ast.WalkContinue, nil
+	}
+
+	var explicitWidth, explicitHeight, explicitAlign string
+	if attr, ok := n.Attribute([]byte("width")); ok {
+		if b, ok := attr.([]byte); ok {
+			explicitWidth = string(b)
+		}
+	}
+	if attr, ok := n.Attribute([]byte("height")); ok {
+		if b, ok := attr.([]byte); ok {
+			explicitHeight = string(b)
+		}
+	}
+	if attr, ok := n.Attribute([]byte("align")); ok {
+		if b, ok := attr.([]byte); ok {
+			explicitAlign = string(b)
+		}
+	}
+
+	align := r.ImageAlign
+	if explicitAlign != "" {
+		align = explicitAlign
+	}
+
 	attachments, err := attachment.ResolveLocalAttachments(vfs.LocalOS, filepath.Dir(r.Path), []string{string(n.Destination)})
 
 	// We were unable to resolve it locally, treat as URL
 	if err != nil {
 		escapedURL := string(n.Destination)
 		escapedURL = strings.ReplaceAll(escapedURL, "&", "&amp;")
+
+		effectiveAlign := calculateAlign(align, explicitWidth)
+		effectiveLayout := calculateLayout(effectiveAlign, explicitWidth)
+		displayWidth := calculateDisplayWidth(explicitWidth, effectiveLayout)
 
 		err = r.Stdlib.Templates.ExecuteTemplate(
 			writer,
@@ -129,12 +177,12 @@ func (r *ConfluenceImageRenderer) renderImage(writer util.BufWriter, source []by
 				Attachment     string
 				Url            string
 			}{
-				r.ImageAlign,
-				calculateLayout(r.ImageAlign, ""),
+				effectiveAlign,
+				effectiveLayout,
 				"",
 				"",
-				"",
-				"",
+				displayWidth,
+				explicitHeight,
 				string(n.Title),
 				string(nodeToHTMLText(n, source)),
 				"",
@@ -149,9 +197,10 @@ func (r *ConfluenceImageRenderer) renderImage(writer util.BufWriter, source []by
 
 		r.Attachments.Attach(attachments[0])
 
-		effectiveAlign := calculateAlign(r.ImageAlign, attachments[0].Width)
-		effectiveLayout := calculateLayout(effectiveAlign, attachments[0].Width)
-		displayWidth := calculateDisplayWidth(attachments[0].Width, effectiveLayout)
+		effectiveWidth := resolveWidth(explicitWidth, attachments[0].Width)
+		effectiveAlign := calculateAlign(align, effectiveWidth)
+		effectiveLayout := calculateLayout(effectiveAlign, effectiveWidth)
+		displayWidth := calculateDisplayWidth(effectiveWidth, effectiveLayout)
 
 		err = r.Stdlib.Templates.ExecuteTemplate(
 			writer,
@@ -173,7 +222,7 @@ func (r *ConfluenceImageRenderer) renderImage(writer util.BufWriter, source []by
 				attachments[0].Width,
 				attachments[0].Height,
 				displayWidth,
-				"",
+				explicitHeight,
 				string(n.Title),
 				string(nodeToHTMLText(n, source)),
 				attachments[0].Filename,

--- a/renderer/image_test.go
+++ b/renderer/image_test.go
@@ -92,3 +92,27 @@ func TestCalculateDisplayWidth(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveWidth(t *testing.T) {
+	tests := []struct {
+		name          string
+		explicitWidth string
+		originalWidth string
+		expectedWidth string
+	}{
+		{"Empty explicit width returns original width", "", "1000", "1000"},
+		{"Pixel width returned unchanged", "500", "1000", "500"},
+		{"50% width calculated relative to original width", "50%", "1000", "500"},
+		{"25% width calculated relative to original width", "25%", "800", "200"},
+		{"Percentage width without original width returned as-is", "50%", "", "50%"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveWidth(tt.explicitWidth, tt.originalWidth)
+			if result != tt.expectedWidth {
+				t.Errorf("resolveWidth(%q, %q) = %q, want %q", tt.explicitWidth, tt.originalWidth, result, tt.expectedWidth)
+			}
+		})
+	}
+}

--- a/transformer/html_img.go
+++ b/transformer/html_img.go
@@ -1,0 +1,223 @@
+package transformer
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+	"golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+// HTMLImgTransformer walks the AST and transforms HTML <img> tags found in
+// ast.KindHTMLBlock and ast.KindRawHTML nodes into ast.KindImage nodes with
+// attributes (width, height, alt, title, align) so that the image renderer
+// can render them as Confluence <ac:image> macros uniformly.
+type HTMLImgTransformer struct{}
+
+// NewHTMLImgTransformer creates a new instance of HTMLImgTransformer.
+func NewHTMLImgTransformer() *HTMLImgTransformer {
+	return &HTMLImgTransformer{}
+}
+
+// Transform implements the parser.ASTTransformer interface.
+func (t *HTMLImgTransformer) Transform(doc *ast.Document, reader text.Reader, pc parser.Context) {
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		switch n := node.(type) {
+		case *ast.HTMLBlock:
+			t.transformHTMLBlock(n, reader)
+		case *ast.RawHTML:
+			t.transformRawHTML(n, reader)
+		}
+
+		return ast.WalkContinue, nil
+	})
+}
+
+func (t *HTMLImgTransformer) transformHTMLBlock(n *ast.HTMLBlock, reader text.Reader) {
+	var buf bytes.Buffer
+	l := n.Lines().Len()
+	for i := 0; i < l; i++ {
+		line := n.Lines().At(i)
+		buf.Write(line.Value(reader.Source()))
+	}
+	rawBytes := buf.Bytes()
+
+	imgNodes := t.parseHTMLImages(rawBytes)
+	if len(imgNodes) == 0 {
+		return
+	}
+
+	// If the HTML block contains only <img> tags (or single <img> tag), replace HTMLBlock node
+	parent := n.Parent()
+	if parent == nil {
+		return
+	}
+
+	p := ast.NewParagraph()
+	for _, imgNode := range imgNodes {
+		p.AppendChild(p, imgNode)
+	}
+
+	parent.ReplaceChild(parent, n, p)
+}
+
+func (t *HTMLImgTransformer) transformRawHTML(n *ast.RawHTML, reader text.Reader) {
+	var buf bytes.Buffer
+	l := n.Segments.Len()
+	for i := 0; i < l; i++ {
+		segment := n.Segments.At(i)
+		buf.Write(segment.Value(reader.Source()))
+	}
+	rawBytes := buf.Bytes()
+
+	imgNodes := t.parseHTMLImages(rawBytes)
+	if len(imgNodes) == 0 {
+		return
+	}
+
+	parent := n.Parent()
+	if parent == nil {
+		return
+	}
+
+	// Replace RawHTML node with converted image AST nodes
+	for _, imgNode := range imgNodes {
+		parent.InsertBefore(parent, n, imgNode)
+	}
+	parent.RemoveChild(parent, n)
+}
+
+func (t *HTMLImgTransformer) parseHTMLImages(rawBytes []byte) []*ast.Image {
+	if !bytes.Contains(bytes.ToLower(rawBytes), []byte("<img")) {
+		return nil
+	}
+
+	nodes, err := html.ParseFragment(bytes.NewReader(rawBytes), &html.Node{
+		Type:     html.ElementNode,
+		Data:     "body",
+		DataAtom: atom.Body,
+	})
+	if err != nil || len(nodes) == 0 {
+		return nil
+	}
+
+	var imgElements []*html.Node
+	var findImg func(*html.Node)
+	findImg = func(n *html.Node) {
+		if n.Type == html.ElementNode && strings.EqualFold(n.Data, "img") {
+			imgElements = append(imgElements, n)
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			findImg(c)
+		}
+	}
+
+	for _, n := range nodes {
+		findImg(n)
+	}
+
+	if len(imgElements) == 0 {
+		return nil
+	}
+
+	var astImages []*ast.Image
+	for _, elem := range imgElements {
+		var src, width, height, alt, title, align, style string
+		for _, attr := range elem.Attr {
+			switch strings.ToLower(attr.Key) {
+			case "src":
+				src = attr.Val
+			case "width":
+				width = attr.Val
+			case "height":
+				height = attr.Val
+			case "alt":
+				alt = attr.Val
+			case "title":
+				title = attr.Val
+			case "align":
+				align = attr.Val
+			case "style":
+				style = attr.Val
+			}
+		}
+
+		if style != "" {
+			sWidth, sHeight, sAlign := parseStyleAttr(style)
+			if width == "" {
+				width = sWidth
+			}
+			if height == "" {
+				height = sHeight
+			}
+			if align == "" {
+				align = sAlign
+			}
+		}
+
+		width = strings.TrimSuffix(strings.TrimSpace(width), "px")
+		height = strings.TrimSuffix(strings.TrimSpace(height), "px")
+
+		if src == "" {
+			continue
+		}
+
+		imgNode := ast.NewImage(ast.NewLink())
+		imgNode.Destination = []byte(src)
+
+		if title != "" {
+			imgNode.Title = []byte(title)
+		}
+		if width != "" {
+			imgNode.SetAttribute([]byte("width"), []byte(width))
+		}
+		if height != "" {
+			imgNode.SetAttribute([]byte("height"), []byte(height))
+		}
+		if align != "" {
+			imgNode.SetAttribute([]byte("align"), []byte(align))
+		}
+		if alt != "" {
+			imgNode.AppendChild(imgNode, ast.NewString([]byte(alt)))
+		}
+
+		astImages = append(astImages, imgNode)
+	}
+
+	return astImages
+}
+
+func parseStyleAttr(styleStr string) (width, height, align string) {
+	for _, declaration := range strings.Split(styleStr, ";") {
+		parts := strings.SplitN(declaration, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		prop := strings.TrimSpace(strings.ToLower(parts[0]))
+		val := strings.TrimSpace(strings.ToLower(parts[1]))
+		val = strings.TrimSuffix(val, "px")
+
+		switch prop {
+		case "width", "max-width":
+			if width == "" {
+				width = val
+			}
+		case "height", "max-height":
+			if height == "" {
+				height = val
+			}
+		case "float":
+			if val == "left" || val == "right" {
+				align = val
+			}
+		}
+	}
+	return width, height, align
+}

--- a/transformer/html_img_test.go
+++ b/transformer/html_img_test.go
@@ -1,0 +1,178 @@
+package transformer
+
+import (
+	"testing"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+func TestHTMLImgTransformer_BlockImage(t *testing.T) {
+	markdown := []byte(`<img src="https://example.com/logo.png" width="600" height="400" alt="Logo" title="My Logo">`)
+	md := goldmark.New(
+		goldmark.WithParserOptions(
+			parser.WithASTTransformers(
+				util.Prioritized(NewHTMLImgTransformer(), 100),
+			),
+		),
+	)
+
+	reader := text.NewReader(markdown)
+	doc := md.Parser().Parse(reader)
+
+	var foundImg *ast.Image
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering {
+			if img, ok := n.(*ast.Image); ok {
+				foundImg = img
+				return ast.WalkStop, nil
+			}
+		}
+		return ast.WalkContinue, nil
+	})
+
+	if foundImg == nil {
+		t.Fatalf("expected AST image node, got nil")
+	}
+
+	if string(foundImg.Destination) != "https://example.com/logo.png" {
+		t.Errorf("destination = %q, want https://example.com/logo.png", string(foundImg.Destination))
+	}
+
+	if string(foundImg.Title) != "My Logo" {
+		t.Errorf("title = %q, want My Logo", string(foundImg.Title))
+	}
+
+	widthAttr, ok := foundImg.Attribute([]byte("width"))
+	if !ok || string(widthAttr.([]byte)) != "600" {
+		t.Errorf("width attribute = %v, want 600", widthAttr)
+	}
+
+	heightAttr, ok := foundImg.Attribute([]byte("height"))
+	if !ok || string(heightAttr.([]byte)) != "400" {
+		t.Errorf("height attribute = %v, want 400", heightAttr)
+	}
+}
+
+func TestHTMLImgTransformer_InlineImage(t *testing.T) {
+	markdown := []byte(`Here is an inline image <img src="local.png" width="200" alt="Inline"> in paragraph.`)
+	md := goldmark.New(
+		goldmark.WithParserOptions(
+			parser.WithASTTransformers(
+				util.Prioritized(NewHTMLImgTransformer(), 100),
+			),
+		),
+	)
+
+	reader := text.NewReader(markdown)
+	doc := md.Parser().Parse(reader)
+
+	var foundImg *ast.Image
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering {
+			if img, ok := n.(*ast.Image); ok {
+				foundImg = img
+				return ast.WalkStop, nil
+			}
+		}
+		return ast.WalkContinue, nil
+	})
+
+	if foundImg == nil {
+		t.Fatalf("expected AST image node for inline img tag, got nil")
+	}
+
+	if string(foundImg.Destination) != "local.png" {
+		t.Errorf("destination = %q, want local.png", string(foundImg.Destination))
+	}
+
+	widthAttr, ok := foundImg.Attribute([]byte("width"))
+	if !ok || string(widthAttr.([]byte)) != "200" {
+		t.Errorf("width attribute = %v, want 200", widthAttr)
+	}
+}
+
+func TestHTMLImgTransformer_MultilineImage(t *testing.T) {
+	markdown := []byte("<img\n  src=\"hero.png\"\n  width=\"800\"\n  alt=\"Hero\"\n/>")
+	md := goldmark.New(
+		goldmark.WithParserOptions(
+			parser.WithASTTransformers(
+				util.Prioritized(NewHTMLImgTransformer(), 100),
+			),
+		),
+	)
+
+	reader := text.NewReader(markdown)
+	doc := md.Parser().Parse(reader)
+
+	var foundImg *ast.Image
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering {
+			if img, ok := n.(*ast.Image); ok {
+				foundImg = img
+				return ast.WalkStop, nil
+			}
+		}
+		return ast.WalkContinue, nil
+	})
+
+	if foundImg == nil {
+		t.Fatalf("expected AST image node for multiline img tag, got nil")
+	}
+
+	if string(foundImg.Destination) != "hero.png" {
+		t.Errorf("destination = %q, want hero.png", string(foundImg.Destination))
+	}
+
+	widthAttr, ok := foundImg.Attribute([]byte("width"))
+	if !ok || string(widthAttr.([]byte)) != "800" {
+		t.Errorf("width attribute = %v, want 800", widthAttr)
+	}
+}
+
+func TestHTMLImgTransformer_StyleAttribute(t *testing.T) {
+	markdown := []byte(`<img src="styled.png" style="width: 350px; height: 175px; float: left">`)
+	md := goldmark.New(
+		goldmark.WithParserOptions(
+			parser.WithASTTransformers(
+				util.Prioritized(NewHTMLImgTransformer(), 100),
+			),
+		),
+	)
+
+	reader := text.NewReader(markdown)
+	doc := md.Parser().Parse(reader)
+
+	var foundImg *ast.Image
+	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if entering {
+			if img, ok := n.(*ast.Image); ok {
+				foundImg = img
+				return ast.WalkStop, nil
+			}
+		}
+		return ast.WalkContinue, nil
+	})
+
+	if foundImg == nil {
+		t.Fatalf("expected AST image node for styled img tag, got nil")
+	}
+
+	widthAttr, ok := foundImg.Attribute([]byte("width"))
+	if !ok || string(widthAttr.([]byte)) != "350" {
+		t.Errorf("width attribute = %v, want 350", widthAttr)
+	}
+
+	heightAttr, ok := foundImg.Attribute([]byte("height"))
+	if !ok || string(heightAttr.([]byte)) != "175" {
+		t.Errorf("height attribute = %v, want 175", heightAttr)
+	}
+
+	alignAttr, ok := foundImg.Attribute([]byte("align"))
+	if !ok || string(alignAttr.([]byte)) != "left" {
+		t.Errorf("align attribute = %v, want left", alignAttr)
+	}
+}

--- a/util/flags.go
+++ b/util/flags.go
@@ -210,7 +210,7 @@ var Flags = []cli.Flag{
 	&cli.StringSliceFlag{
 		Name:    "features",
 		Value:   []string{"mermaid", "mention"},
-		Usage:   "Enables optional features. Current features: d2, details, frontmatter, inline-link-card, mermaid, mention, mkdocsadmonitions, plantuml",
+		Usage:   "Enables optional features. Current features: d2, details, frontmatter, html-img-tag, inline-link-card, math, mention, mermaid, mkdocsadmonitions, plantuml",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_FEATURES"), altsrctoml.TOML("features", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.BoolFlag{


### PR DESCRIPTION
### Summary

Refactors HTML `<img>` tag handling to use a Goldmark AST Transformer (`HTMLImgTransformer`). Converts both block-level (`ast.KindHTMLBlock`) and inline (`ast.KindRawHTML`) HTML `<img>` tags into Goldmark `ast.KindImage` nodes during AST parsing.

### Advantages of AST-based Approach over Regex Line Scanning

1. **HTML5 Spec Compliant Parsing**: Uses `golang.org/x/net/html` to accurately parse HTML attributes (`src`, `width`, `height`, `alt`, `title`, `align`) regardless of single/double quotes, unquoted attributes, spaces, or self-closing tags.
2. **Handles Both Inline and Block HTML**: Converts `<img>` tags whether they appear on their own block line or inline inside sentences/paragraphs/list items.
3. **Supports Multi-line Tags**: Handles `<img>` tags formatted across multiple lines without breaking.
4. **Unified Image Renderer Pipeline**: Integrates with `ConfluenceImageRenderer` so that both Markdown image syntax (`![alt](src)`) and HTML image syntax (`<img src="src" width="300">`) use the exact same attachment resolution, image layout, alignment, and `<ac:image>` template pipeline.

### Verification

- Rebased onto latest `upstream/master`.
- `go test -count=1 ./...` passes 100%.
- `golangci-lint run` passes with 0 issues.
- Preserved authorship: `Sven-Ole Fedders <sven-ole.fedders@moia.io>`.