### PR TITLE
fix: synchronise the folder cache and the IsCloud probe

### DIFF
--- a/confluence/api.go
+++ b/confluence/api.go
@@ -29,8 +29,8 @@ type API struct {
 	restV2  *gopencils.Resource
 	BaseURL string
 
-	isCloudFlag    bool
-	isCloudChecked bool
+	isCloudFlag bool
+	isCloudOnce sync.Once
 
 	pageCache      map[string]*PageInfo
 	pageCacheByID  map[string]*PageInfo
@@ -1071,31 +1071,32 @@ func (api *API) GetCurrentUser() (*User, error) {
 	return &user, nil
 }
 
+// IsCloud reports whether the target is Confluence Cloud, probing at most once
+// per API value.
+//
+// The result is memoised through sync.Once rather than a plain bool pair: the
+// slow path issues an HTTP request, so two callers racing here would both probe
+// and would also write isCloudFlag concurrently. Once also guarantees that a
+// caller arriving while the probe is in flight waits for the answer instead of
+// reading a half-written one.
 func (api *API) IsCloud() bool {
-	if api.isCloudChecked {
-		return api.isCloudFlag
-	}
+	api.isCloudOnce.Do(func() {
+		// 1. Fast path: check default domain suffix
+		host := api.rest.Api.BaseUrl.Hostname()
+		if strings.HasSuffix(host, "jira.com") || strings.HasSuffix(host, "atlassian.net") {
+			api.isCloudFlag = true
+			return
+		}
 
-	// 1. Fast path: check default domain suffix
-	host := api.rest.Api.BaseUrl.Hostname()
-	if strings.HasSuffix(host, "jira.com") || strings.HasSuffix(host, "atlassian.net") {
-		api.isCloudFlag = true
-		api.isCloudChecked = true
-		return api.isCloudFlag
-	}
-
-	// 2. Slow path: probe Cloud-only v2 API endpoint
-	var result any
-	request, err := api.restV2.Res("spaces", &result).Get(map[string]string{
-		"limit": "1",
+		// 2. Slow path: probe Cloud-only v2 API endpoint
+		var result any
+		request, err := api.restV2.Res("spaces", &result).Get(map[string]string{
+			"limit": "1",
+		})
+		api.isCloudFlag = err == nil &&
+			(request.Raw.StatusCode == http.StatusOK || request.Raw.StatusCode == http.StatusForbidden)
 	})
-	if err == nil && (request.Raw.StatusCode == http.StatusOK || request.Raw.StatusCode == http.StatusForbidden) {
-		api.isCloudFlag = true
-	} else {
-		api.isCloudFlag = false
-	}
 
-	api.isCloudChecked = true
 	return api.isCloudFlag
 }
 

--- a/confluence/api_server_test.go
+++ b/confluence/api_server_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/kovetskiy/mark/v16/confluence"
@@ -509,4 +510,55 @@ func TestGetUserByNameCachesPerName(t *testing.T) {
 
 	assert.Equal(t, 2, server.CountRequests("GET", "/rest/api/search"),
 		"one search per distinct name")
+}
+
+// TestIsCloudConcurrentCallsProbeOnce covers the memoisation and its safety
+// together: many goroutines calling IsCloud must agree on the answer, and the
+// Cloud-only probe must be issued at most once. Before sync.Once the flag was
+// read and written without synchronisation, so concurrent callers raced on it
+// and each could issue its own probe.
+func TestIsCloudConcurrentCallsProbeOnce(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddSpace("DOCS")
+
+	const goroutines = 24
+
+	results := make([]bool, goroutines)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for i := range goroutines {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // release them together to maximise contention
+			results[i] = api.IsCloud()
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, got := range results {
+		assert.Equal(t, results[0], got, "goroutine %d disagreed about IsCloud", i)
+	}
+
+	assert.LessOrEqual(t, server.CountRequests("GET", "/api/v2/spaces"), 1,
+		"the Cloud probe should be issued at most once regardless of caller count")
+}
+
+// TestIsCloudCachesAcrossSequentialCalls is the plain-path counterpart: the
+// answer is memoised, so a second call does not re-probe.
+func TestIsCloudCachesAcrossSequentialCalls(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddSpace("DOCS")
+
+	first := api.IsCloud()
+	before := server.CountRequests("GET", "/api/v2/spaces")
+
+	for range 5 {
+		assert.Equal(t, first, api.IsCloud())
+	}
+
+	assert.Equal(t, before, server.CountRequests("GET", "/api/v2/spaces"),
+		"repeat calls must not re-probe")
 }

--- a/page/ancestry.go
+++ b/page/ancestry.go
@@ -3,6 +3,7 @@ package page
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/kovetskiy/mark/v16/confluence"
 	"github.com/rs/zerolog/log"
@@ -15,18 +16,32 @@ type ParentInfo struct {
 	Type  string // "page" or "folder"
 }
 
-// ponytail: process-wide folder cache; mark syncs files sequentially so no lock needed.
-var createdFolderCache = map[string]string{}
+// Process-wide cache of folders created or found during a run, so that files
+// sharing a folder ancestry do not each re-resolve it.
+//
+// The mutex is not optional even though mark currently syncs files
+// sequentially: the map is package state, so a caller using the library from
+// more than one goroutine -- or any future move to parallel file processing --
+// would otherwise corrupt it, and an unsynchronised map write is a hard
+// runtime throw rather than a subtle wrong answer.
+var (
+	createdFolderCache = map[string]string{}
+	createdFolderMutex sync.RWMutex
+)
 
 func folderCacheKey(space, contextID, title string) string {
 	return space + "\x00" + contextID + "\x00" + title
 }
 
 func cacheFolder(space, contextID, title, id string) {
+	createdFolderMutex.Lock()
+	defer createdFolderMutex.Unlock()
 	createdFolderCache[folderCacheKey(space, contextID, title)] = id
 }
 
 func cachedFolderID(space, contextID, title string) (string, bool) {
+	createdFolderMutex.RLock()
+	defer createdFolderMutex.RUnlock()
 	id, ok := createdFolderCache[folderCacheKey(space, contextID, title)]
 	return id, ok
 }

--- a/page/concurrency_test.go
+++ b/page/concurrency_test.go
@@ -1,0 +1,57 @@
+package page
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFolderCacheConcurrentAccess hammers the process-wide folder cache from
+// many goroutines. Before the mutex, an unsynchronised map write here was not
+// a subtle wrong answer but a hard "concurrent map writes" throw, and the race
+// detector reports it even when the throw does not fire.
+//
+// The test lives in package page rather than page_test because the cache and
+// its accessors are unexported.
+func TestFolderCacheConcurrentAccess(t *testing.T) {
+	const (
+		goroutines = 16
+		perRoutine = 200
+	)
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range perRoutine {
+				// Interleave distinct and shared keys so writers collide both
+				// on the map itself and on individual entries.
+				unique := "space-" + strconv.Itoa(g)
+				shared := "shared"
+				title := "folder-" + strconv.Itoa(i)
+
+				cacheFolder(unique, "parent", title, strconv.Itoa(g*perRoutine+i))
+				cacheFolder(shared, "parent", "contended", strconv.Itoa(i))
+
+				_, _ = cachedFolderID(unique, "parent", title)
+				_, _ = cachedFolderID(shared, "parent", "contended")
+				_, _ = cachedFolderID("absent", "parent", title)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// Every unique key written should still be readable: a torn map would
+	// typically have thrown by now, but this also catches lost writes.
+	for g := range goroutines {
+		id, ok := cachedFolderID("space-"+strconv.Itoa(g), "parent", "folder-0")
+		assert.True(t, ok, "entry for goroutine %d went missing", g)
+		assert.Equal(t, strconv.Itoa(g*perRoutine), id)
+	}
+
+	_, ok := cachedFolderID("shared", "parent", "contended")
+	assert.True(t, ok, "the contended entry should hold one of the written values")
+}


### PR DESCRIPTION
Two pieces of shared mutable state were unguarded. Neither is reachable today — mark syncs files sequentially — but both are reachable from a library caller using more than one goroutine, and both block any move to parallel file processing.

### 1. `page.createdFolderCache`

A package-level map, with a comment explaining that a lock was unnecessary because syncing is sequential:

```go
// ponytail: process-wide folder cache; mark syncs files sequentially so no lock needed.
var createdFolderCache = map[string]string{}
```

Now guarded by an `RWMutex`. This is the more dangerous of the two: an unsynchronised map write is a hard `fatal error: concurrent map writes`, not a subtle wrong answer.

### 2. `confluence.API.isCloudFlag` / `isCloudChecked`

Read and written without synchronisation — in the same struct whose page and user caches *are* mutex-guarded.

`IsCloud` is now memoised with `sync.Once`, which fits the semantics better than a mutex. The slow path issues an HTTP probe, so racing callers would each have issued their own; `Once` also means a caller arriving mid-probe waits for the answer instead of reading a half-written one.

### The tests fail without the fixes

Both come with tests that actually detect the bugs, which I verified by reverting each fix:

| test | without the fix |
| --- | --- |
| `TestFolderCacheConcurrentAccess` | `fatal error: concurrent map writes`, plus `WARNING: DATA RACE` |
| `TestIsCloudConcurrentCallsProbeOnce` | `WARNING: DATA RACE`, test fails |

The `IsCloud` test also asserts the probe is issued **at most once** regardless of how many callers arrive simultaneously — the memoisation, not just the safety.

### Survey of what else is exposed

I checked the rest of the package-level state rather than only the two known cases. Nothing else is: the d2 and mermaid Chrome handles already have mutexes, `transformer`'s buffer pool is a `sync.Pool`, and the `parser`/`renderer` variables are immutable after init.

### Out of scope, worth knowing

`createdFolderCache` is still **process-global rather than per-API**, so two `API` instances pointed at different Confluence hosts would share folder IDs keyed only by space, parent and title. That is a pre-existing scoping question rather than a race, so I left it alone — but it is the other reason this cache is worth revisiting before parallelising.

### Verification

Full `go test ./...` and `golangci-lint run ./...` clean; `go test -race ./...` reports **0 data races**.

One environment note: four packages intermittently fail to *link* their race-instrumented test binaries on my machine with `link: mapping output file failed: disk quota exceeded` — my disk is at 98%. They pass when run serially (`-p 1`). Not related to this change; flagging so a reviewer seeing it locally knows what it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)