### PR TITLE
build(deps): bump goldmark-katex to c52a8e1564b2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kovetskiy/mark/v16
 go 1.26
 
 require (
-	github.com/FurqanSoftware/goldmark-katex v0.0.0-20260802114817-44def238656c
+	github.com/FurqanSoftware/goldmark-katex v0.0.0-20260803101007-c52a8e1564b2
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/chromedp/cdproto v0.0.0-20260714215040-dc233986426f
 	github.com/chromedp/chromedp v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/FurqanSoftware/goldmark-katex v0.0.0-20260802114817-44def238656c h1:Ronz4g11h1iR8tysgX/jLnMPe42OEZJ4+iQBe7T7VPQ=
-github.com/FurqanSoftware/goldmark-katex v0.0.0-20260802114817-44def238656c/go.mod h1:lp/AixdhozkspNZDBD+bshxnQ3Kd9GKUkvi7zeaH0EQ=
+github.com/FurqanSoftware/goldmark-katex v0.0.0-20260803101007-c52a8e1564b2 h1:8X7YkNKOOIwYgGcmXkcj8/HPpY7JI5QnRUW32pu1Sgg=
+github.com/FurqanSoftware/goldmark-katex v0.0.0-20260803101007-c52a8e1564b2/go.mod h1:lp/AixdhozkspNZDBD+bshxnQ3Kd9GKUkvi7zeaH0EQ=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/PuerkitoBio/goquery v1.10.0 h1:6fiXdLuUvYs2OJSvNRqlNPoBm6YABE226xrbavY5Wv4=


### PR DESCRIPTION
Splitting this out of the local `go.mod` changes, separate from the d2 module-path migration in #867.

Not a routine bump — it carries two upstream changes:

- **KaTeX itself moves to v0.18.1** (upstream PR #8)
- **`katex.min.js` is now integrity-checked** against a pinned checksum

### Rendered math changes

KaTeX v0.18 namespaces its presentational CSS classes:

| before | after |
| --- | --- |
| `base` | `katex-base` |
| `strut` | `katex-strut` |
| `sizing` | `katex-sizing` |

I verified this by compiling a document containing inline math, a display integral and a matrix against binaries built from both pins. The **MathML half of the output is byte-identical** — only the `aria-hidden="true"` `katex-html` half, which is presentational and needs KaTeX CSS to mean anything, differs.

The namespacing is a small win in this context specifically: bare class names like `base` and `strut` sitting inside Confluence storage HTML are collision-prone against Confluence's own stylesheet. `katex-*` is not.

### Two consequences worth knowing

1. **Pages using the `math` feature will re-upload once** under `--changes-only`, because the rendered HTML — and therefore the content hash in the version message — changes. One-time, expected.
2. **Anyone who has installed KaTeX CSS into their Confluence theme** needs the v0.18-or-later stylesheet for the class names to match.

### Verification

Full `go test ./...`, `golangci-lint run ./...` and `gofmt -l` are clean — but note the `math` feature has **no golden-file fixture** in `testdata/`, so the suite would not have caught this rendering change. The class-name diff above came from a manual before/after comparison. A `math.md` fixture would be worth adding; happy to do it here or separately.

### Unrelated finding

`go mod tidy` reports that `modernc.org/libc v1.74.3` is **retracted** (latest is v1.75.3). It arrives indirectly via quickjs, which goldmark-katex uses. It is pre-existing on master and untouched by this PR — my diff is the single katex line — but it should probably be dealt with on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)