### PR TITLE
perf(mark): build the stdlib once per run, not once per file

### DIFF
--- a/mark.go
+++ b/mark.go
@@ -107,11 +107,20 @@ func Run(config Config) error {
 		}
 	}
 
+	// The standard library is a fixed set of templates that does not depend on
+	// the file being processed, so it is built once for the whole run rather
+	// than once per file. Building it cannot reach the network -- the "user"
+	// template func captures the API but is only invoked during rendering.
+	std, err := stdlib.New(api)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve standard library: %w", err)
+	}
+
 	var hasErrors bool
 	for _, file := range files {
 		log.Info().Msgf("processing %s", file)
 
-		target, err := ProcessFile(file, api, config)
+		target, err := processFile(file, api, config, std)
 		if err != nil {
 			if config.ContinueOnError {
 				log.Error().Err(err).Msgf("processing %s", file)
@@ -138,7 +147,19 @@ func Run(config Config) error {
 
 // ProcessFile processes a single markdown file and publishes it to Confluence.
 // Returns nil for the page info when compile-only or dry-run mode is active.
+//
+// Callers processing several files should prefer Run, which builds the standard
+// library once instead of once per file.
 func ProcessFile(file string, api *confluence.API, config Config) (*confluence.PageInfo, error) {
+	std, err := stdlib.New(api)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve standard library: %w", err)
+	}
+
+	return processFile(file, api, config, std)
+}
+
+func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib) (*confluence.PageInfo, error) {
 	markdown, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read file %q: %w", file, err)
@@ -191,11 +212,6 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 					"or the --title-from-h1 / --title-from-filename flags",
 			)
 		}
-	}
-
-	std, err := stdlib.New(api)
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve standard library: %w", err)
 	}
 
 	links, err := page.ResolveRelativeLinks(

--- a/mark_test.go
+++ b/mark_test.go
@@ -1,9 +1,14 @@
 package mark
 
 import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -365,4 +370,48 @@ func TestMergeComments_CDATASelection(t *testing.T) {
 	assert.NoError(t, err)
 	// The raw selection "<nil>" should be found and wrapped with a marker.
 	assert.Equal(t, `<ac:structured-macro ac:name="code"><ac:plain-text-body><![CDATA[func foo() { return <ac:inline-comment-marker ac:ref="uuid-cdata"><nil></ac:inline-comment-marker> }]]></ac:plain-text-body></ac:structured-macro>`, result)
+}
+
+// BenchmarkRunCompileOnly exercises the whole per-file loop in compile-only
+// mode, which never reaches the network, so it measures the fixed per-file
+// overhead that Run pays regardless of Confluence latency.
+func BenchmarkRunCompileOnly(b *testing.B) {
+	// Other tests in this package raise the global level; log formatting would
+	// otherwise dominate the measurement.
+	previousLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	b.Cleanup(func() { zerolog.SetGlobalLevel(previousLevel) })
+
+	for _, fileCount := range []int{1, 50} {
+		b.Run(fmt.Sprintf("files=%d", fileCount), func(b *testing.B) {
+			dir := b.TempDir()
+			for i := range fileCount {
+				body := fmt.Sprintf(
+					"<!-- Space: TEST -->\n<!-- Title: Page %d -->\n\n"+
+						"# Page %d\n\nSome **text** with a [link](https://example.com).\n\n"+
+						"| a | b |\n| --- | --- |\n| 1 | 2 |\n\n```go\nfunc main() {}\n```\n",
+					i, i,
+				)
+				path := filepath.Join(dir, fmt.Sprintf("page-%03d.md", i))
+				if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			config := Config{
+				BaseURL:     "http://127.0.0.1:1",
+				Files:       filepath.Join(dir, "*.md"),
+				CompileOnly: true,
+				Features:    []string{"mention"},
+				Output:      io.Discard,
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := Run(config); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 }

--- a/stdlib/stdlib_test.go
+++ b/stdlib/stdlib_test.go
@@ -1,0 +1,81 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewParsesAllTemplates guards against a template in templates() failing to
+// parse, which New reports as an error rather than a panic and which no other
+// test in the repository would catch.
+func TestNewParsesAllTemplates(t *testing.T) {
+	lib, err := New(nil)
+	require.NoError(t, err)
+	require.NotNil(t, lib)
+	require.NotNil(t, lib.Templates)
+
+	// A representative sample across the macro families; if templates() is
+	// rewritten these must all still be defined.
+	for _, name := range []string{
+		"ac:layout",
+		"ac:code",
+		"ac:status",
+		"ac:link:user",
+		"ac:image",
+		"ac:toc",
+		"ac:children",
+		"ac:emoticon",
+	} {
+		assert.NotNil(t, lib.Templates.Lookup(name), "template %q is not defined", name)
+	}
+}
+
+// TestTemplatesEscapeInterpolatedValues covers the escaping helpers that the
+// storage-format output depends on: a quote in a code block title must not be
+// able to close the ac:parameter attribute, and a CDATA end marker in the body
+// must be split across two sections.
+func TestTemplatesEscapeInterpolatedValues(t *testing.T) {
+	lib, err := New(nil)
+	require.NoError(t, err)
+
+	var out strings.Builder
+	err = lib.Templates.ExecuteTemplate(&out, "ac:code", struct {
+		Language    string
+		Collapse    bool
+		Theme       string
+		Linenumbers bool
+		Firstline   int
+		Title       string
+		Text        string
+	}{
+		Language: "go",
+		Title:    `a "quoted" <title> & more`,
+		Text:     "before ]]> after",
+	})
+	require.NoError(t, err)
+
+	rendered := out.String()
+	assert.NotContains(t, rendered, `"quoted"`, "title quotes must be escaped")
+	assert.Contains(t, rendered, "&#34;quoted&#34;")
+	assert.Contains(t, rendered, "&lt;title&gt;")
+	assert.NotContains(
+		t,
+		rendered,
+		"before ]]> after",
+		"a raw ]]> would terminate the CDATA section early",
+	)
+}
+
+// BenchmarkNew measures the cost of building the standard library. mark calls
+// New once per processed file, so this is the per-file floor for template
+// parsing.
+func BenchmarkNew(b *testing.B) {
+	for b.Loop() {
+		if _, err := New(nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
`stdlib.New` parses a fixed set of ~30 templates that does not depend on the file being processed, but `ProcessFile` called it for every file. `Run` now builds it once and passes it down.

### Measurements

Added `BenchmarkRunCompileOnly`, which drives the whole per-file loop in compile-only mode so it never touches the network:

| | ns/op | B/op | allocs/op |
| --- | --- | --- | --- |
| `files=50` before | 27,400,000 | 13,600,000 | 177,827 |
| `files=50` after | 7,440,000 | 4,190,000 | 41,338 |
| `files=1` before | 571,984 | 275,018 | 3,594 |
| `files=1` after | 576,071 | 275,462 | 3,595 |

**3.7x on the compile path** and ~2,730 fewer allocations per file. `files=1` is unchanged, which is the expected control — with a single file you build the stdlib once either way.

Isolating the cost, `BenchmarkNew` (also added) puts `stdlib.New` at ~370 µs and 2,784 allocations per call, i.e. roughly 72% of the per-file CPU on the compile path.

Worth setting expectations: a real publish run is dominated by Confluence round-trips, so ~400 µs/file is invisible there. The end-to-end win applies mainly to `--compile-only` (CI validation) and to large trees.

### Compatibility

The exported `ProcessFile` keeps its signature and still builds its own stdlib, so library callers are unaffected. `Run` uses an unexported `processFile` that takes the shared `*stdlib.Lib`.

**One behaviour change worth a reviewer's eye:** a stdlib construction failure now aborts before the first file rather than failing per file, so `--continue-on-error` no longer skips past it. Since `templates()` parses only static template literals, this can only fail on a malformed literal — a build-time bug, not a per-file condition — so failing fast seemed clearly better. Easy to restore the old behaviour if you disagree.

### Tests

Also adds the first tests for the `stdlib` package, which had none (0% coverage): template parsing, and the `ac:code` escaping invariants — that a quote in a title cannot close the `ac:parameter` attribute, and that a `]]>` in the body is split across two CDATA sections.

`go test ./...`, `go test -race ./...`, and `golangci-lint run ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)