### PR TITLE
fix(chrome): stop tests orphaning browsers, and widen the startup wait

### DIFF
--- a/chrome/chrome.go
+++ b/chrome/chrome.go
@@ -4,7 +4,32 @@
 // which let the two launch paths drift apart.
 package chrome
 
-import "github.com/chromedp/chromedp"
+import (
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+// wsURLReadTimeout is how long to wait for Chrome to print the DevTools
+// websocket URL it is reached on.
+//
+// chromedp defaults this to 20 seconds, which is generous for an idle desktop
+// and too tight for a loaded machine. Chrome has already been spawned by the
+// time this clock starts, so what is being waited on is the browser getting far
+// enough through startup to write one line -- exactly the thing that stretches
+// when CPU is contended. Overshooting it fails the run with "websocket url
+// timeout reached", which reads like a Chrome or network fault rather than a
+// machine that was merely busy.
+//
+// mark hits this in the places it is least able to afford: CI containers with a
+// fraction of a core, and its own test suite, where `go test ./...` runs the d2,
+// mermaid and markdown packages in parallel and each launches its own browser.
+//
+// Raising it costs nothing when Chrome starts promptly, and nothing when Chrome
+// is absent or unrunnable -- that fails at exec time, before this wait. The only
+// case that pays is a browser that starts but never reports, where the choice is
+// between failing at 20 seconds and failing at 60.
+const wsURLReadTimeout = 60 * time.Second
 
 // AllocatorOptions returns the options mark appends to
 // chromedp.DefaultExecAllocatorOptions.
@@ -25,5 +50,6 @@ func AllocatorOptions() []chromedp.ExecAllocatorOption {
 		chromedp.DisableGPU,
 		chromedp.NoSandbox,
 		chromedp.Flag("disable-setuid-sandbox", true),
+		chromedp.WSURLReadTimeout(wsURLReadTimeout),
 	}
 }

--- a/d2/main_test.go
+++ b/d2/main_test.go
@@ -1,0 +1,23 @@
+package d2
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain shuts the browser down after the package's tests.
+//
+// Chrome is held in a package-level singleton that is created lazily on first
+// render and cancelled only by Cleanup. Production does that through
+// util/cli.go's `defer mark.Cleanup()`, but nothing did it here, so every test
+// run orphaned a browser: the test binary exited, the allocator context was
+// never cancelled, and Chrome carried on with its /tmp/chromedp-runner* profile
+// directory. They accumulate one per run, and since they are each a browser
+// with its own zygote, GPU and renderer children, a few dozen runs are enough
+// to exhaust memory on a developer machine and make the diagram tests fail for
+// reasons that have nothing to do with the code under test.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	Cleanup()
+	os.Exit(code)
+}

--- a/markdown/main_test.go
+++ b/markdown/main_test.go
@@ -1,0 +1,22 @@
+package mark_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/d2"
+	"github.com/kovetskiy/mark/v16/mermaid"
+)
+
+// TestMain shuts down the browsers this package starts indirectly.
+//
+// Rendering a d2 or mermaid fenced block goes through renderer, which drives
+// the d2 and mermaid packages and their Chrome singletons, so these tests
+// orphan browsers exactly as those packages' own tests do. See the note on
+// d2's TestMain.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	d2.Cleanup()
+	mermaid.Cleanup()
+	os.Exit(code)
+}

--- a/mermaid/main_test.go
+++ b/mermaid/main_test.go
@@ -1,0 +1,15 @@
+package mermaid
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain shuts the render engine down after the package's tests; see the
+// note on d2's TestMain for why this is needed. The engine holds a Chrome
+// instance in a package-level singleton that only Cleanup cancels.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	Cleanup()
+	os.Exit(code)
+}


### PR DESCRIPTION
Two independent causes of the diagram tests failing for reasons unrelated to the code under test. Both showed up while investigating an intermittent `ci-unit-tests` failure on #798.

## Leaked browsers

`d2` and `mermaid` each hold Chrome in a package-level singleton, created lazily on first render and released only by `Cleanup`. Production calls it through `util/cli.go`'s `defer mark.Cleanup()` — but no test did, because **there was no `TestMain` in the repository at all**. Every run of the `d2`, `mermaid` or `markdown` tests exited without cancelling the allocator context, leaving a browser and its `/tmp/chromedp-runner*` profile directory behind.

They accumulate one per run, and each is a browser with its own zygote, GPU and renderer children. Measured by toggling the fix:

| | processes before → after one `go test ./d2/` | leaked profile dirs |
| --- | --- | --- |
| without `TestMain` | 2 → **12** | 1 |
| with `TestMain` | 2 → 2 | 0 |

Once enough pile up the machine runs out of memory and the diagram tests fail with whatever Chrome does when it cannot start — which looks like a rendering bug and is not one. This is likely what the authors of #723 and #726 both independently ran into locally. Clearing 30 orphans took the `markdown` package from 154s to 21s here.

## Startup wait

chromedp allows 20 seconds for Chrome to print its DevTools websocket URL (`allocate.go:40`). That is ample on an idle desktop and tight on a loaded one, and mark hits it where it can least afford to: `go test ./...` runs `d2`, `mermaid` and `markdown` in parallel, each launching its own browser, and CI adds `-race` on top.

The three failures observed on CI landed at **20.03s, 20.62s and 22.64s** — the timeout firing, not a crash. Raised to 60s in `chrome/chrome.go`, so it reaches all three packages from one place. The wiring was verified by temporarily setting it to 1ns and reproducing `websocket url timeout reached` through both the d2 and mermaid paths.

Raising it costs nothing when Chrome starts promptly, and nothing when Chrome is absent or unrunnable — that fails at `cmd.Start()` (`allocate.go:204`), before this wait begins. The only case that pays is a browser that starts but never reports, where the choice is between failing at 20s and failing at 60s. The same limit applies to anyone running mark in a constrained CI container, so this is not only a test fix.

## Testing

Full uncached suite green, and again under `-race` as CI runs it, with all three Chrome packages in parallel and no new leaks. `golangci-lint` reports 0 issues.

I cannot prove from here which of the two fixes resolves the CI flake. The leak is unambiguously a real bug; the timeout raise directly matches the error CI reported. They are complementary, and since the failure is intermittent, a single green run would not settle it either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)