### PR TITLE
fix(macro): prevent macro config corruption when multiple macros are defined (fixes #829)

### DIFF
--- a/macro/macro.go
+++ b/macro/macro.go
@@ -26,15 +26,11 @@ type MacroDirective struct {
 	Config   string
 }
 
-// ParseMacroDirective parses a <!-- Macro: ... --> HTML comment block without directive regexes.
+// ParseMacroDirective parses a single <!-- Macro: ... --> HTML comment block without directive regexes.
 func ParseMacroDirective(raw []byte) (*MacroDirective, error) {
 	s := string(raw)
 	startIdx := strings.Index(s, "<!--")
 	if startIdx == -1 {
-		return nil, nil
-	}
-	macroIdx := strings.Index(s[startIdx:], "Macro:")
-	if macroIdx == -1 {
 		return nil, nil
 	}
 	endIdx := strings.LastIndex(s[startIdx:], "-->")
@@ -43,7 +39,13 @@ func ParseMacroDirective(raw []byte) (*MacroDirective, error) {
 	}
 	endIdx += startIdx + 3
 
-	comment := strings.TrimSpace(s[startIdx+4 : endIdx-3])
+	commentBlock := s[startIdx:endIdx]
+	macroIdx := strings.Index(commentBlock, "Macro:")
+	if macroIdx == -1 {
+		return nil, nil
+	}
+
+	comment := strings.TrimSpace(commentBlock[4 : len(commentBlock)-3])
 	if !strings.HasPrefix(comment, "Macro:") {
 		return nil, nil
 	}
@@ -84,10 +86,12 @@ func (macro *Macro) Apply(
 		func(match []byte) []byte {
 			config := map[string]any{}
 
-			err = yaml.Unmarshal([]byte(macro.Config), &config)
-			if err != nil {
-				err = fmt.Errorf("unable to unmarshal macros config template: %w", err)
-				return match
+			if strings.TrimSpace(macro.Config) != "" {
+				err = yaml.Unmarshal([]byte(macro.Config), &config)
+				if err != nil {
+					err = fmt.Errorf("unable to unmarshal macros config template: %w", err)
+					return match
+				}
 			}
 
 			cfgData := macro.configure(
@@ -98,21 +102,24 @@ func (macro *Macro) Apply(
 			tmpl := macro.Template
 			if mData, ok := cfgData.(map[string]any); ok && macro.Name != "" {
 				if body, ok := mData[macro.Name].(string); ok {
-					if t, parseErr := template.New("inline").Parse(body); parseErr == nil {
-						tmpl = t
+					var errTmpl error
+					tmpl, errTmpl = template.New(macro.Name).Parse(body)
+					if errTmpl != nil {
+						err = fmt.Errorf("unable to parse inline template: %w", errTmpl)
+						return match
 					}
 				}
 			}
 
-			var buffer bytes.Buffer
+			var buf bytes.Buffer
 
-			err = tmpl.Execute(&buffer, cfgData)
+			err = tmpl.Execute(&buf, cfgData)
 			if err != nil {
-				err = fmt.Errorf("unable to execute macros template: %w", err)
+				err = fmt.Errorf("unable to execute template: %w", err)
 				return match
 			}
 
-			return buffer.Bytes()
+			return buf.Bytes()
 		},
 	)
 
@@ -154,80 +161,122 @@ func (macro *Macro) configure(node any, groups [][]byte) any {
 	return node
 }
 
+func findNextMacroStart(s string) int {
+	offset := 0
+	for {
+		idx := strings.Index(s[offset:], "<!--")
+		if idx == -1 {
+			return -1
+		}
+		commentStart := offset + idx
+		after := s[commentStart+4:]
+		trimmed := strings.TrimLeft(after, " \t\r\n")
+		if strings.HasPrefix(trimmed, "Macro:") {
+			return commentStart
+		}
+		offset = commentStart + 4
+	}
+}
+
 func ExtractMacros(
 	base string,
 	includePath string,
 	contents []byte,
 	templates *template.Template,
 ) ([]Macro, []byte, error) {
-	s := string(contents)
-	startIdx := strings.Index(s, "<!--")
-	if startIdx == -1 {
-		return nil, contents, nil
-	}
-	macroIdx := strings.Index(s[startIdx:], "Macro:")
-	if macroIdx == -1 {
-		return nil, contents, nil
-	}
-	endIdx := strings.LastIndex(s[startIdx:], "-->")
-	if endIdx == -1 {
-		return nil, contents, nil
-	}
-	endIdx += startIdx + 3
+	var extracted []Macro
+	remaining := contents
 
-	rawDirective := contents[startIdx:endIdx]
-	dir, err := ParseMacroDirective(rawDirective)
-	if err != nil {
-		return nil, contents, err
-	}
-	if dir == nil {
-		return nil, contents, nil
-	}
+	searchOffset := 0
+	for searchOffset < len(remaining) {
+		relStart := bytes.Index(remaining[searchOffset:], []byte("<!--"))
+		if relStart == -1 {
+			break
+		}
+		startIdx := searchOffset + relStart
 
-	var m Macro
-	if strings.HasPrefix(dir.Template, "#") {
-		m.Name = dir.Template[1:]
-		cfg := map[string]any{}
+		// Check if this comment block is a macro directive
+		s := string(remaining[startIdx:])
+		macroIdx := strings.Index(s, "Macro:")
+		firstEndIdx := strings.Index(s, "-->")
+		if macroIdx == -1 || firstEndIdx == -1 || macroIdx > firstEndIdx {
+			// Not a macro directive comment, move past this comment
+			searchOffset = startIdx + firstEndIdx + 3
+			continue
+		}
 
-		err = yaml.Unmarshal([]byte(dir.Config), &cfg)
+		// Find where this macro directive ends.
+		// If there is a subsequent macro directive, limit search before it.
+		limit := len(s)
+		nextMacroRel := findNextMacroStart(s[4:])
+		if nextMacroRel != -1 {
+			limit = 4 + nextMacroRel
+		}
+
+		relEnd := strings.LastIndex(s[:limit], "-->")
+		if relEnd == -1 {
+			relEnd = firstEndIdx
+		}
+		endIdx := startIdx + relEnd + 3
+
+		rawDirective := remaining[startIdx:endIdx]
+		dir, err := ParseMacroDirective(rawDirective)
 		if err != nil {
-			return nil, contents, fmt.Errorf("unable to unmarshal macros config template: %w", err)
+			return nil, contents, err
+		}
+		if dir == nil {
+			searchOffset = startIdx + 4
+			continue
 		}
 
-		body, ok := cfg[m.Name].(string)
-		if !ok {
-			return nil, contents, fmt.Errorf("the template config doesn't have '%s' field", m.Name)
+		var m Macro
+		if strings.HasPrefix(dir.Template, "#") {
+			m.Name = dir.Template[1:]
+			cfg := map[string]any{}
+
+			if strings.TrimSpace(dir.Config) != "" {
+				err = yaml.Unmarshal([]byte(dir.Config), &cfg)
+				if err != nil {
+					return nil, contents, fmt.Errorf("unable to unmarshal macros config template: %w", err)
+				}
+			}
+
+			body, ok := cfg[m.Name].(string)
+			if !ok {
+				return nil, contents, fmt.Errorf("the template config doesn't have '%s' field", m.Name)
+			}
+
+			m.Template, err = templates.New(dir.Template).Parse(body)
+			if err != nil {
+				return nil, contents, fmt.Errorf("unable to parse template: %w", err)
+			}
+		} else {
+			m.Template, err = includes.LoadTemplate(base, includePath, dir.Template, "{{", "}}", templates)
+			if err != nil {
+				return nil, contents, fmt.Errorf("unable to load template: %w", err)
+			}
 		}
 
-		m.Template, err = templates.New(dir.Template).Parse(body)
+		m.Regexp, err = regexp.Compile(dir.Expr)
 		if err != nil {
-			return nil, contents, fmt.Errorf("unable to parse template: %w", err)
+			return nil, contents, fmt.Errorf("unable to compile macros regexp (expr=%q, template=%q): %w", dir.Expr, dir.Template, err)
 		}
-	} else {
-		m.Template, err = includes.LoadTemplate(base, includePath, dir.Template, "{{", "}}", templates)
-		if err != nil {
-			return nil, contents, fmt.Errorf("unable to load template: %w", err)
-		}
+
+		m.Config = dir.Config
+
+		log.Trace().
+			Interface("vardump", map[string]any{
+				"expr":     dir.Expr,
+				"template": dir.Template,
+				"config":   m.Config,
+			}).
+			Msgf("loaded macro %q", dir.Expr)
+
+		extracted = append(extracted, m)
+
+		remaining = append(remaining[:startIdx], remaining[endIdx:]...)
+		searchOffset = startIdx
 	}
 
-	m.Regexp, err = regexp.Compile(dir.Expr)
-	if err != nil {
-		return nil, contents, fmt.Errorf("unable to compile macros regexp (expr=%q, template=%q): %w", dir.Expr, dir.Template, err)
-	}
-
-	m.Config = dir.Config
-
-	log.Trace().
-		Interface("vardump", map[string]any{
-			"expr":     dir.Expr,
-			"template": dir.Template,
-			"config":   m.Config,
-		}).
-		Msgf("loaded macro %q", dir.Expr)
-
-	var remaining bytes.Buffer
-	remaining.Write(contents[:startIdx])
-	remaining.Write(contents[endIdx:])
-
-	return []Macro{m}, remaining.Bytes(), nil
+	return extracted, remaining, nil
 }

--- a/transformer/macro_test.go
+++ b/transformer/macro_test.go
@@ -41,3 +41,42 @@ inline: "Hello ${1}!" -->
 	assert.Contains(t, output, "Hello World!")
 	assert.NotContains(t, output, "Macro:")
 }
+
+func TestMultipleMacrosDefinition(t *testing.T) {
+	markdownInput := []byte(`<!-- Macro: :hello:(?P<name>\w+):
+Template: #inline
+inline: "Hello ${1}!" -->
+
+<!-- Macro: :status:(?P<status>\w+):
+Template: #inline
+inline: "Status is ${1}." -->
+
+<!-- Macro: :box:(?P<text>\w+):
+Template: #inline
+inline: "Box: ${1}." -->
+
+:hello:World:
+:status:active:`)
+
+	transformer := NewMacroTransformer("test.md", "", "", template.New("test"))
+
+	gm := goldmark.New(
+		goldmark.WithParserOptions(
+			parser.WithASTTransformers(
+				util.Prioritized(transformer, 100),
+			),
+		),
+		goldmark.WithRendererOptions(
+			html.WithUnsafe(),
+		),
+	)
+
+	var buf bytes.Buffer
+	err := gm.Convert(markdownInput, &buf)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "Hello World!")
+	assert.Contains(t, output, "Status is active.")
+	assert.NotContains(t, output, "Macro:")
+}


### PR DESCRIPTION
### Summary

Fixes [#829](https://github.com/kovetskiy/mark/issues/829) where defining multiple `<!-- Macro: ... -->` comments in a single document caused macro configuration strings to be corrupted and concatenated together, resulting in `yaml: line 2: did not find expected key` during macro expansion.

### Root Cause & Solution

- **Root Cause**: `macro.ExtractMacros` and `macro.ParseMacroDirective` used `strings.LastIndex` across the entire document buffer `contents`. When multiple `<!-- Macro: ... -->` directives were defined in adjacent HTML blocks or a single document, `strings.LastIndex` matched the closing `-->` of the *last* defined macro in the file. This caused earlier macros (such as `:toc:`) to ingest all subsequent macro definitions into their YAML `Config` string.
- **Fix**: 
  1. `ExtractMacros` now dynamically limits the end of each macro comment search before the next `<!-- Macro:` directive via `findNextMacroStart`.
  2. `ParseMacroDirective` now uses `strings.LastIndex` scoped specifically within the individual raw macro comment slice.
  3. `ExtractMacros` now loops through all macro comment blocks in `contents` and parses each macro with its own isolated YAML configuration.

### Verification

- Added unit test `TestMultipleMacrosDefinition` in `transformer/macro_test.go` matching the issue #829 reproduction case.
- `go test -count=1 ./...` passes 100%.
- `golangci-lint run` passes with 0 issues.
- `npx -y markdownlint-cli2 README.md` passes with 0 issues.