### PR TITLE
refactor(transformer): process Confluence layout comments via AST LayoutTransformer

### DIFF
--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -242,9 +242,10 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 		util.Prioritized(crenderer.NewConfluenceTextRenderer(c.MarkConfig.StripNewlines), 200),
 	))
 
-	// Add AST Transformers for Macros, Includes, and GitHub Alerts
+	// Add AST Transformers for Macros, Includes, Layouts, and GitHub Alerts
 	m.Parser().AddOptions(parser.WithASTTransformers(
 		util.Prioritized(c.Pipeline, 10),
+		util.Prioritized(ctransformer.NewLayoutTransformer(), 100),
 		util.Prioritized(ctransformer.NewGHAlertsTransformer(), 100),
 	))
 

--- a/renderer/htmlblock.go
+++ b/renderer/htmlblock.go
@@ -1,8 +1,6 @@
 package renderer
 
 import (
-	"strings"
-
 	"github.com/kovetskiy/mark/v16/attachment"
 	"github.com/kovetskiy/mark/v16/stdlib"
 
@@ -41,59 +39,6 @@ func (r *ConfluenceHTMLBlockRenderer) RegisterFuncs(reg renderer.NodeRendererFun
 }
 
 func (r *ConfluenceHTMLBlockRenderer) renderHTMLBlock(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
-	if !entering {
-		return r.goldmarkRenderHTMLBlock(w, source, node, entering)
-	}
-
-	n := node.(*ast.HTMLBlock)
-	l := n.Lines().Len()
-	for i := 0; i < l; i++ {
-		line := n.Lines().At(i)
-		lineStr := strings.Trim(string(line.Value(source)), "\n")
-
-		switch lineStr {
-		case "<!-- ac:layout -->":
-			_, _ = w.WriteString("<ac:layout>\n")
-			return ast.WalkContinue, nil
-		case "<!-- ac:layout end -->":
-			_, _ = w.WriteString("</ac:layout>\n")
-			return ast.WalkContinue, nil
-		case "<!-- ac:layout-section type:single -->":
-			_, _ = w.WriteString("<ac:layout-section ac:type=\"single\">\n")
-			return ast.WalkContinue, nil
-		case "<!-- ac:layout-section type:two_equal -->":
-			_, _ = w.WriteString("<ac:layout-section ac:type=\"two_equal\">\n")
-			return ast.WalkContinue, nil
-		case "<!-- ac:layout-section type:two_left_sidebar -->":
-			_, _ = w.WriteString("<ac:layout-section ac:type=\"two_left_sidebar\">\n")
-			return ast.WalkContinue, nil
-		case "<!-- ac:layout-section type:two_right_sidebar -->":
-			_, _ = w.WriteString("<ac:layout-section ac:type=\"two_right_sidebar\">\n")
-			return ast.WalkContinue, nil
-		case "<!-- ac:layout-section type:three -->":
-			_, _ = w.WriteString("<ac:layout-section ac:type=\"three\">\n")
-			return ast.WalkContinue, nil
-		case "<!-- ac:layout-section type:three_with_sidebars -->":
-			_, _ = w.WriteString("<ac:layout-section ac:type=\"three_with_sidebars\">\n")
-			return ast.WalkContinue, nil
-		case "<!-- ac:layout-section end -->":
-			_, _ = w.WriteString("</ac:layout-section>\n")
-			return ast.WalkContinue, nil
-		case "<!-- ac:layout-cell -->":
-			_, _ = w.WriteString("<ac:layout-cell>\n")
-			return ast.WalkContinue, nil
-		case "<!-- ac:layout-cell end -->":
-			_, _ = w.WriteString("</ac:layout-cell>\n")
-			return ast.WalkContinue, nil
-		case "<!-- ac:placeholder -->":
-			_, _ = w.WriteString("<ac:placeholder>\n")
-			return ast.WalkContinue, nil
-		case "<!-- ac:placeholder end -->":
-			_, _ = w.WriteString("</ac:placeholder>\n")
-			return ast.WalkContinue, nil
-		}
-	}
-
 	return r.goldmarkRenderHTMLBlock(w, source, node, entering)
 }
 

--- a/transformer/layout.go
+++ b/transformer/layout.go
@@ -1,0 +1,125 @@
+package transformer
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+// LayoutTransformer walks the AST and transforms Confluence layout HTML comment tags
+// (e.g. <!-- ac:layout -->, <!-- ac:layout-section type:single -->, <!-- ac:layout-cell -->, etc.)
+// into Confluence XML elements (<ac:layout>, <ac:layout-section ac:type="...">, etc.) during AST compilation.
+type LayoutTransformer struct{}
+
+// NewLayoutTransformer creates a new instance of LayoutTransformer.
+func NewLayoutTransformer() *LayoutTransformer {
+	return &LayoutTransformer{}
+}
+
+// Transform implements the parser.ASTTransformer interface.
+func (t *LayoutTransformer) Transform(doc *ast.Document, reader text.Reader, pc parser.Context) {
+	var nodesToReplace []struct {
+		node ast.Node
+		newB []byte
+	}
+
+	source := reader.Source()
+
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		switch n := node.(type) {
+		case *ast.HTMLBlock, *ast.RawHTML, *ast.Text, *ast.String:
+			raw := ExtractNodeRawContent(n, source)
+			if len(raw) == 0 {
+				return ast.WalkContinue, nil
+			}
+
+			newRaw, transformed := t.transformLayoutComments(raw)
+			if transformed {
+				nodesToReplace = append(nodesToReplace, struct {
+					node ast.Node
+					newB []byte
+				}{node: n, newB: newRaw})
+			}
+		}
+
+		return ast.WalkContinue, nil
+	})
+
+	for _, item := range nodesToReplace {
+		parent := item.node.Parent()
+		if parent != nil {
+			textNode := ast.NewText()
+			textNode.SetAttribute([]byte("replacement-content"), item.newB)
+			parent.InsertBefore(parent, item.node, textNode)
+			parent.RemoveChild(parent, item.node)
+		}
+	}
+}
+
+func (t *LayoutTransformer) transformLayoutComments(raw []byte) ([]byte, bool) {
+	if !bytes.Contains(raw, []byte("<!-- ac:")) {
+		return raw, false
+	}
+
+	lines := strings.Split(string(raw), "\n")
+	var buf bytes.Buffer
+	var modified bool
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		var converted string
+
+		switch trimmed {
+		case "<!-- ac:layout -->":
+			converted = "<ac:layout>"
+		case "<!-- ac:layout end -->":
+			converted = "</ac:layout>"
+		case "<!-- ac:layout-section type:single -->":
+			converted = `<ac:layout-section ac:type="single">`
+		case "<!-- ac:layout-section type:two_equal -->":
+			converted = `<ac:layout-section ac:type="two_equal">`
+		case "<!-- ac:layout-section type:two_left_sidebar -->":
+			converted = `<ac:layout-section ac:type="two_left_sidebar">`
+		case "<!-- ac:layout-section type:two_right_sidebar -->":
+			converted = `<ac:layout-section ac:type="two_right_sidebar">`
+		case "<!-- ac:layout-section type:three -->":
+			converted = `<ac:layout-section ac:type="three">`
+		case "<!-- ac:layout-section type:three_with_sidebars -->":
+			converted = `<ac:layout-section ac:type="three_with_sidebars">`
+		case "<!-- ac:layout-section end -->":
+			converted = "</ac:layout-section>"
+		case "<!-- ac:layout-cell -->":
+			converted = "<ac:layout-cell>"
+		case "<!-- ac:layout-cell end -->":
+			converted = "</ac:layout-cell>"
+		case "<!-- ac:placeholder -->":
+			converted = "<ac:placeholder>"
+		case "<!-- ac:placeholder end -->":
+			converted = "</ac:placeholder>"
+		}
+
+		if converted != "" {
+			buf.WriteString(converted)
+			modified = true
+		} else {
+			buf.WriteString(line)
+		}
+
+		if i < len(lines)-1 {
+			buf.WriteString("\n")
+		}
+	}
+
+	if modified {
+		return buf.Bytes(), true
+	}
+
+	return raw, false
+}

--- a/transformer/layout_test.go
+++ b/transformer/layout_test.go
@@ -1,0 +1,57 @@
+package transformer_test
+
+import (
+	"bytes"
+	"testing"
+
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	"github.com/kovetskiy/mark/v16/transformer"
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/util"
+)
+
+func TestLayoutTransformer(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "layout section single",
+			input:    "<!-- ac:layout -->\n<!-- ac:layout-section type:single -->\n<!-- ac:layout-cell -->\nCell content\n<!-- ac:layout-cell end -->\n<!-- ac:layout-section end -->\n<!-- ac:layout end -->",
+			expected: "<ac:layout>\n<ac:layout-section ac:type=\"single\">\n<ac:layout-cell>\n<p>Cell content</p>\n</ac:layout-cell>\n</ac:layout-section>\n</ac:layout>",
+		},
+		{
+			name:     "placeholder tags",
+			input:    "<!-- ac:placeholder -->\nPlaceholder content\n<!-- ac:placeholder end -->",
+			expected: "<ac:placeholder>\n<p>Placeholder content</p>\n</ac:placeholder>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gm := goldmark.New(
+				goldmark.WithRendererOptions(
+					html.WithUnsafe(),
+					renderer.WithNodeRenderers(
+						util.Prioritized(crenderer.NewConfluenceTextRenderer(false), 200),
+					),
+				),
+				goldmark.WithParserOptions(
+					parser.WithASTTransformers(
+						util.Prioritized(transformer.NewLayoutTransformer(), 100),
+					),
+				),
+			)
+
+			var buf bytes.Buffer
+			err := gm.Convert([]byte(tt.input), &buf)
+			assert.NoError(t, err)
+			assert.Contains(t, buf.String(), tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
### Summary

Refactors Confluence HTML layout comment tag processing (`<!-- ac:layout -->`, `<!-- ac:layout-section ... -->`, `<!-- ac:layout-cell -->`, `<!-- ac:placeholder -->`) into a Goldmark AST Transformer (`LayoutTransformer`), removing line-by-line comment scanning from `renderer/htmlblock.go`.

### Architectural Benefits

1. **AST-Native Preprocessing**: Converts layout comment blocks into Confluence XML elements during AST compilation before rendering.
2. **Simplified Renderer**: Simplifies `renderHTMLBlock` in `renderer/htmlblock.go` to be a pure writer for `ast.KindHTMLBlock` nodes, eliminating comment inspection loops during output serialization.
3. **Separation of Concerns**: Moves AST inspection and text node replacement logic into `transformer/layout.go`.

### Verification

- Created branch `refactor/layout-transformer` off updated `upstream/master`.
- Added unit tests in `transformer/layout_test.go`.
- `go test -count=1 ./...` passes 100%.
- `golangci-lint run` passes with 0 issues.
- `npx -y markdownlint-cli2 README.md` passes with 0 issues.