### PR TITLE
chore: add AGENTS.md, golangci-lint config, and workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ on:
 env:
   GO_VERSION: "1.26.1"
 
+# Least privilege by default. No job in this workflow writes to the repository;
+# the Docker Hub push authenticates with its own secrets, not GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   # Runs Golangci-lint on the source code
   ci-go-lint:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -5,9 +5,15 @@ on:
     tags:
     - '*'
 
+permissions:
+  contents: read
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    # GoReleaser publishes the GitHub release for the pushed tag.
+    permissions:
+      contents: write
     steps:
     - name: Checkout
       uses: actions/checkout@v7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,47 @@
+version: "2"
+
+linters:
+  # "standard" is errcheck, govet, ineffassign, staticcheck and unused -- the
+  # set golangci-lint ran with before this file existed. Everything below is
+  # additive, so enabling the config cannot silently drop a check.
+  default: standard
+  enable:
+    - bodyclose      # HTTP response bodies must be closed; mark makes ~30 Confluence calls
+    - copyloopvar    # detects now-redundant loop variable copies (Go >= 1.22)
+    - errorlint      # %v on errors, type assertions instead of errors.As/Is
+    - gosec          # security-focused checks
+    - misspell
+    - nilerr         # "return nil" on a non-nil error
+    - unconvert      # redundant type conversions
+    - usestdlibvars  # http.StatusOK over 200, http.MethodGet over "GET"
+    - wastedassign
+
+  settings:
+    gosec:
+      excludes:
+        # G104 duplicates errcheck, which is already part of the standard set.
+        - G104
+    misspell:
+      # Deliberately no locale: the Confluence storage format spells attributes
+      # in British English (ac:parameter ac:name="colour"), so enforcing US
+      # spelling would flag correct markup in stdlib templates.
+      ignore-rules:
+        - colour
+
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # Tests read fixture paths built from testdata/ and shell out to nothing;
+      # file inclusion and weak-random findings there are noise.
+      - path: _test\.go
+        linters:
+          - gosec
+
+formatters:
+  enable:
+    - gofmt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,135 @@
+# AGENTS.md
+
+Guidance for AI coding agents (and new human contributors) working in this repository.
+
+`mark` reads Markdown and writes **Confluence storage format** — an XML dialect, not
+HTML. Most of the subtle bugs in this project's history come from forgetting that. Read
+the Invariants section before changing anything under `renderer/`, `transformer/`,
+`parser/`, `macro/`, `includes/`, or `stdlib/`.
+
+## Build, test, lint
+
+```shell
+make build                 # -> ./mark  (CGO_ENABLED=0, ./cmd/mark)
+make test                  # go test -race -coverprofile=profile.cov ./... -v
+go test ./... -count=1     # faster loop
+golangci-lint run ./...    # config in .golangci.yml; CI runs this
+markdownlint-cli2          # config in .markdownlint-cli2.jsonc; CI runs this on *.md
+```
+
+Go 1.26. The module path is `github.com/kovetskiy/mark/v16` — the major version is part
+of the path, so a major bump means rewriting every internal import.
+
+`d2` and `mermaid` tests launch headless Chrome and take ~4s each; a full `go test ./...`
+is dominated by them. There is currently no `-short` skip.
+
+## Layout
+
+| path | role |
+| --- | --- |
+| `cmd/mark` | thin `main`; flag wiring lives in `util/` |
+| `util/` | CLI flags, config file/env sourcing, credential resolution |
+| `mark.go` | orchestration: `Run` (glob → loop) and `ProcessFile` (the whole per-file pipeline) |
+| `metadata/` | `<!-- Header: -->` comments and YAML front matter → `Meta` |
+| `page/` | ancestry/folder resolution, relative-link rewriting, relocation |
+| `confluence/` | REST client (v1 `/rest/api` + v2 `/api/v2`), page cache |
+| `attachment/` | checksum, upload/update, link rewriting |
+| `markdown/` | goldmark assembly; `CompileMarkdown` is the entry point |
+| `parser/` | goldmark inline/block parsers (`<ac:*/>` tags, mentions, dates) |
+| `transformer/` | goldmark AST transformers (macros, includes, GH alerts, details, layout, `<img>`) |
+| `renderer/` | goldmark node renderers → storage format |
+| `stdlib/` | the `text/template` set that emits all `<ac:*>` markup |
+
+Pipeline in `ProcessFile`: read → normalise CRLF → extract metadata → resolve relative
+links → resolve/create page + ancestry → resolve attachments → `CompileMarkdown` →
+resolve inline attachments → wrap in `ac:layout` → optionally merge inline comments →
+update page → sync labels.
+
+## Invariants
+
+**1. Output must be well-formed XML.** Confluence rejects the whole page with
+`BadRequestException` if it is not. Unbalanced tags, stray `&`, or an unescaped quote in
+an attribute break the entire upload, not just one element.
+
+**2. Escape through the `stdlib` template funcs, never by hand.**
+
+- `xmlesc` — any interpolated text or attribute value.
+- `cdata` — any text placed inside `<![CDATA[...]]>`; it splits an embedded `]]>` across
+  two CDATA sections, which is the only legal way to escape it.
+- `convertAttachment` — values destined for `ri:filename`; slash-flattens *and* escapes.
+
+Titles, filenames, and `ri:content-title` have each caused a malformed-XML bug in the
+past. If you add a template that interpolates user-controlled text, pipe it through one
+of these.
+
+**3. Macros and includes are expanded *before* goldmark parses.** Macro bodies routinely
+contain raw `<ac:...>` XML that goldmark would escape or mangle — particularly inside
+table cells. `macro.ExtractMacros` and `includes.ProcessIncludes` run on the raw bytes in
+`CompileMarkdown` before the converter is built. Do not move this work into an AST
+transformer without understanding why it was moved out of one.
+
+**4. goldmark priorities run in opposite directions for parsers and renderers.**
+
+- *Node renderers*: registered in ascending priority order, so a **larger** number is
+  registered later and **overrides** an earlier registration for the same node kind. The
+  GH-alerts blockquote/text renderers use `200` specifically to beat the `100` defaults.
+- *Inline/block parsers*: a **smaller** number is tried **first**. `ConfluenceTagParser`
+  uses `199` to run before goldmark's own link parser at `200`, so that `<ac:*/>` tags are
+  not parsed as links.
+
+Getting this backwards silently produces the default rendering.
+
+**5. AST transformers cannot return errors.** goldmark's `ASTTransformer` interface has no
+error return, so `transformer.PipelineTransformer` accumulates errors internally and
+`CompileMarkdown` retrieves them with `Pipeline.GetError()` after `Convert`. A transformer
+that fails silently without recording into the pipeline will produce a wrong page and a
+zero exit code.
+
+**6. Two compile paths must both keep working.** `CompileMarkdown` (default, GH alerts +
+pipeline transformer) and `CompileMarkdownLegacy` (the original renderer set). They are
+compared against each other in `markdown/transformer_comparison_test.go`.
+
+**7. Attachment checksums are content-addressed, but diagrams are source-addressed.**
+Checksums live in the remote attachment's comment behind the `AttachmentChecksumPrefix`
+(`mark:checksum:` followed by a space).
+Mermaid and d2 attachments set `Checksum` from the *diagram source*, not the rendered PNG
+bytes, because Chrome's output is not byte-stable across environments. `ResolveAttachments`
+skips checksum computation when `Checksum` is already set — preserve that.
+
+**8. `--features` replaces the defaults, it does not add to them.** Defaults are
+`mermaid,mention`. When adding a feature: register it in `markdown/markdown.go` (both
+extensions if applicable), add it to the `Usage` string of the `features` flag in
+`util/flags.go`, and document it in `README.md`.
+
+**9. Everything is sequential today, and some caches rely on that.**
+`page.createdFolderCache` is an unguarded map with a comment saying so, and
+`confluence.API.isCloudFlag/isCloudChecked` are unsynchronised (unlike `pageCache`, which
+is mutex-guarded). Anything that introduces concurrency across files must fix those first.
+
+## Tests
+
+Golden-file tests drive most rendering coverage. `testdata/<name>.md` is compiled and
+compared against `testdata/<name>.html`; variant suffixes cover flag combinations:
+
+- `<name>-droph1.html` — `DropFirstH1`
+- `<name>-stripnewlines.html` — `StripNewlines`
+- feature-specific variants, e.g. `plantuml-nofeature.html`, `inline-link-card-inlinecard.html`
+
+Adding a `.md` fixture without its matching `.html` panics the test — the loader reads
+both unconditionally. There is no `-update` flag; golden files are written by hand.
+
+Coverage is uneven and worth knowing before you trust a green run: `page/` ~10%,
+`renderer/` ~14%, `confluence/` ~19%, and `stdlib/`, `vfs/`, `cmd/mark/` at 0%. There is
+no fake Confluence server, so nothing that touches the REST API is covered. If you change
+`page/ancestry.go` or `confluence/api.go`, the test suite will very likely still pass.
+
+## Conventions
+
+- Conventional-commit subjects: `feat(scope):`, `fix(scope):`, `refactor(scope):`,
+  `build(deps):`. The release changelog excludes `docs:` and `test:`.
+- Errors wrap with `%w` and read bottom-up: `fmt.Errorf("unable to compile markdown: %w", err)`.
+- Logging is `zerolog` via the package-level `log`; user-facing results go to
+  `config.output()`, never directly to `os.Stdout`.
+- Suppress a linter only with a reason attached: `//nolint:gosec // G401: ...`.
+  The two existing suppressions (SHA-1 as a content fingerprint, opt-in TLS skip) are
+  the model.

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -266,7 +266,10 @@ func NewAPI(baseURL string, username string, password string, insecureSkipVerify
 		httpClient = &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
+					// Reached only when the user opts in with
+					// --insecure-skip-tls-verify, for self-signed Confluence
+					// Server instances.
+					InsecureSkipVerify: true, //nolint:gosec // G402: explicitly requested by the operator
 				},
 			},
 		}

--- a/mark.go
+++ b/mark.go
@@ -2,7 +2,11 @@ package mark
 
 import (
 	"bytes"
-	"crypto/sha1"
+	// SHA-1 is used only as a content fingerprint for --changes-only, never as
+	// a security primitive. The digest is embedded in the page version message
+	// and matched back with a 40-hex-character regex, so widening it would stop
+	// mark from recognising pages published by earlier versions.
+	"crypto/sha1" //nolint:gosec // G505: non-cryptographic content fingerprint
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -161,8 +165,6 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 	if err != nil {
 		return nil, fmt.Errorf("unable to extract metadata from file %q: %w", file, err)
 	}
-
-
 
 	if config.PageID != "" && meta != nil {
 		log.Warn().Msg(
@@ -543,7 +545,7 @@ func getImageAlign(align string, meta *metadata.Meta) (string, error) {
 }
 
 func sha1Hash(input string) string {
-	h := sha1.New()
+	h := sha1.New() //nolint:gosec // G401: see the crypto/sha1 import comment
 	h.Write([]byte(input))
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -312,7 +312,6 @@ Image-Align: center
 	assert.Equal(t, "# Content\n", string(body))
 }
 
-
 func TestExtractMetaYAMLFrontMatterWithoutTrailingNewline(t *testing.T) {
 	markdown := "---\nspace: DOCS\ntitle: Test Page\n---"
 

--- a/page/link.go
+++ b/page/link.go
@@ -95,7 +95,10 @@ func resolveLink(
 		log.Trace().Msgf("filepath: %s", filepath)
 		stat, err := os.Stat(filepath)
 		if err != nil {
-			return "", nil
+			// Not a link to a file on disk (or unreadable): leave the link
+			// untouched rather than failing the run. Swallowing err is
+			// deliberate here.
+			return "", nil //nolint:nilerr
 		}
 
 		if stat.IsDir() {

--- a/renderer/fencedcodeblock.go
+++ b/renderer/fencedcodeblock.go
@@ -142,7 +142,7 @@ func (r *ConfluenceFencedCodeBlockRenderer) renderFencedCodeBlock(writer util.Bu
 		attachment, err := d2.ProcessD2(title, lval, r.MarkConfig.D2Scale)
 		if err != nil {
 			line, col := GetLineCol(source, node.Pos())
-			return ast.WalkStop, fmt.Errorf("line %d, col %d: d2 rendering failed: %v", line, col, err)
+			return ast.WalkStop, fmt.Errorf("line %d, col %d: d2 rendering failed: %w", line, col, err)
 		}
 		r.Attachments.Attach(attachment)
 
@@ -191,7 +191,7 @@ func (r *ConfluenceFencedCodeBlockRenderer) renderFencedCodeBlock(writer util.Bu
 		attachment, err := mermaid.ProcessMermaidLocally(title, lval, r.MarkConfig.MermaidScale)
 		if err != nil {
 			line, col := GetLineCol(source, node.Pos())
-			return ast.WalkStop, fmt.Errorf("line %d, col %d: mermaid rendering failed: %v", line, col, err)
+			return ast.WalkStop, fmt.Errorf("line %d, col %d: mermaid rendering failed: %w", line, col, err)
 		}
 		r.Attachments.Attach(attachment)
 

--- a/renderer/text.go
+++ b/renderer/text.go
@@ -12,12 +12,15 @@ import (
 
 type ConfluenceTextRenderer struct {
 	html.Config
-	softBreak rune
+	// softBreak is written verbatim with WriteByte and is only ever '\n' or
+	// ' ', so it is a byte rather than a rune -- a rune would imply multi-byte
+	// values that the write path cannot represent.
+	softBreak byte
 }
 
 // NewConfluenceTextRenderer creates a new instance of the renderer with GitHub Alerts support
 func NewConfluenceTextRenderer(stripNewlines bool, opts ...html.Option) renderer.NodeRenderer {
-	sb := '\n'
+	sb := byte('\n')
 	if stripNewlines {
 		sb = ' '
 	}
@@ -88,12 +91,12 @@ func (r *ConfluenceTextRenderer) renderText(w util.BufWriter, source []byte, nod
 						}
 
 						if writeLineBreak {
-							_ = w.WriteByte(byte(r.softBreak))
+							_ = w.WriteByte(r.softBreak)
 						}
 					}
 				}
 			} else {
-				_ = w.WriteByte(byte(r.softBreak))
+				_ = w.WriteByte(r.softBreak)
 			}
 		}
 	}

--- a/renderer/text_legacy.go
+++ b/renderer/text_legacy.go
@@ -19,12 +19,15 @@ import (
 // See also https://sembr.org/ for partial motivation.
 type ConfluenceTextLegacyRenderer struct {
 	html.Config
-	softBreak rune
+	// softBreak is written verbatim with WriteByte and is only ever '\n' or
+	// ' ', so it is a byte rather than a rune -- a rune would imply multi-byte
+	// values that the write path cannot represent.
+	softBreak byte
 }
 
 // NewConfluenceTextLegacyRenderer creates a new instance of the ConfluenceTextRenderer (legacy version)
 func NewConfluenceTextLegacyRenderer(stripNL bool, opts ...html.Option) renderer.NodeRenderer {
-	sb := '\n'
+	sb := byte('\n')
 	if stripNL {
 		sb = ' '
 	}
@@ -77,12 +80,12 @@ func (r *ConfluenceTextLegacyRenderer) renderText(w util.BufWriter, source []byt
 						}
 
 						if writeLineBreak {
-							_ = w.WriteByte(byte(r.softBreak))
+							_ = w.WriteByte(r.softBreak)
 						}
 					}
 				}
 			} else {
-				_ = w.WriteByte(byte(r.softBreak))
+				_ = w.WriteByte(r.softBreak)
 			}
 		}
 	}


### PR DESCRIPTION
Three independent repository-hygiene changes, one commit each so they can be reviewed (or dropped) separately.

### 1. `ci:` least-privilege `GITHUB_TOKEN` permissions

Neither workflow declared a `permissions:` block, so every job ran with the repository-default token scope — including the ones holding Docker Hub and release credentials. Both workflows now default to `contents: read`, with `contents: write` granted only to the `goreleaser` job that publishes the release. The Docker Hub push uses its own secrets and is unaffected.

### 2. `build:` a `.golangci.yml`

`golangci-lint-action` was running with defaults only (errcheck, govet, ineffassign, staticcheck, unused). That set is kept as the base — enabling this config cannot silently drop a check — and these are added: `bodyclose`, `copyloopvar`, `errorlint`, `gosec`, `misspell`, `nilerr`, `unconvert`, `usestdlibvars`, `wastedassign`, plus `gofmt`.

`misspell` deliberately runs without a locale: the Confluence storage format spells the status macro parameter `ac:name="colour"`, so US-spelling enforcement would flag correct markup in the stdlib templates.

Enabling it surfaced 14 findings, all fixed in the same commit:

| finding | resolution |
| --- | --- |
| gofmt (2) | stray blank lines in `mark.go`, `metadata_test.go` |
| errorlint (2) | `%v` → `%w` in the fenced-code-block renderer, so d2/mermaid failures are matchable with `errors.Is` |
| gosec G115 (3) | `softBreak` is only ever `'\n'` or `' '`, so it is now a `byte` — the three `rune`→`byte` conversions are gone rather than suppressed |
| gosec G401/G505/G402, nilerr (5) | suppressed with reasons (see below) |

The four suppressions are all pre-existing intentional behaviour, now documented in place:

- **SHA-1** (`mark.go`) is a content fingerprint for `--changes-only`, not a security primitive. Its digest length is baked into the `\[v([a-f0-9]{40})]$` version-message regex, so widening it would stop mark recognising pages published by earlier versions.
- **`InsecureSkipVerify`** (`confluence/api.go`) is reached only via `--insecure-skip-tls-verify`.
- **`nilerr`** (`page/link.go`) — the `os.Stat` error is deliberately swallowed so a link that is not a file on disk is left untouched rather than failing the run.

### 3. `docs:` `AGENTS.md`

Guidance for AI agents and new contributors. Build/test/lint commands and the package layout are the easy half; the useful half is the **Invariants** section, which writes down rules that the recent commit history shows keep getting rediscovered the hard way — output is XML and malformed output rejects the *whole* page, escaping goes through the stdlib template funcs, macros/includes expand before goldmark parses, goldmark priorities run in opposite directions for parsers vs renderers, AST transformers cannot return errors so failures must be recorded on the pipeline, and several caches assume the strictly sequential file loop.

It also states current per-package coverage plainly, so a green test run is not mistaken for coverage of the REST API paths.

### Verification

`golangci-lint run ./...` → `0 issues`. `go test ./... -count=1` → all packages pass. `markdownlint-cli2` → clean.

No behaviour changes beyond the `%v` → `%w` wrapping and the `softBreak` type narrowing, both of which are covered by the existing golden-file tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)