### PR TITLE
fix(includes): preserve raw unescaped HTML/XML in included templates

### DIFF
--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -2,11 +2,14 @@ package mark
 
 import (
 	"bytes"
+	"fmt"
+	"path/filepath"
 	"slices"
 	"text/template"
 
 	katex "github.com/FurqanSoftware/goldmark-katex"
 	"github.com/kovetskiy/mark/v16/attachment"
+	"github.com/kovetskiy/mark/v16/includes"
 	cparser "github.com/kovetskiy/mark/v16/parser"
 	crenderer "github.com/kovetskiy/mark/v16/renderer"
 	"github.com/kovetskiy/mark/v16/stdlib"
@@ -157,26 +160,74 @@ func compileMarkdownWithExtension(markdown []byte, ext goldmark.Extender, logMes
 }
 
 func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib, path string, cfg types.MarkConfig) (string, []attachment.Attachment, error) {
+	var tmpl *template.Template
+	if stdlib != nil {
+		tmpl = stdlib.Templates
+	} else {
+		tmpl = template.New("stdlib")
+	}
+
+	var err error
+	var recurse bool
+	for {
+		tmpl, markdown, recurse, err = includes.ProcessIncludes(
+			filepath.Dir(path),
+			cfg.IncludePath,
+			markdown,
+			tmpl,
+		)
+		if err != nil {
+			return "", nil, fmt.Errorf("unable to process includes: %w", err)
+		}
+		if !recurse {
+			break
+		}
+	}
+
 	ghAlertsExtension := NewConfluenceExtension(stdlib, path, cfg)
-	html, err := compileMarkdownWithExtension(markdown, ghAlertsExtension, "rendering markdown with GitHub Alerts support:\n%s")
+	htmlOutput, err := compileMarkdownWithExtension(markdown, ghAlertsExtension, "rendering markdown with GitHub Alerts support:\n%s")
 	if err == nil && ghAlertsExtension.Pipeline != nil && ghAlertsExtension.Pipeline.GetError() != nil {
 		err = ghAlertsExtension.Pipeline.GetError()
 	}
 	if err != nil {
 		return "", nil, err
 	}
-	return html, ghAlertsExtension.Attachments, nil
+	return htmlOutput, ghAlertsExtension.Attachments, nil
 }
 
 // CompileMarkdownLegacy compiles markdown using the legacy approach without GitHub Alerts transformer
 // This function is preserved for backward compatibility and testing purposes
 func CompileMarkdownLegacy(markdown []byte, stdlib *stdlib.Lib, path string, cfg types.MarkConfig) (string, []attachment.Attachment, error) {
+	var tmpl *template.Template
+	if stdlib != nil {
+		tmpl = stdlib.Templates
+	} else {
+		tmpl = template.New("stdlib")
+	}
+
+	var err error
+	var recurse bool
+	for {
+		tmpl, markdown, recurse, err = includes.ProcessIncludes(
+			filepath.Dir(path),
+			cfg.IncludePath,
+			markdown,
+			tmpl,
+		)
+		if err != nil {
+			return "", nil, fmt.Errorf("unable to process includes: %w", err)
+		}
+		if !recurse {
+			break
+		}
+	}
+
 	confluenceExtension := NewConfluenceLegacyExtension(stdlib, path, cfg)
-	html, err := compileMarkdownWithExtension(markdown, confluenceExtension, "rendering markdown with legacy renderer:\n%s")
+	htmlOutput, err := compileMarkdownWithExtension(markdown, confluenceExtension, "rendering markdown with legacy renderer:\n%s")
 	if err != nil {
 		return "", nil, err
 	}
-	return html, confluenceExtension.Attachments, nil
+	return htmlOutput, confluenceExtension.Attachments, nil
 }
 
 // ConfluenceExtension is a goldmark extension for GitHub Alerts with Transformer approach

--- a/transformer/include.go
+++ b/transformer/include.go
@@ -5,11 +5,14 @@ import (
 	"text/template"
 
 	"github.com/kovetskiy/mark/v16/includes"
+	cparser "github.com/kovetskiy/mark/v16/parser"
 	"github.com/rs/zerolog/log"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
 )
 
 // IncludeTransformer transforms <!-- Include: ... --> directives in the Goldmark AST
@@ -116,7 +119,16 @@ func (t *IncludeTransformer) TransformWithModified(doc *ast.Document, reader tex
 		}
 		t.Templates = tmpl
 
-		p := goldmark.DefaultParser()
+		p := goldmark.New(
+			goldmark.WithParserOptions(
+				parser.WithInlineParsers(
+					util.Prioritized(cparser.NewConfluenceTagParser(), 99),
+				),
+			),
+			goldmark.WithRendererOptions(
+				html.WithUnsafe(),
+			),
+		).Parser()
 		subDoc := p.Parse(text.NewReader(expanded))
 		convertSegmentsToStrings(subDoc, expanded)
 

--- a/transformer/include_test.go
+++ b/transformer/include_test.go
@@ -1,4 +1,4 @@
-package transformer
+package transformer_test
 
 import (
 	"bytes"
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"text/template"
 
+	cmarkdown "github.com/kovetskiy/mark/v16/markdown"
+	ctransformer "github.com/kovetskiy/mark/v16/transformer"
+	"github.com/kovetskiy/mark/v16/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/yuin/goldmark"
@@ -23,7 +26,7 @@ func TestIncludeTransformer(t *testing.T) {
 
 	markdownInput := []byte("<!-- Include: header.md\nname: World -->\n\nMain content here.")
 
-	transformer := NewIncludeTransformer("test.md", tempDir, "", template.New("test"))
+	transformer := ctransformer.NewIncludeTransformer("test.md", tempDir, "", template.New("test"))
 
 	gm := goldmark.New(
 		goldmark.WithParserOptions(
@@ -44,4 +47,21 @@ func TestIncludeTransformer(t *testing.T) {
 	assert.Contains(t, output, "Header from Include")
 	assert.Contains(t, output, "Hello World")
 	assert.Contains(t, output, "Main content here.")
+}
+
+func TestIncludeTransformerUnsafeHTML(t *testing.T) {
+	tempDir := t.TempDir()
+	templatePath := filepath.Join(tempDir, "raw_html.md")
+	err := os.WriteFile(templatePath, []byte("<div><ac:structured-macro ac:name=\"info\"><ac:rich-text-body><p>Unescaped content</p></ac:rich-text-body></ac:structured-macro></div>"), 0644)
+	require.NoError(t, err)
+
+	markdownInput := []byte("<!-- Include: raw_html.md -->")
+
+	output, _, err := cmarkdown.CompileMarkdown(markdownInput, nil, filepath.Join(tempDir, "test.md"), types.MarkConfig{
+		IncludePath: tempDir,
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "<ac:structured-macro ac:name=\"info\">")
+	assert.NotContains(t, output, "&lt;ac:structured-macro")
 }

--- a/transformer/macro.go
+++ b/transformer/macro.go
@@ -5,11 +5,14 @@ import (
 	"text/template"
 
 	"github.com/kovetskiy/mark/v16/macro"
+	cparser "github.com/kovetskiy/mark/v16/parser"
 	"github.com/rs/zerolog/log"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
 )
 
 // MacroTransformer extracts macro directives from HTML comment blocks in the Goldmark AST,
@@ -175,7 +178,16 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 				continue
 			}
 
-			p := goldmark.DefaultParser()
+			p := goldmark.New(
+				goldmark.WithParserOptions(
+					parser.WithInlineParsers(
+						util.Prioritized(cparser.NewConfluenceTagParser(), 99),
+					),
+				),
+				goldmark.WithRendererOptions(
+					html.WithUnsafe(),
+				),
+			).Parser()
 			subDoc := p.Parse(text.NewReader(expanded))
 			convertSegmentsToStrings(subDoc, expanded)
 

--- a/transformer/util.go
+++ b/transformer/util.go
@@ -120,10 +120,12 @@ func ExtractNodeRawContent(node ast.Node, source []byte) []byte {
 }
 
 func convertSegmentsToStrings(doc ast.Node, source []byte) {
-	var nodesToReplace []struct {
-		node ast.Node
-		val  []byte
+	type replaceItem struct {
+		node  ast.Node
+		val   []byte
+		isRaw bool
 	}
+	var nodesToReplace []replaceItem
 
 	_ = ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
@@ -135,19 +137,13 @@ func convertSegmentsToStrings(doc ast.Node, source []byte) {
 				val := t.Segment.Value(source)
 				valCopy := make([]byte, len(val))
 				copy(valCopy, val)
-				nodesToReplace = append(nodesToReplace, struct {
-					node ast.Node
-					val  []byte
-				}{node: t, val: valCopy})
+				nodesToReplace = append(nodesToReplace, replaceItem{node: t, val: valCopy, isRaw: false})
 			}
 		case *ast.HTMLBlock:
 			val := extractHTMLBlockBytes(t, source)
 			valCopy := make([]byte, len(val))
 			copy(valCopy, val)
-			nodesToReplace = append(nodesToReplace, struct {
-				node ast.Node
-				val  []byte
-			}{node: t, val: valCopy})
+			nodesToReplace = append(nodesToReplace, replaceItem{node: t, val: valCopy, isRaw: true})
 		case *ast.RawHTML:
 			if t.Segments.Len() == 1 {
 				seg := t.Segments.At(0)
@@ -155,10 +151,7 @@ func convertSegmentsToStrings(doc ast.Node, source []byte) {
 					val := seg.Value(source)
 					valCopy := make([]byte, len(val))
 					copy(valCopy, val)
-					nodesToReplace = append(nodesToReplace, struct {
-						node ast.Node
-						val  []byte
-					}{node: t, val: valCopy})
+					nodesToReplace = append(nodesToReplace, replaceItem{node: t, val: valCopy, isRaw: true})
 				}
 			} else {
 				buf := getBuffer()
@@ -171,10 +164,7 @@ func convertSegmentsToStrings(doc ast.Node, source []byte) {
 				valCopy := make([]byte, buf.Len())
 				copy(valCopy, buf.Bytes())
 				putBuffer(buf)
-				nodesToReplace = append(nodesToReplace, struct {
-					node ast.Node
-					val  []byte
-				}{node: t, val: valCopy})
+				nodesToReplace = append(nodesToReplace, replaceItem{node: t, val: valCopy, isRaw: true})
 			}
 		}
 		return ast.WalkContinue, nil
@@ -184,6 +174,9 @@ func convertSegmentsToStrings(doc ast.Node, source []byte) {
 		parent := item.node.Parent()
 		if parent != nil {
 			strNode := ast.NewString(item.val)
+			if item.isRaw {
+				strNode.SetRaw(true)
+			}
 			parent.InsertBefore(parent, item.node, strNode)
 			parent.RemoveChild(parent, item.node)
 		}


### PR DESCRIPTION
### Summary

Fixes a regression where raw HTML / XML tags (such as Confluence `<ac:...>` macros, `<div>`, `<table>`, etc.) contained inside included files (`<!-- Include: ... -->`) were HTML-escaped into `&lt;ac:...&gt;` during rendering.

### Root Cause & Solution

1. **Root Cause**: 
   - `IncludeTransformer` and `MacroTransformer` parsed included sub-documents with Goldmark's default parser configuration without `cparser.NewConfluenceTagParser()` or `html.WithUnsafe()`.
   - In `transformer/util.go`, `convertSegmentsToStrings` converted `*ast.HTMLBlock` and `*ast.RawHTML` into `ast.NewString(val)` without calling `strNode.SetRaw(true)`. Goldmark's HTML renderer subsequently escaped all `<` characters in those string nodes.
2. **Fix**:
   - `CompileMarkdown` pre-expands `includes.ProcessIncludes` directly on the raw Markdown buffer before Goldmark parses, ensuring all included raw HTML elements, Confluence storage tags, tables, and headings are parsed into the main AST without escaping.
   - `IncludeTransformer` and `MacroTransformer` sub-document parsers now register `cparser.NewConfluenceTagParser()` and `html.WithUnsafe()`.
   - `convertSegmentsToStrings` sets `strNode.SetRaw(true)` on converted `*ast.HTMLBlock` and `*ast.RawHTML` nodes.

### Verification

- Added unit test `TestIncludeTransformerUnsafeHTML` in `transformer/include_test.go` verifying that raw Confluence tags in included files render unescaped.
- `go test -count=1 ./...` passes 100%.
- `golangci-lint run` passes with 0 issues.
- `npx -y markdownlint-cli2 README.md` passes with 0 issues.