### PR TITLE
fix(confluence): retry throttled and failed requests, bound timeouts

### DIFF
--- a/confluence/api.go
+++ b/confluence/api.go
@@ -2,7 +2,6 @@ package confluence
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -261,21 +260,13 @@ func NewAPI(baseURL string, username string, password string, insecureSkipVerify
 	// Normalize baseURL once before building all derived endpoints.
 	baseURL = strings.TrimSuffix(baseURL, "/")
 
-	var httpClient *http.Client
-	if insecureSkipVerify {
-		httpClient = &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					// Reached only when the user opts in with
-					// --insecure-skip-tls-verify, for self-signed Confluence
-					// Server instances.
-					InsecureSkipVerify: true, //nolint:gosec // G402: explicitly requested by the operator
-				},
-			},
-		}
-	}
+	httpClient := newHTTPClient(insecureSkipVerify)
 
-	rest := gopencils.Api(baseURL+"/rest/api", auth, httpClient, 3) // set option for 3 retries on failure
+	// gopencils is given 0 retries: its own retry loop only runs when the very
+	// first Client.Do returns a transport error, so a 429 or 503 -- which come
+	// back with a nil error -- was never retried at all. retryTransport in the
+	// client handles both cases, and is the single place retries happen.
+	rest := gopencils.Api(baseURL+"/rest/api", auth, httpClient, 0)
 	if username == "" {
 		if rest.Headers == nil {
 			rest.Headers = http.Header{}
@@ -283,7 +274,7 @@ func NewAPI(baseURL string, username string, password string, insecureSkipVerify
 		rest.SetHeader("Authorization", fmt.Sprintf("Bearer %s", password))
 	}
 
-	restV2 := gopencils.Api(baseURL+"/api/v2", auth, httpClient, 3) // v2 API for folders and new features
+	restV2 := gopencils.Api(baseURL+"/api/v2", auth, httpClient, 0) // v2 API for folders and new features
 	if username == "" {
 		if restV2.Headers == nil {
 			restV2.Headers = http.Header{}

--- a/confluence/api_server_test.go
+++ b/confluence/api_server_test.go
@@ -2,7 +2,9 @@ package confluence_test
 
 import (
 	"bytes"
+	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/kovetskiy/mark/v16/confluence"
@@ -357,4 +359,95 @@ func TestGetSpaceID(t *testing.T) {
 		"the v1 lookup is attempted")
 	assert.Equal(t, 1, server.CountRequests("GET", "/api/v2/spaces"),
 		"but its response cannot be decoded, so v2 is always used")
+}
+
+// TestRetriesThroughTheRealClientStack drives a retry end to end: real
+// confluence.API, real gopencils, real HTTP, with the fake returning 503 for
+// the first two GETs. Before the retry transport existed this returned an
+// error on the first 503, because gopencils only retried transport-level
+// failures and a 503 arrives with a nil error.
+func TestRetriesThroughTheRealClientStack(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddPage("DOCS", "Flaky", "page", "")
+
+	var seen int
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/content") {
+			return 0, "", false
+		}
+		seen++
+		if seen <= 2 {
+			return http.StatusServiceUnavailable, `{"message":"overloaded"}`, true
+		}
+		return 0, "", false
+	})
+
+	page, err := api.FindPage("DOCS", "Flaky", "page")
+	require.NoError(t, err, "two 503s should be retried, not surfaced")
+	require.NotNil(t, page)
+	assert.Equal(t, "Flaky", page.Title)
+	assert.Equal(t, 3, server.CountRequests("GET", "/rest/api/content"))
+}
+
+// TestRateLimitIsRetried covers the 429 path, which is what a throttled
+// Confluence Cloud tenant actually returns.
+func TestRateLimitIsRetried(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddPage("DOCS", "Throttled", "page", "")
+
+	var seen int
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/content") {
+			return 0, "", false
+		}
+		seen++
+		if seen == 1 {
+			return http.StatusTooManyRequests, `{"message":"rate limited"}`, true
+		}
+		return 0, "", false
+	})
+
+	page, err := api.FindPage("DOCS", "Throttled", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+	assert.Equal(t, 2, server.CountRequests("GET", "/rest/api/content"))
+}
+
+// TestPersistent5xxStillFails confirms retries are bounded and the eventual
+// error still reaches the caller.
+func TestPersistent5xxStillFails(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddPage("DOCS", "Broken", "page", "")
+
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/content") {
+			return http.StatusServiceUnavailable, `{"message":"down"}`, true
+		}
+		return 0, "", false
+	})
+
+	_, err := api.FindPage("DOCS", "Broken", "page")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "503")
+	assert.Equal(t, 4, server.CountRequests("GET", "/rest/api/content"),
+		"bounded at maxAttempts")
+}
+
+// TestCreatePageIsNotRetriedOn5xx is the safety property: replaying a failed
+// create could leave two pages behind.
+func TestCreatePageIsNotRetriedOn5xx(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddSpace("DOCS")
+
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if r.Method == http.MethodPost {
+			return http.StatusServiceUnavailable, `{"message":"down"}`, true
+		}
+		return 0, "", false
+	})
+
+	_, err := api.CreatePage("DOCS", "page", nil, "Once Only", "")
+	require.Error(t, err)
+	assert.Equal(t, 1, server.CountRequests("POST", "/rest/api/content"),
+		"a create must be attempted exactly once")
 }

--- a/confluence/transport.go
+++ b/confluence/transport.go
@@ -1,0 +1,259 @@
+package confluence
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"strconv"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// maxAttempts bounds the total number of tries for a single request,
+	// including the first.
+	maxAttempts = 4
+
+	// maxBackoff caps a single wait, so a large Retry-After from a throttled
+	// Confluence Cloud tenant cannot stall a run indefinitely.
+	maxBackoff = 30 * time.Second
+
+	// baseBackoff is the first delay; subsequent delays double it.
+	baseBackoff = time.Second
+
+	// dialTimeout, tlsHandshakeTimeout and responseHeaderTimeout bound the
+	// phases of a request that can otherwise hang forever. Deliberately no
+	// http.Client.Timeout: that caps the whole exchange including the request
+	// body, which would break large attachment uploads on slow links.
+	// responseHeaderTimeout is the one that matters for a server that accepts
+	// the connection and then goes quiet.
+	dialTimeout           = 30 * time.Second
+	tlsHandshakeTimeout   = 15 * time.Second
+	responseHeaderTimeout = 2 * time.Minute
+	idleConnTimeout       = 90 * time.Second
+)
+
+// newHTTPClient builds the client used for every Confluence call.
+//
+// A cookie jar is always installed. Confluence Server hands out a session
+// cookie on the first authenticated call and expects it back; previously the
+// jar was only present in the default case, because gopencils creates one only
+// when it is not given a client, so --insecure-skip-tls-verify silently
+// dropped session affinity.
+func newHTTPClient(insecureSkipVerify bool) *http.Client {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   dialTimeout,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       idleConnTimeout,
+		TLSHandshakeTimeout:   tlsHandshakeTimeout,
+		ResponseHeaderTimeout: responseHeaderTimeout,
+		ExpectContinueTimeout: time.Second,
+	}
+
+	if insecureSkipVerify {
+		transport.TLSClientConfig = &tls.Config{
+			// Reached only when the user opts in with
+			// --insecure-skip-tls-verify, for self-signed Confluence Server
+			// instances.
+			InsecureSkipVerify: true, //nolint:gosec // G402: explicitly requested by the operator
+		}
+	}
+
+	// cookiejar.New never returns an error for a nil options value, but a jar
+	// is not worth failing construction over if that ever changes.
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		log.Warn().Err(err).Msg("unable to create cookie jar; session cookies will not be retained")
+	}
+
+	return &http.Client{
+		Jar:       jar,
+		Transport: &retryTransport{base: transport, sleep: time.Sleep},
+	}
+}
+
+// retryTransport retries requests that Confluence rejected without acting on
+// them. It sits below gopencils, which is configured not to retry, so this is
+// the only place retries happen.
+type retryTransport struct {
+	base  http.RoundTripper
+	sleep func(time.Duration)
+}
+
+// retryableStatus reports whether a response status is worth retrying for the
+// given method.
+//
+// 429 is retried for every method: Confluence rejects a throttled request
+// before acting on it, so replaying it cannot duplicate work.
+//
+// 5xx is retried only for methods without side effects. A 5xx on POST is
+// ambiguous -- the page may well have been created before the error -- and
+// retrying it risks duplicate pages or attachments. A 5xx on PUT is equally
+// ambiguous and would surface as a confusing 409 version conflict on the
+// replay, so it is left alone too.
+func retryableStatus(status int, method string) bool {
+	if status == http.StatusTooManyRequests {
+		return true
+	}
+	if status < 500 || status > 599 {
+		return false
+	}
+	// 501 is a permanent "not implemented"; replaying it never helps.
+	if status == http.StatusNotImplemented {
+		return false
+	}
+	return method == http.MethodGet || method == http.MethodHead
+}
+
+// retryableError reports whether a transport-level failure is worth retrying.
+// Only side-effect-free methods qualify: a timeout partway through a POST may
+// mean the server already committed the write.
+func retryableError(err error, method string) bool {
+	if err == nil {
+		return false
+	}
+	if method != http.MethodGet && method != http.MethodHead {
+		return false
+	}
+	// A request cancelled by the caller's context must not be retried.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	return true
+}
+
+// parseRetryAfter interprets the Retry-After header, which Confluence Cloud
+// sends with 429s either as a number of seconds or as an HTTP date.
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	if value == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds < 0 {
+			return 0, false
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+	if when, err := http.ParseTime(value); err == nil {
+		if d := when.Sub(now); d > 0 {
+			return d, true
+		}
+		return 0, true
+	}
+	return 0, false
+}
+
+// backoffFor returns the wait before the given attempt (1-based), preferring a
+// server-supplied Retry-After and otherwise using exponential backoff with
+// jitter to avoid synchronising retries across a batch of files.
+func backoffFor(attempt int, retryAfter string, now time.Time) time.Duration {
+	if d, ok := parseRetryAfter(retryAfter, now); ok {
+		return min(d, maxBackoff)
+	}
+
+	backoff := baseBackoff << (attempt - 1)
+	if backoff > maxBackoff {
+		backoff = maxBackoff
+	}
+	// Full jitter over [backoff/2, backoff). Retry spacing is a scheduling
+	// concern, not a security one, so a cheap PRNG is the right tool.
+	half := backoff / 2
+	return half + time.Duration(rand.Int64N(int64(half)+1)) //nolint:gosec // G404: jitter, not a secret
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// A request whose body cannot be rewound must not be replayed. net/http
+	// populates GetBody for the in-memory body types gopencils uses.
+	canReplay := req.Body == nil || req.GetBody != nil
+
+	var lastResp *http.Response
+	var lastErr error
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if attempt > 1 {
+			body, err := rewind(req)
+			if err != nil {
+				return nil, err
+			}
+			req = body
+		}
+
+		resp, err := t.base.RoundTrip(req)
+
+		switch {
+		case err != nil:
+			lastResp, lastErr = nil, err
+			if !canReplay || !retryableError(err, req.Method) || attempt == maxAttempts {
+				return nil, err
+			}
+		case retryableStatus(resp.StatusCode, req.Method):
+			lastResp, lastErr = resp, nil
+			if !canReplay || attempt == maxAttempts {
+				return resp, nil
+			}
+		default:
+			return resp, nil
+		}
+
+		var retryAfter string
+		if lastResp != nil {
+			retryAfter = lastResp.Header.Get("Retry-After")
+			// The body must be drained and closed or the connection leaks.
+			drain(lastResp)
+		}
+
+		wait := backoffFor(attempt, retryAfter, time.Now())
+
+		event := log.Warn().
+			Str("method", req.Method).
+			Str("url", req.URL.Redacted()).
+			Int("attempt", attempt).
+			Dur("retry_in", wait)
+		if lastErr != nil {
+			event = event.Err(lastErr)
+		} else {
+			event = event.Int("status", lastResp.StatusCode)
+		}
+		event.Msg("Confluence request failed, retrying")
+
+		t.sleep(wait)
+	}
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return lastResp, nil
+}
+
+// rewind returns a copy of req with a fresh body for a retry.
+func rewind(req *http.Request) (*http.Request, error) {
+	if req.Body == nil || req.GetBody == nil {
+		return req, nil
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, err
+	}
+	clone := req.Clone(req.Context())
+	clone.Body = body
+	return clone, nil
+}
+
+func drain(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	_ = resp.Body.Close()
+}

--- a/confluence/transport_test.go
+++ b/confluence/transport_test.go
@@ -1,0 +1,363 @@
+package confluence
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryableStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		method string
+		want   bool
+	}{
+		{"429 on GET", http.StatusTooManyRequests, http.MethodGet, true},
+		// The case that mattered: a throttled write is rejected before
+		// Confluence acts on it, so replaying cannot duplicate a page.
+		{"429 on POST", http.StatusTooManyRequests, http.MethodPost, true},
+		{"429 on PUT", http.StatusTooManyRequests, http.MethodPut, true},
+
+		{"503 on GET", http.StatusServiceUnavailable, http.MethodGet, true},
+		{"500 on GET", http.StatusInternalServerError, http.MethodGet, true},
+		{"502 on HEAD", http.StatusBadGateway, http.MethodHead, true},
+
+		// A 5xx on a write is ambiguous: the page may already exist.
+		{"503 on POST", http.StatusServiceUnavailable, http.MethodPost, false},
+		{"500 on PUT", http.StatusInternalServerError, http.MethodPut, false},
+		{"501 on GET", http.StatusNotImplemented, http.MethodGet, false},
+
+		{"200", http.StatusOK, http.MethodGet, false},
+		{"404", http.StatusNotFound, http.MethodGet, false},
+		{"401", http.StatusUnauthorized, http.MethodGet, false},
+		{"409", http.StatusConflict, http.MethodPut, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, retryableStatus(tt.status, tt.method))
+		})
+	}
+}
+
+func TestRetryableError(t *testing.T) {
+	someErr := errors.New("connection reset")
+
+	assert.True(t, retryableError(someErr, http.MethodGet))
+	assert.True(t, retryableError(someErr, http.MethodHead))
+	// A transport error partway through a write may still have been committed.
+	assert.False(t, retryableError(someErr, http.MethodPost))
+	assert.False(t, retryableError(someErr, http.MethodPut))
+	assert.False(t, retryableError(nil, http.MethodGet))
+}
+
+func TestParseRetryAfterSeconds(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+
+	d, ok := parseRetryAfter("30", now)
+	require.True(t, ok)
+	assert.Equal(t, 30*time.Second, d)
+
+	d, ok = parseRetryAfter("0", now)
+	require.True(t, ok)
+	assert.Equal(t, time.Duration(0), d)
+
+	_, ok = parseRetryAfter("", now)
+	assert.False(t, ok)
+
+	_, ok = parseRetryAfter("not-a-number", now)
+	assert.False(t, ok)
+
+	_, ok = parseRetryAfter("-5", now)
+	assert.False(t, ok, "a negative delay is malformed and should be ignored")
+}
+
+func TestParseRetryAfterHTTPDate(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+
+	d, ok := parseRetryAfter("Sat, 08 Aug 2026 12:00:45 GMT", now)
+	require.True(t, ok)
+	assert.Equal(t, 45*time.Second, d)
+
+	// A date already in the past means "retry now", not a negative wait.
+	d, ok = parseRetryAfter("Sat, 08 Aug 2026 11:59:00 GMT", now)
+	require.True(t, ok)
+	assert.Equal(t, time.Duration(0), d)
+}
+
+func TestBackoffForHonoursRetryAfter(t *testing.T) {
+	now := time.Now()
+	assert.Equal(t, 5*time.Second, backoffFor(1, "5", now))
+	// Even a server asking for a very long wait is capped.
+	assert.Equal(t, maxBackoff, backoffFor(1, "3600", now))
+}
+
+func TestBackoffForGrowsAndIsJittered(t *testing.T) {
+	now := time.Now()
+
+	// Without Retry-After the delay is exponential with jitter in
+	// [backoff/2, backoff]. Assert on the bounds rather than an exact value.
+	for attempt, want := range map[int]time.Duration{
+		1: baseBackoff,
+		2: 2 * baseBackoff,
+		3: 4 * baseBackoff,
+	} {
+		for range 50 {
+			got := backoffFor(attempt, "", now)
+			assert.GreaterOrEqual(t, got, want/2)
+			assert.LessOrEqual(t, got, want)
+		}
+	}
+
+	// Late attempts are capped.
+	assert.LessOrEqual(t, backoffFor(20, "", now), maxBackoff)
+}
+
+// roundTripperFunc adapts a function to http.RoundTripper.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// newTestTransport returns a retryTransport whose sleeps are recorded instead
+// of performed, so retry tests run instantly.
+func newTestTransport(t *testing.T, fn roundTripperFunc) (*retryTransport, *[]time.Duration) {
+	t.Helper()
+	var slept []time.Duration
+	return &retryTransport{
+		base:  fn,
+		sleep: func(d time.Duration) { slept = append(slept, d) },
+	}, &slept
+}
+
+func respond(status int, header http.Header) *http.Response {
+	if header == nil {
+		header = http.Header{}
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     header,
+		Body:       http.NoBody,
+	}
+}
+
+func TestRoundTripRetriesUntilSuccess(t *testing.T) {
+	var calls int
+	transport, slept := newTestTransport(t, func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls < 3 {
+			return respond(http.StatusServiceUnavailable, nil), nil
+		}
+		return respond(http.StatusOK, nil), nil
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.invalid/rest/api/content", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 3, calls)
+	assert.Len(t, *slept, 2, "two failures means two waits")
+}
+
+func TestRoundTripGivesUpAfterMaxAttempts(t *testing.T) {
+	var calls int
+	transport, _ := newTestTransport(t, func(*http.Request) (*http.Response, error) {
+		calls++
+		return respond(http.StatusServiceUnavailable, nil), nil
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.invalid/rest/api/content", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
+		"the final response is returned rather than swallowed")
+	assert.Equal(t, maxAttempts, calls)
+}
+
+func TestRoundTripDoesNotRetryPostOn5xx(t *testing.T) {
+	var calls int
+	transport, _ := newTestTransport(t, func(*http.Request) (*http.Response, error) {
+		calls++
+		return respond(http.StatusServiceUnavailable, nil), nil
+	})
+
+	req, err := http.NewRequest(http.MethodPost, "https://example.invalid/rest/api/content", http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, 1, calls, "a 5xx on POST must not be replayed")
+}
+
+func TestRoundTripRetriesPostOn429(t *testing.T) {
+	var calls int
+	transport, _ := newTestTransport(t, func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return respond(http.StatusTooManyRequests, http.Header{"Retry-After": []string{"0"}}), nil
+		}
+		return respond(http.StatusOK, nil), nil
+	})
+
+	// A *bytes.Buffer body is what gopencils sends, and it is what makes
+	// net/http populate GetBody so the request can be replayed.
+	req, err := http.NewRequest(
+		http.MethodPost,
+		"https://example.invalid/rest/api/content",
+		bytes.NewBufferString(`{"title":"x"}`),
+	)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, calls)
+}
+
+// TestRoundTripReplaysRequestBody proves the retried attempt carries the body
+// again rather than sending an empty one.
+func TestRoundTripReplaysRequestBody(t *testing.T) {
+	var bodies []string
+	var calls int
+	transport, _ := newTestTransport(t, func(r *http.Request) (*http.Response, error) {
+		calls++
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		bodies = append(bodies, string(b))
+		if calls == 1 {
+			return respond(http.StatusTooManyRequests, http.Header{"Retry-After": []string{"0"}}), nil
+		}
+		return respond(http.StatusOK, nil), nil
+	})
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		"https://example.invalid/rest/api/content",
+		bytes.NewBufferString(`{"title":"x"}`),
+	)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, []string{`{"title":"x"}`, `{"title":"x"}`}, bodies)
+}
+
+// TestRoundTripDoesNotReplayUnrewindableBody covers the safety valve: a body
+// that cannot be rewound is sent once and the response returned as-is, rather
+// than replayed with an empty body.
+func TestRoundTripDoesNotReplayUnrewindableBody(t *testing.T) {
+	var calls int
+	transport, _ := newTestTransport(t, func(*http.Request) (*http.Response, error) {
+		calls++
+		return respond(http.StatusTooManyRequests, nil), nil
+	})
+
+	req, err := http.NewRequest(
+		http.MethodPost,
+		"https://example.invalid/rest/api/content",
+		io.NopCloser(bytes.NewBufferString("stream")),
+	)
+	require.NoError(t, err)
+	require.Nil(t, req.GetBody, "an opaque reader gives net/http nothing to rewind")
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRoundTripUsesRetryAfterForWait(t *testing.T) {
+	var calls int
+	transport, slept := newTestTransport(t, func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return respond(http.StatusTooManyRequests, http.Header{"Retry-After": []string{"7"}}), nil
+		}
+		return respond(http.StatusOK, nil), nil
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.invalid/rest/api/content", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Len(t, *slept, 1)
+	assert.Equal(t, 7*time.Second, (*slept)[0], "the server's Retry-After wins over backoff")
+}
+
+func TestRoundTripRetriesTransportErrorOnGet(t *testing.T) {
+	var calls int
+	transport, _ := newTestTransport(t, func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls < 2 {
+			return nil, errors.New("connection refused")
+		}
+		return respond(http.StatusOK, nil), nil
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.invalid/rest/api/content", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, calls)
+}
+
+func TestRoundTripDoesNotRetryTransportErrorOnPost(t *testing.T) {
+	var calls int
+	transport, _ := newTestTransport(t, func(*http.Request) (*http.Response, error) {
+		calls++
+		return nil, errors.New("connection reset by peer")
+	})
+
+	req, err := http.NewRequest(http.MethodPost, "https://example.invalid/rest/api/content", http.NoBody)
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req) //nolint:bodyclose // the base always errors, so there is no response
+	require.Error(t, err)
+	assert.Equal(t, 1, calls,
+		"the write may already have been committed, so it must not be replayed")
+}
+
+// TestNewHTTPClientHasCookieJar guards the regression that made
+// --insecure-skip-tls-verify behave differently from the default: gopencils
+// only creates a jar when it is not handed a client.
+func TestNewHTTPClientHasCookieJar(t *testing.T) {
+	for _, insecure := range []bool{false, true} {
+		client := newHTTPClient(insecure)
+		assert.NotNil(t, client.Jar, "insecure=%v should still retain session cookies", insecure)
+	}
+}
+
+func TestNewHTTPClientSetsTimeouts(t *testing.T) {
+	client := newHTTPClient(false)
+
+	retry, ok := client.Transport.(*retryTransport)
+	require.True(t, ok)
+	transport, ok := retry.base.(*http.Transport)
+	require.True(t, ok)
+
+	assert.Equal(t, responseHeaderTimeout, transport.ResponseHeaderTimeout)
+	assert.Equal(t, tlsHandshakeTimeout, transport.TLSHandshakeTimeout)
+	assert.Zero(t, client.Timeout,
+		"a whole-exchange timeout would cut off large attachment uploads")
+}


### PR DESCRIPTION
Second of two Tier 1 PRs. **Stacked on #863** — it uses the `confluencetest` fake introduced there, so please merge that first (the diff here will shrink to just the transport once #863 lands).

### The bug

`NewAPI` passes `3` to gopencils with the comment *"3 retries on failure"*. But gopencils only enters its retry loop when the **first** `Client.Do` returns a transport error:

```go
resp, err := r.Api.Client.Do(req)
if err != nil {
    for i := 0; i < r.Api.RetryCount; i++ { ... }   // ← only reachable when err != nil
}
```

A 429 or 503 arrives with `err == nil`, skips the loop entirely, and surfaces as a hard failure. The `resp.StatusCode < 500` check *inside* the loop is unreachable for that case. So a single throttled response from Confluence Cloud aborts a whole run — a plausible cause of the intermittent failures in #651 and #623.

Separately, no timeout was set anywhere: a server that accepts the connection and then goes quiet hangs the process indefinitely.

### What is retried, and what deliberately is not

Retries now live in one place, a `RoundTripper` below gopencils, which is given `0` retries so nothing retries twice.

| | retried | rationale |
| --- | --- | --- |
| **429**, any method | yes | Confluence rejects a throttled request *before* acting on it, so replaying cannot duplicate work. `Retry-After` honoured in both seconds and HTTP-date form, capped at 30s. |
| **5xx** on GET/HEAD | yes | no side effects |
| **5xx** on POST | **no** | ambiguous — the page may have been created before the error. Replaying risks duplicate pages and attachments. |
| **5xx** on PUT | **no** | equally ambiguous, and the replay would surface as a confusing 409 version conflict |
| **transport errors** on GET/HEAD | yes | |
| **transport errors** on POST/PUT | **no** | see below |

That last row is **narrower than today's behaviour** and worth a reviewer's attention: gopencils currently replays *every* method blindly on a transport error, including page creation. I think trading a little resilience for not silently creating duplicate pages is right, but it is a behaviour change, not purely a fix.

Backoff is exponential with full jitter, bounded at 4 attempts. A request whose body cannot be rewound is never replayed.

### Timeouts

Set per phase rather than as one `http.Client.Timeout`, because a whole-exchange timeout also caps the request body and would break large attachment uploads on slow links:

- `ResponseHeaderTimeout` 2m — this is the one that ends the indefinite hang
- `TLSHandshakeTimeout` 15s, dial 30s, idle 90s

### Cookie jar

The client now always installs one. gopencils creates a jar only when it is *not* handed a client, so `--insecure-skip-tls-verify` previously dropped the session cookie Confluence Server issues — making auth behave differently between secure and insecure mode. Related to #775 and #679.

### Tests

Unit tests for the retry predicates, `Retry-After` parsing (seconds, HTTP-date, past dates, malformed), backoff bounds and body replay. Plus end-to-end tests through the real `confluence.API` → gopencils → HTTP stack using the fake's failure injection:

- two 503s then success now resolves a page instead of erroring
- a 429 is retried
- persistent 5xx still fails, after exactly 4 attempts
- a failing `CreatePage` is attempted **exactly once**

`confluence` coverage 56.7% → **61.6%**.

`go test ./...`, `go test -race ./...`, `golangci-lint run ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)