### PR TITLE
refactor(renderer): streamline Goldmark renderer fallbacks and parser IDs

### DIFF
--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -141,7 +141,7 @@ func compileMarkdownWithExtension(markdown []byte, ext goldmark.Extender, logMes
 			html.WithXHTML(),
 		))
 
-	ctx := parser.NewContext(parser.WithIDs(&cparser.ConfluenceIDs{Values: map[string]bool{}}))
+	ctx := parser.NewContext(parser.WithIDs(cparser.NewConfluenceIDs()))
 
 	var buf bytes.Buffer
 	err := converter.Convert(markdown, &buf, parser.WithContext(ctx))

--- a/parser/confluenceids.go
+++ b/parser/confluenceids.go
@@ -7,11 +7,18 @@ import (
 	"github.com/yuin/goldmark/util"
 )
 
+// ConfluenceIDs implements parser.IDs for Confluence-compatible header anchor IDs,
+// preserving '/', '_', '.', and '-' characters in heading IDs.
 type ConfluenceIDs struct {
 	Values map[string]bool
 }
 
-// https://github.com/yuin/goldmark/blob/d9c03f07f08c2d36f23afe52dda865f05320ac86/parser/parser.go#L75
+// NewConfluenceIDs creates a new ConfluenceIDs instance.
+func NewConfluenceIDs() *ConfluenceIDs {
+	return &ConfluenceIDs{
+		Values: make(map[string]bool),
+	}
+}
 func (s *ConfluenceIDs) Generate(value []byte, kind ast.NodeKind) []byte {
 	value = util.TrimLeftSpace(value)
 	value = util.TrimRightSpace(value)

--- a/parser/confluenceids.go
+++ b/parser/confluenceids.go
@@ -20,6 +20,9 @@ func NewConfluenceIDs() *ConfluenceIDs {
 	}
 }
 func (s *ConfluenceIDs) Generate(value []byte, kind ast.NodeKind) []byte {
+	if s.Values == nil {
+		s.Values = make(map[string]bool)
+	}
 	value = util.TrimLeftSpace(value)
 	value = util.TrimRightSpace(value)
 	result := []byte{}
@@ -53,10 +56,12 @@ func (s *ConfluenceIDs) Generate(value []byte, kind ast.NodeKind) []byte {
 			s.Values[newResult] = true
 			return []byte(newResult)
 		}
-
 	}
 }
 
 func (s *ConfluenceIDs) Put(value []byte) {
+	if s.Values == nil {
+		s.Values = make(map[string]bool)
+	}
 	s.Values[util.BytesToReadOnlyString(value)] = true
 }

--- a/parser/confluenceids_test.go
+++ b/parser/confluenceids_test.go
@@ -1,0 +1,53 @@
+package parser_test
+
+import (
+	"testing"
+
+	cparser "github.com/kovetskiy/mark/v16/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark/ast"
+)
+
+func TestConfluenceIDs_Generate(t *testing.T) {
+	t.Run("Standard title with spaces", func(t *testing.T) {
+		ids := cparser.NewConfluenceIDs()
+		res := ids.Generate([]byte("Hello World"), ast.KindHeading)
+		assert.Equal(t, "Hello-World", string(res))
+	})
+
+	t.Run("Title preserving slashes underscores and dots", func(t *testing.T) {
+		ids := cparser.NewConfluenceIDs()
+		res := ids.Generate([]byte("This/is some_Heading.yml"), ast.KindHeading)
+		assert.Equal(t, "This/is-some_Heading.yml", string(res))
+	})
+
+	t.Run("Collision handling", func(t *testing.T) {
+		ids := cparser.NewConfluenceIDs()
+		res1 := ids.Generate([]byte("Section"), ast.KindHeading)
+		res2 := ids.Generate([]byte("Section"), ast.KindHeading)
+		res3 := ids.Generate([]byte("Section"), ast.KindHeading)
+
+		assert.Equal(t, "Section", string(res1))
+		assert.Equal(t, "Section-1", string(res2))
+		assert.Equal(t, "Section-2", string(res3))
+	})
+
+	t.Run("Empty title fallback", func(t *testing.T) {
+		ids := cparser.NewConfluenceIDs()
+		resHeading := ids.Generate([]byte("!!!"), ast.KindHeading)
+		resOther := ids.Generate([]byte("???"), ast.KindParagraph)
+
+		assert.Equal(t, "heading", string(resHeading))
+		assert.Equal(t, "id", string(resOther))
+	})
+
+	t.Run("Lazy initialization of nil map", func(t *testing.T) {
+		var ids cparser.ConfluenceIDs
+		res := ids.Generate([]byte("Test Header"), ast.KindHeading)
+		assert.Equal(t, "Test-Header", string(res))
+
+		ids.Put([]byte("ManualID"))
+		resDup := ids.Generate([]byte("ManualID"), ast.KindHeading)
+		assert.Equal(t, "ManualID-1", string(resDup))
+	})
+}

--- a/renderer/blockquote.go
+++ b/renderer/blockquote.go
@@ -172,21 +172,16 @@ func (r *ConfluenceBlockQuoteRenderer) renderBlockQuote(writer util.BufWriter, s
 		}
 		return ast.WalkContinue, nil
 	}
-	return r.goldmarkRenderBlockquote(writer, source, node, entering)
-}
-
-// goldmarkRenderBlockquote is the default renderBlockquote implementation from https://github.com/yuin/goldmark/blob/9d6f314b99ca23037c93d76f248be7b37de6220a/renderer/html/html.go#L286
-func (r *ConfluenceBlockQuoteRenderer) goldmarkRenderBlockquote(w util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
-		if n.Attributes() != nil {
-			_, _ = w.WriteString("<blockquote")
-			html.RenderAttributes(w, n, html.BlockquoteAttributeFilter)
-			_ = w.WriteByte('>')
+		if node.Attributes() != nil {
+			_, _ = writer.WriteString("<blockquote")
+			html.RenderAttributes(writer, node, html.BlockquoteAttributeFilter)
+			_ = writer.WriteByte('>')
 		} else {
-			_, _ = w.WriteString("<blockquote>\n")
+			_, _ = writer.WriteString("<blockquote>\n")
 		}
 	} else {
-		_, _ = w.WriteString("</blockquote>\n")
+		_, _ = writer.WriteString("</blockquote>\n")
 	}
 	return ast.WalkContinue, nil
 }

--- a/renderer/link.go
+++ b/renderer/link.go
@@ -64,29 +64,23 @@ func (r *ConfluenceLinkRenderer) renderLink(writer util.BufWriter, source []byte
 		}
 		return ast.WalkSkipChildren, nil
 	}
-	return r.goldmarkRenderLink(writer, source, node, entering)
-}
-
-// goldmarkRenderLink is the default renderLink implementation from https://github.com/yuin/goldmark/blob/9d6f314b99ca23037c93d76f248be7b37de6220a/renderer/html/html.go#L552
-func (r *ConfluenceLinkRenderer) goldmarkRenderLink(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
-	n := node.(*ast.Link)
 	if entering {
-		_, _ = w.WriteString("<a href=\"")
+		_, _ = writer.WriteString("<a href=\"")
 		if r.Unsafe || !html.IsDangerousURL(n.Destination) {
-			_, _ = w.Write(util.EscapeHTML(util.URLEscape(n.Destination, true)))
+			_, _ = writer.Write(util.EscapeHTML(util.URLEscape(n.Destination, true)))
 		}
-		_ = w.WriteByte('"')
+		_ = writer.WriteByte('"')
 		if n.Title != nil {
-			_, _ = w.WriteString(` title="`)
-			r.Writer.Write(w, n.Title)
-			_ = w.WriteByte('"')
+			_, _ = writer.WriteString(` title="`)
+			r.Writer.Write(writer, n.Title)
+			_ = writer.WriteByte('"')
 		}
 		if n.Attributes() != nil {
-			html.RenderAttributes(w, n, html.LinkAttributeFilter)
+			html.RenderAttributes(writer, n, html.LinkAttributeFilter)
 		}
-		_ = w.WriteByte('>')
+		_ = writer.WriteByte('>')
 	} else {
-		_, _ = w.WriteString("</a>")
+		_, _ = writer.WriteString("</a>")
 	}
 	return ast.WalkContinue, nil
 }


### PR DESCRIPTION
### Summary

Streamlines and cleans up fallback Goldmark node rendering across `renderer/link.go` and `renderer/blockquote.go`, and adds an explicit constructor for `parser.ConfluenceIDs`.

### Key Improvements

1. **Inlined & Streamlined Renderer Fallbacks**:
   - Removed redundant copy-pasted `goldmarkRenderLink` function in `renderer/link.go` and inlined HTML attribute rendering (`html.RenderAttributes`).
   - Cleaned up duplicate fallback functions in `renderer/blockquote.go`.
2. **Standardized `ConfluenceIDs` Constructor**:
   - Added `NewConfluenceIDs()` constructor in `parser/confluenceids.go` to cleanly instantiate `Values` maps when implementing Goldmark's `parser.IDs` interface.

### Verification

- `go test -count=1 ./...` passes 100%.
- `golangci-lint run` passes with 0 issues.
- `npx -y markdownlint-cli2 README.md` passes with 0 issues.