### PR TITLE
fix(macro): pre-expand macros before Goldmark parsing to preserve unescaped XML in table cells

### DIFF
--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -10,6 +10,7 @@ import (
 	katex "github.com/FurqanSoftware/goldmark-katex"
 	"github.com/kovetskiy/mark/v16/attachment"
 	"github.com/kovetskiy/mark/v16/includes"
+	"github.com/kovetskiy/mark/v16/macro"
 	cparser "github.com/kovetskiy/mark/v16/parser"
 	crenderer "github.com/kovetskiy/mark/v16/renderer"
 	"github.com/kovetskiy/mark/v16/stdlib"
@@ -184,6 +185,18 @@ func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib, path string, cfg types
 		}
 	}
 
+	var macros []macro.Macro
+	macros, markdown, err = macro.ExtractMacros(filepath.Dir(path), cfg.IncludePath, markdown, tmpl)
+	if err != nil {
+		return "", nil, fmt.Errorf("unable to extract macros: %w", err)
+	}
+	for _, m := range macros {
+		markdown, err = m.Apply(markdown)
+		if err != nil {
+			return "", nil, fmt.Errorf("unable to apply macro %q: %w", m.Regexp.String(), err)
+		}
+	}
+
 	ghAlertsExtension := NewConfluenceExtension(stdlib, path, cfg)
 	htmlOutput, err := compileMarkdownWithExtension(markdown, ghAlertsExtension, "rendering markdown with GitHub Alerts support:\n%s")
 	if err == nil && ghAlertsExtension.Pipeline != nil && ghAlertsExtension.Pipeline.GetError() != nil {
@@ -219,6 +232,18 @@ func CompileMarkdownLegacy(markdown []byte, stdlib *stdlib.Lib, path string, cfg
 		}
 		if !recurse {
 			break
+		}
+	}
+
+	var macros []macro.Macro
+	macros, markdown, err = macro.ExtractMacros(filepath.Dir(path), cfg.IncludePath, markdown, tmpl)
+	if err != nil {
+		return "", nil, fmt.Errorf("unable to extract macros: %w", err)
+	}
+	for _, m := range macros {
+		markdown, err = m.Apply(markdown)
+		if err != nil {
+			return "", nil, fmt.Errorf("unable to apply macro %q: %w", m.Regexp.String(), err)
 		}
 	}
 

--- a/transformer/macro_test.go
+++ b/transformer/macro_test.go
@@ -1,10 +1,13 @@
-package transformer
+package transformer_test
 
 import (
 	"bytes"
 	"testing"
 	"text/template"
 
+	cmarkdown "github.com/kovetskiy/mark/v16/markdown"
+	ctransformer "github.com/kovetskiy/mark/v16/transformer"
+	"github.com/kovetskiy/mark/v16/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/yuin/goldmark"
@@ -20,7 +23,7 @@ inline: "Hello ${1}!" -->
 
 :hello:World:`)
 
-	transformer := NewMacroTransformer("test.md", "", "", template.New("test"))
+	transformer := ctransformer.NewMacroTransformer("test.md", "", "", template.New("test"))
 
 	gm := goldmark.New(
 		goldmark.WithParserOptions(
@@ -58,7 +61,7 @@ inline: "Box: ${1}." -->
 :hello:World:
 :status:active:`)
 
-	transformer := NewMacroTransformer("test.md", "", "", template.New("test"))
+	transformer := ctransformer.NewMacroTransformer("test.md", "", "", template.New("test"))
 
 	gm := goldmark.New(
 		goldmark.WithParserOptions(
@@ -79,4 +82,20 @@ inline: "Box: ${1}." -->
 	assert.Contains(t, output, "Hello World!")
 	assert.Contains(t, output, "Status is active.")
 	assert.NotContains(t, output, "Macro:")
+}
+
+func TestMacroInTableCell(t *testing.T) {
+	markdownInput := []byte(`<!-- Macro: :accept:
+Template: #inline
+inline: "<ac:structured-macro ac:name=\"status\"><ac:parameter ac:name=\"title\">ACCEPTED</ac:parameter></ac:structured-macro>" -->
+
+| Status | Description |
+| --- | --- |
+| :accept: | Approved |`)
+
+	output, _, err := cmarkdown.CompileMarkdown(markdownInput, nil, "test.md", types.MarkConfig{})
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "<ac:structured-macro ac:name=\"status\">")
+	assert.NotContains(t, output, "&lt;ac:structured-macro")
 }


### PR DESCRIPTION
### Summary

Fixes an issue where macros (such as status macros like `:accept:`) expanded inside table cells were HTML-escaped into `&lt;ac:structured-macro...&gt;`.

### Root Cause & Solution

1. **Root Cause**: 
   - When macros were transformed during the AST transformer phase (`MacroTransformer`), Goldmark had already parsed table cells into `table.TableCell` nodes. When sub-documents from expanded macros were parsed and injected into `table.TableCell`, Goldmark's table cell renderer rendered inline string nodes with `util.EscapeHTML`, escaping `<` to `&lt;`.
2. **Fix**:
   - `CompileMarkdown` and `CompileMarkdownLegacy` pre-expand macro definitions (`macro.ExtractMacros` and `m.Apply`) on the raw Markdown buffer before Goldmark parses the document into the AST.
   - When Goldmark parses the pre-expanded buffer containing table cells with Confluence storage tags (e.g. `<ac:structured-macro...`), Goldmark's `cparser.NewConfluenceTagParser()` parses the tags into `ast.KindRawHTML` nodes inside table cells, rendering them as raw unescaped HTML.

### Verification

- Added unit test `TestMacroInTableCell` in `transformer/macro_test.go` verifying that status macros expanded inside table cells render unescaped XML.
- `go test -count=1 ./...` passes 100%.
- `golangci-lint run` passes with 0 issues.
- `npx -y markdownlint-cli2 README.md` passes with 0 issues.