### PR TITLE
fix(macro): use default delimiters for inline macro templates

### DIFF
--- a/macro/macro.go
+++ b/macro/macro.go
@@ -282,7 +282,15 @@ func ExtractMacros(
 				return nil, contents, fmt.Errorf("the template config doesn't have '%s' field", m.Name)
 			}
 
-			m.Template, err = templates.New(dir.Template).Parse(body)
+			// Delims must be set explicitly, exactly as the file-backed branch
+			// below does when it calls LoadTemplate. text/template's New copies
+			// the receiver's delimiters, and the set arriving here came from
+			// ProcessIncludes, whose most recent member carries whatever an
+			// include declared via `Delims:`. Without this the macro body would
+			// be parsed with those delimiters and its own {{ }} left as literal
+			// text -- with no error, since a template containing no recognised
+			// actions parses fine.
+			m.Template, err = templates.New(dir.Template).Delims("{{", "}}").Parse(body)
 			if err != nil {
 				return nil, contents, fmt.Errorf("unable to parse template: %w", err)
 			}

--- a/macro/macro_test.go
+++ b/macro/macro_test.go
@@ -79,3 +79,38 @@ func TestFindDirectiveEnd(t *testing.T) {
 		})
 	}
 }
+
+// TestExtractMacros_InlineTemplateUsesDefaultDelims pins the fix for #362.
+//
+// text/template's New copies the receiver's delimiters onto the new template,
+// and ProcessIncludes returns a set whose most recent member was parsed with
+// whatever an include declared via `Delims:`. Handing that set to ExtractMacros
+// meant an inline macro body was parsed with the include's delimiters, so its
+// own {{ }} actions were left as literal text -- silently, since a template
+// with no recognised actions parses perfectly well.
+//
+// The file-backed branch already pinned "{{" and "}}" explicitly when calling
+// LoadTemplate; only the inline branch inherited.
+func TestExtractMacros_InlineTemplateUsesDefaultDelims(t *testing.T) {
+	// A template set as it looks after an include declaring `Delims: << >>`.
+	poisoned, err := template.New("root").Delims("<<", ">>").Parse("ignored")
+	require.NoError(t, err)
+
+	contents := []byte(`<!-- Macro: ::greet::
+     Template: #inline
+     inline: "Hello {{ .Var }}"
+-->
+
+::greet::
+`)
+
+	macros, _, err := ExtractMacros("", "", contents, poisoned)
+	require.NoError(t, err)
+	require.Len(t, macros, 1)
+
+	var out strings.Builder
+	require.NoError(t, macros[0].Template.Execute(&out, map[string]any{"Var": "world"}))
+
+	assert.Equal(t, "Hello world", out.String(),
+		"an inline macro must use {{ }} regardless of any Delims: an include declared")
+}


### PR DESCRIPTION
Fixes #362.

## The bug

`text/template`'s `New` copies the receiver's delimiters onto the new template. The set reaching `ExtractMacros` comes from `ProcessIncludes`, whose most recent member was parsed with whatever an include declared via `Delims:` — so an inline macro body was parsed with *those* delimiters, and its own `{{ }}` was left as literal text.

So a document like this:

```markdown
<!-- Include: header.md
     Delims: << >>
     -->

<!-- Macro: ::greet::
     Template: #inline
     inline: "Hello {{ .Var }}"
     -->

::greet::
```

sends `Hello {{ .Var }}` to Confluence verbatim.

Nothing errors, because a template containing no *recognised* actions parses perfectly well. The macro simply stops interpolating — which is why this survived three years since it was reported.

## The fix

Pin `"{{"` and `"}}"` on the inline branch. The file-backed branch a few lines below (`macro.go:290`) already did exactly this when calling `LoadTemplate`; only the inline branch inherited from the receiver.

This is the one-line fix #363 proposed in 2023, applied to the current file layout — that PR targets `pkg/mark/macro/macro.go`, which no longer exists, so it can't be merged as-is.

## Testing

`TestExtractMacros_InlineTemplateUsesDefaultDelims` builds a template set carrying `<< >>`, runs an inline macro through it, and asserts the body interpolates. Confirmed to fail without the fix (renders the literal `"Hello {{ .Var }}"`) and pass with it.

`macro`, `includes` and the root package are green, `-race` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)