### PR TITLE
perf: cache user lookups and fetch attachments once per page

### DIFF
--- a/attachment/attachment.go
+++ b/attachment/attachment.go
@@ -43,11 +43,38 @@ type Attacher interface {
 	Attach(Attachment)
 }
 
+// ResolveAttachments uploads the given attachments to the page, skipping any
+// whose checksum already matches what is stored remotely.
+//
+// It fetches the page's current attachment list itself. Callers that resolve
+// attachments more than once for the same page -- as mark does, first for
+// declared attachments and then for diagrams discovered while rendering --
+// should use ResolveAttachmentsWithRemotes to avoid re-fetching a list they
+// already hold.
 func ResolveAttachments(
 	api *confluence.API,
 	page *confluence.PageInfo,
 	attachments []Attachment,
 ) ([]Attachment, error) {
+	remotes, err := api.GetAttachments(page.ID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get attachments for page %s: %w", page.ID, err)
+	}
+
+	resolved, _, err := ResolveAttachmentsWithRemotes(api, page, attachments, remotes)
+	return resolved, err
+}
+
+// ResolveAttachmentsWithRemotes is ResolveAttachments against an
+// already-fetched remote attachment list. It returns the resolved attachments
+// and an updated remote list that includes anything created or updated by this
+// call, so a subsequent call can be made without another round-trip.
+func ResolveAttachmentsWithRemotes(
+	api *confluence.API,
+	page *confluence.PageInfo,
+	attachments []Attachment,
+	remotes []confluence.AttachmentInfo,
+) ([]Attachment, []confluence.AttachmentInfo, error) {
 	for i := range attachments {
 		// Skip checksum computation if already set (e.g. by mermaid/d2 renderers
 		// which use the source content as the stable checksum rather than the
@@ -58,15 +85,10 @@ func ResolveAttachments(
 
 		checksum, err := GetChecksum(bytes.NewReader(attachments[i].FileBytes))
 		if err != nil {
-			return nil, fmt.Errorf("unable to get checksum for attachment %q: %w", attachments[i].Name, err)
+			return nil, nil, fmt.Errorf("unable to get checksum for attachment %q: %w", attachments[i].Name, err)
 		}
 
 		attachments[i].Checksum = checksum
-	}
-
-	remotes, err := api.GetAttachments(page.ID)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get attachments for page %s: %w", page.ID, err)
 	}
 
 	existing := []Attachment{}
@@ -115,7 +137,7 @@ func ResolveAttachments(
 			bytes.NewReader(attachment.FileBytes),
 		)
 		if err != nil {
-			return nil, fmt.Errorf("unable to create attachment %q: %w", attachment.Name, err)
+			return nil, nil, fmt.Errorf("unable to create attachment %q: %w", attachment.Name, err)
 		}
 
 		attachment.ID = info.ID
@@ -125,6 +147,7 @@ func ResolveAttachments(
 		)
 
 		creating[i] = attachment
+		remotes = append(remotes, info)
 	}
 
 	for i, attachment := range updating {
@@ -138,7 +161,7 @@ func ResolveAttachments(
 			bytes.NewReader(attachment.FileBytes),
 		)
 		if err != nil {
-			return nil, fmt.Errorf("unable to update attachment %q: %w", attachment.Name, err)
+			return nil, nil, fmt.Errorf("unable to update attachment %q: %w", attachment.Name, err)
 		}
 
 		attachment.Link = path.Join(
@@ -147,6 +170,15 @@ func ResolveAttachments(
 		)
 
 		updating[i] = attachment
+
+		// Reflect the new checksum so a later call against this same list sees
+		// the attachment as current rather than re-uploading it.
+		for j := range remotes {
+			if remotes[j].Filename == attachment.Filename {
+				remotes[j].Metadata.Comment = AttachmentChecksumPrefix + attachment.Checksum
+				break
+			}
+		}
 	}
 
 	for i := range existing {
@@ -158,7 +190,7 @@ func ResolveAttachments(
 	attachments = append(attachments, creating...)
 	attachments = append(attachments, updating...)
 
-	return attachments, nil
+	return attachments, remotes, nil
 }
 
 func ResolveLocalAttachments(opener vfs.Opener, base string, replacements []string) ([]Attachment, error) {

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -35,6 +35,17 @@ type API struct {
 	pageCache      map[string]*PageInfo
 	pageCacheByID  map[string]*PageInfo
 	pageCacheMutex sync.RWMutex
+
+	userCache      map[string]userCacheEntry
+	userCacheMutex sync.RWMutex
+}
+
+// userCacheEntry records the outcome of a user lookup, including a failed one:
+// a document that mentions an unknown name would otherwise re-query for every
+// occurrence, which is the case the cache is least able to afford.
+type userCacheEntry struct {
+	user *User
+	err  error
 }
 
 func pageCacheKey(space, title, pageType string) string {
@@ -969,7 +980,39 @@ func (api *API) GetPageLabels(page *PageInfo, prefix string) (*LabelInfo, error)
 	return &LabelInfo{Labels: all, Size: len(all)}, nil
 }
 
+// GetUserByName resolves a display name to a Confluence user.
+//
+// Results are cached for the lifetime of the API value. Every @mention in a
+// document renders through the "user" stdlib template func, so an uncached
+// lookup meant one CQL search per occurrence -- a document naming the same
+// person twenty times issued twenty searches, multiplied by every file in the
+// run. Names do not change mid-run, so the lookup is memoised, failures
+// included.
 func (api *API) GetUserByName(name string) (*User, error) {
+	if entry, ok := api.cachedUser(name); ok {
+		return entry.user, entry.err
+	}
+
+	user, err := api.fetchUserByName(name)
+
+	api.userCacheMutex.Lock()
+	if api.userCache == nil {
+		api.userCache = make(map[string]userCacheEntry)
+	}
+	api.userCache[name] = userCacheEntry{user: user, err: err}
+	api.userCacheMutex.Unlock()
+
+	return user, err
+}
+
+func (api *API) cachedUser(name string) (userCacheEntry, bool) {
+	api.userCacheMutex.RLock()
+	defer api.userCacheMutex.RUnlock()
+	entry, ok := api.userCache[name]
+	return entry, ok
+}
+
+func (api *API) fetchUserByName(name string) (*User, error) {
 	var response struct {
 		Results []struct {
 			User User

--- a/confluence/api_server_test.go
+++ b/confluence/api_server_test.go
@@ -451,3 +451,62 @@ func TestCreatePageIsNotRetriedOn5xx(t *testing.T) {
 	assert.Equal(t, 1, server.CountRequests("POST", "/rest/api/content"),
 		"a create must be attempted exactly once")
 }
+
+// TestGetUserByNameIsCached pins the fix for the @mention N+1: every mention in
+// a document renders through the "user" stdlib template func, so an uncached
+// lookup meant one CQL search per occurrence.
+func TestGetUserByNameIsCached(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddUser(confluencetest.User{
+		AccountID: "acct-1",
+		Username:  "jdoe",
+		FullName:  "Jane Doe",
+	})
+
+	for range 20 {
+		user, err := api.GetUserByName("Jane Doe")
+		require.NoError(t, err)
+		require.NotNil(t, user)
+		assert.Equal(t, "acct-1", user.AccountID)
+	}
+
+	assert.Equal(t, 1, server.CountRequests("GET", "/rest/api/search"),
+		"twenty mentions of the same person should cost one search")
+}
+
+// TestGetUserByNameCachesMisses covers the case the cache can least afford to
+// skip: an unknown name renders nothing, so nothing stops the document from
+// asking again for every occurrence.
+func TestGetUserByNameCachesMisses(t *testing.T) {
+	api, server := newAPI(t)
+
+	for range 5 {
+		_, err := api.GetUserByName("Nobody At All")
+		require.Error(t, err)
+	}
+
+	// A miss costs two requests, not one: GetUserByName tries /search/user and
+	// then falls back to the legacy /search path when that yields no results.
+	// The point of the assertion is that five lookups cost the same as one.
+	assert.Equal(t, 2, server.CountRequests("GET", "/rest/api/search"),
+		"a failed lookup should be remembered too")
+}
+
+func TestGetUserByNameCachesPerName(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddUser(confluencetest.User{AccountID: "a", FullName: "Ann"})
+	server.AddUser(confluencetest.User{AccountID: "b", FullName: "Bob"})
+
+	for range 3 {
+		ann, err := api.GetUserByName("Ann")
+		require.NoError(t, err)
+		assert.Equal(t, "a", ann.AccountID)
+
+		bob, err := api.GetUserByName("Bob")
+		require.NoError(t, err)
+		assert.Equal(t, "b", bob.AccountID)
+	}
+
+	assert.Equal(t, 2, server.CountRequests("GET", "/rest/api/search"),
+		"one search per distinct name")
+}

--- a/mark.go
+++ b/mark.go
@@ -339,7 +339,18 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		return nil, fmt.Errorf("unable to locate attachments: %w", err)
 	}
 
-	attaches, err := attachment.ResolveAttachments(api, target, localAttachments)
+	// The page's remote attachment list is fetched once and threaded through
+	// both resolve passes. Attachments are resolved twice per page -- declared
+	// attachments here, then diagrams discovered while rendering -- and each
+	// pass previously issued its own paginated fetch of the same list.
+	remoteAttachments, err := api.GetAttachments(target.ID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get attachments for page %s: %w", target.ID, err)
+	}
+
+	attaches, remoteAttachments, err := attachment.ResolveAttachmentsWithRemotes(
+		api, target, localAttachments, remoteAttachments,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create/update attachments: %w", err)
 	}
@@ -370,7 +381,9 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		return nil, fmt.Errorf("unable to compile markdown: %w", err)
 	}
 
-	if _, err = attachment.ResolveAttachments(api, target, inlineAttachments); err != nil {
+	if _, _, err = attachment.ResolveAttachmentsWithRemotes(
+		api, target, inlineAttachments, remoteAttachments,
+	); err != nil {
 		return nil, fmt.Errorf("unable to create/update attachments: %w", err)
 	}
 

--- a/mark_process_test.go
+++ b/mark_process_test.go
@@ -1,0 +1,128 @@
+package mark
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFile writes content into dir and returns its path.
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+// TestProcessFileFetchesAttachmentsOnce pins the fix for the duplicate
+// GetAttachments. ProcessFile resolves attachments twice per page -- declared
+// attachments, then diagrams found while rendering -- and each pass used to
+// issue its own paginated fetch of the same remote list.
+func TestProcessFileFetchesAttachmentsOnce(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	// A parentless page is only valid as the space homepage, so build a
+	// realistic tree: Home is the homepage, Parent sits under it.
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	// A 1x1 PNG so the image-dimension probe has something valid to read.
+	png := []byte{
+		0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a,
+		0x00, 0x00, 0x00, 0x0d, 'I', 'H', 'D', 'R',
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+		0x89,
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "logo.png"), png, 0o600))
+
+	file := writeFile(t, dir, "doc.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Attachment Doc -->
+<!-- Attachment: logo.png -->
+
+# Attachment Doc
+
+![logo](logo.png)
+`)
+
+	config := Config{
+		BaseURL:  server.URL,
+		Username: "user",
+		Password: "token",
+		Files:    file,
+		Features: []string{"mention"},
+		Output:   io.Discard,
+	}
+
+	server.ResetRequests()
+
+	target, err := ProcessFile(file, api, config)
+	require.NoError(t, err)
+	require.NotNil(t, target)
+
+	assert.Equal(t, 1, server.CountRequests("GET", "/child/attachment"),
+		"the remote attachment list should be fetched once per page")
+
+	stored := server.Attachments(target.ID)
+	require.Len(t, stored, 1)
+	assert.Equal(t, "logo.png", stored[0].Filename)
+}
+
+// TestProcessFileCreatesAndUpdatesPage is a smoke test for the whole
+// orchestration path, which had no coverage at all: metadata, ancestry, page
+// creation, body upload and labels in one run.
+func TestProcessFileCreatesAndUpdatesPage(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	// A parentless page is only valid as the space homepage, so build a
+	// realistic tree: Home is the homepage, Parent sits under it.
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	file := writeFile(t, dir, "doc.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: New Page -->
+<!-- Label: alpha -->
+
+# New Page
+
+Some **content**.
+`)
+
+	config := Config{
+		BaseURL:  server.URL,
+		Username: "user",
+		Password: "token",
+		Files:    file,
+		Features: []string{"mention"},
+		Output:   io.Discard,
+	}
+
+	target, err := ProcessFile(file, api, config)
+	require.NoError(t, err)
+	require.NotNil(t, target)
+
+	stored := server.Page(target.ID)
+	require.NotNil(t, stored)
+	assert.Equal(t, "New Page", stored.Title)
+	assert.Contains(t, stored.Body, "<strong>content</strong>")
+	assert.Equal(t, []string{"alpha"}, stored.Labels)
+
+	// The page was created under the declared parent.
+	parent, err := api.FindPage("DOCS", "Parent", "page")
+	require.NoError(t, err)
+	assert.Equal(t, parent.ID, stored.ParentID)
+}


### PR DESCRIPTION
Tier 3, items 5 and 6. **Stacked on #863** — it uses the `confluencetest` fake to measure the request counts, so please merge that first.

Two independent redundant-request fixes on the publish path. Both are network-level, so unlike the CPU work in #862 these show up on a real run.

### 1. User lookups are cached

Every `@mention` renders through the `user` stdlib template func, which issues a CQL search against `/rest/api/search/user`. Nothing cached it. A document naming the same person twenty times issued twenty searches — multiplied by every file in the run.

Failures are cached too, and that case matters more than it looks: an unknown name renders nothing at all, so there was no visible signal and no backpressure on asking again for every occurrence.

Names don't change mid-run, so the result is memoised on the `API` value under its own mutex, alongside the existing page cache.

### 2. The attachment list is fetched once per page, not twice

`ProcessFile` resolves attachments in two passes — declared attachments up front, then diagrams discovered while rendering — and each pass called `ResolveAttachments`, which issued its own **paginated** `GetAttachments` for the same list. On a page with 250 attachments that was six requests where three would do.

`ResolveAttachmentsWithRemotes` takes an already-fetched list and returns it updated with whatever that pass created or changed, so the second pass sees an accurate view without another round-trip. `ResolveAttachments` keeps its signature and still fetches its own list, so library callers are unaffected.

### Measured

Via the fake's request recording:

| scenario | before | after |
| --- | --- | --- |
| 20 mentions of one person | 20 searches | **1** |
| 5 lookups of a missing name | 10 requests | **2** |
| publish a page with one attachment | 2 attachment fetches | **1** |

The before numbers are from running the new tests against reverted sources, not from reasoning.

Two notes on the middle row: a *miss* costs two requests rather than one because `GetUserByName` falls back to the legacy `/search` path when `/search/user` returns nothing — the point of the assertion is that five lookups now cost the same as one. And the attachment row is measured end-to-end through `ProcessFile`, not at the unit boundary.

### Also

Adds the first tests for the `ProcessFile` orchestration path, which had none: a page is created under its declared parent, body and labels are uploaded, and the attachment list is fetched exactly once. Root package coverage 35.5% → **62.7%**.

### Verification

`go test ./...`, `go test -race ./...`, `golangci-lint run ./...` all clean.

Unrelated observation while running the suite: `d2.TestExtractD2Image` failed once under full-suite load, hitting the 120s Chrome render timeout, then passed in isolation both with and without this change. It looks like Chrome contention when the d2, mermaid and markdown packages render in parallel, not a regression — but it is a real flake worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)