### PR TITLE
fix(d2,mermaid): always disable the Chrome sandbox

### DIFF
--- a/chrome/chrome.go
+++ b/chrome/chrome.go
@@ -1,0 +1,29 @@
+// Package chrome centralises the headless Chrome configuration shared by the
+// diagram renderers. Both the d2 and mermaid renderers drive Chrome through
+// chromedp, and they previously configured their allocators independently,
+// which let the two launch paths drift apart.
+package chrome
+
+import "github.com/chromedp/chromedp"
+
+// AllocatorOptions returns the options mark appends to
+// chromedp.DefaultExecAllocatorOptions.
+//
+// Only genuinely additive options belong here. The chromedp defaults already
+// set headless, no-first-run, no-default-browser-check and
+// disable-dev-shm-usage, so repeating them would be noise.
+//
+// The Chrome sandbox is disabled unconditionally. Chrome refuses to start with
+// "No usable sandbox!" wherever unprivileged user namespaces are unavailable --
+// restricted containers, Kubernetes pods with a hardened seccomp profile, and
+// Ubuntu 23.10+ with its AppArmor userns restrictions -- and mark has no
+// reliable way to detect that before launching the browser. Note that chromedp
+// already passes --no-sandbox on its own when running as root (uid 0), so this
+// only changes behaviour for non-root runs.
+func AllocatorOptions() []chromedp.ExecAllocatorOption {
+	return []chromedp.ExecAllocatorOption{
+		chromedp.DisableGPU,
+		chromedp.NoSandbox,
+		chromedp.Flag("disable-setuid-sandbox", true),
+	}
+}

--- a/d2/d2.go
+++ b/d2/d2.go
@@ -7,7 +7,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"github.com/chromedp/chromedp"
 
 	"github.com/kovetskiy/mark/v16/attachment"
+	"github.com/kovetskiy/mark/v16/chrome"
 	"github.com/rs/zerolog/log"
 
 	"oss.terrastruct.com/d2/d2graph"
@@ -112,18 +112,7 @@ func getChromeCtx(ctx context.Context) (context.Context, error) {
 		return chromeCtx, nil
 	}
 
-	opts := chromedp.DefaultExecAllocatorOptions[:]
-	if os.Getenv("GITHUB_ACTIONS") == "true" {
-		opts = append(opts,
-			chromedp.DisableGPU,
-			chromedp.NoSandbox,
-			chromedp.NoFirstRun,
-			chromedp.NoDefaultBrowserCheck,
-			chromedp.Headless,
-			chromedp.Flag("disable-dev-shm-usage", true),
-			chromedp.Flag("disable-setuid-sandbox", true),
-		)
-	}
+	opts := append(chromedp.DefaultExecAllocatorOptions[:], chrome.AllocatorOptions()...)
 
 	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), opts...)
 	cCtx, cCancel := chromedp.NewContext(allocCtx)

--- a/mermaid/mermaid.go
+++ b/mermaid/mermaid.go
@@ -12,6 +12,7 @@ import (
 
 	mermaid "github.com/dreampuf/mermaid.go"
 	"github.com/kovetskiy/mark/v16/attachment"
+	"github.com/kovetskiy/mark/v16/chrome"
 	"github.com/rs/zerolog/log"
 )
 
@@ -29,7 +30,11 @@ func getMermaidEngine() (*mermaid.RenderEngine, error) {
 	}
 
 	log.Debug().Msg("Setting up global Mermaid renderer")
-	engine, err := mermaid.NewRenderEngine(context.Background(), nil)
+	// NewRenderEngine prepends chromedp.DefaultExecAllocatorOptions itself, so
+	// only the additional options are passed here. Without them Chrome fails to
+	// start wherever the sandbox is unavailable -- the same failure the d2
+	// renderer hits, since both drive Chrome through chromedp.
+	engine, err := mermaid.NewRenderEngine(context.Background(), nil, chrome.AllocatorOptions()...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes the `No usable sandbox!` startup failure for both diagram renderers. Likely resolves #348.

### The problem

Chrome refuses to start with `No usable sandbox!` wherever unprivileged user namespaces are unavailable — restricted containers, Kubernetes pods with a hardened seccomp profile, and Ubuntu 23.10+ with its AppArmor userns restrictions.

- **mermaid** passed no allocator options at all: `NewRenderEngine(context.Background(), nil)`.
- **d2** passed them only when `os.Getenv("GITHUB_ACTIONS") == "true"` — an environment variable that says nothing about whether the sandbox actually works.

So outside GitHub Actions, *both* renderers failed identically. The d2 protection was effectively dead code everywhere else.

Worth noting for reviewers: this was **not** broken in the official Docker image. chromedp already passes `--no-sandbox` on its own when running as root (`allocate.go:159`), and the image runs as root. The failure is specific to non-root execution.

### Reproduction

Against the runtime image, non-root, using a document with one `mermaid` (or `d2`) block:

```shell
docker run --rm -u 1000 -e HOME=/tmp -v "$PWD":/docs \
  --entrypoint /docs/mark chromedp/headless-shell:latest \
  --compile-only -f /docs/diagram.md
```

| case | before | after |
| --- | --- | --- |
| mermaid, non-root | `No usable sandbox!` | renders |
| d2, non-root, no `GITHUB_ACTIONS` | `No usable sandbox!` | renders |
| d2, non-root, `GITHUB_ACTIONS=true` | renders | renders |
| mermaid, root | renders | renders |

The emitted attachment checksums are byte-identical before and after, so only the launch path changed, not the output.

### The change

Both launch paths now share `chrome.AllocatorOptions()` so they cannot drift apart again:

```go
func AllocatorOptions() []chromedp.ExecAllocatorOption {
	return []chromedp.ExecAllocatorOption{
		chromedp.DisableGPU,
		chromedp.NoSandbox,
		chromedp.Flag("disable-setuid-sandbox", true),
	}
}
```

This also drops four flags from the old d2 block that `chromedp.DefaultExecAllocatorOptions` already sets — `headless`, `no-first-run`, `no-default-browser-check`, and `disable-dev-shm-usage` (the last of which was added by 1c6ea6a but was already a chromedp default). Only genuinely additive options remain.

Note that mermaid and d2 need the options supplied differently: `mermaid.NewRenderEngine` prepends `DefaultExecAllocatorOptions` internally, whereas `chromedp.NewExecAllocator` uses exactly what it is given. The helper therefore returns only the delta.

### Trade-off

This disables the Chrome sandbox unconditionally, including on ordinary non-root runs where it currently functions. The alternative considered was starting with the sandbox and retrying with `NoSandbox` only after a sandbox-specific startup failure, which would preserve it where it works. Unconditional was chosen for predictability — happy to switch to the retry approach if reviewers prefer it.

### Verification

`go build ./...`, `go vet ./...`, `go test ./... -count=1` (all pass), `golangci-lint run ./...` (0 issues), plus the container matrix above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)