### PR TITLE
fix: keep the --changes-only fingerprint out of reach of truncation

### DIFF
--- a/mark.go
+++ b/mark.go
@@ -427,8 +427,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		contentHash := sha1Hash(html)
 		log.Debug().Msgf("content hash: %s", contentHash)
 
-		re := regexp.MustCompile(`\[v([a-f0-9]{40})]$`)
-		if matches := re.FindStringSubmatch(target.Version.Message); len(matches) > 1 {
+		if matches := contentHashPattern.FindStringSubmatch(target.Version.Message); len(matches) > 1 {
 			log.Debug().Msgf("previous content hash: %s", matches[1])
 			if matches[1] == contentHash {
 				log.Info().Msgf("page %q is already up to date", target.Title)
@@ -436,7 +435,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 			}
 		}
 
-		finalVersionMessage = fmt.Sprintf("%s [v%s]", config.VersionMessage, contentHash)
+		finalVersionMessage = formatVersionMessage(config.VersionMessage, contentHash)
 	} else {
 		finalVersionMessage = config.VersionMessage
 	}
@@ -577,6 +576,33 @@ func sha1Hash(input string) string {
 	h := sha1.New() //nolint:gosec // G401: see the crypto/sha1 import comment
 	h.Write([]byte(input))
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+// contentHashPattern finds the --changes-only fingerprint in a version message.
+//
+// Deliberately unanchored. It used to require the tag at the very end, which
+// only held while the tag was written last; messages carrying it at the front
+// are still recognised, so pages stamped by an older mark keep matching and do
+// not all take one spurious update on the first run after upgrading.
+var contentHashPattern = regexp.MustCompile(`\[v([a-f0-9]{40})]`)
+
+// formatVersionMessage puts the content fingerprint in front of the operator's
+// message.
+//
+// Confluence bounds the version message, and it used to be appended -- so a
+// long --version-message (a commit subject, say) could push the tag past the
+// limit and have it truncated away. Nothing failed loudly: the tag simply never
+// matched on the next run, and --changes-only quietly degraded to updating
+// every page every time, which is precisely the failure nobody notices.
+//
+// Leading with the tag means truncation eats the operator's prose, which is
+// recoverable and visible, instead of the machinery that has to round-trip.
+func formatVersionMessage(message, contentHash string) string {
+	tag := fmt.Sprintf("[v%s]", contentHash)
+	if message == "" {
+		return tag
+	}
+	return tag + " " + message
 }
 
 // htmlEscapeText escapes only the characters that Confluence storage HTML

--- a/mark_test.go
+++ b/mark_test.go
@@ -5,11 +5,13 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kovetskiy/mark/v16/confluence"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // ---------------------------------------------------------------------------
@@ -413,5 +415,77 @@ func BenchmarkRunCompileOnly(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+// TestFormatVersionMessage covers the round trip --changes-only depends on:
+// whatever formatVersionMessage writes must be readable by
+// contentHashPattern on the next run, or the page updates every time.
+func TestFormatVersionMessage(t *testing.T) {
+	const hash = "0123456789abcdef0123456789abcdef01234567"
+
+	t.Run("hash leads so truncation cannot eat it", func(t *testing.T) {
+		// Confluence bounds the version message. With the tag appended, a long
+		// operator message pushed it past the limit and silently disabled
+		// change detection; leading with the tag costs the prose instead.
+		long := strings.Repeat("a very long commit subject ", 40)
+		got := formatVersionMessage(long, hash)
+
+		assert.True(t, strings.HasPrefix(got, "[v"+hash+"]"),
+			"the fingerprint must come first")
+
+		for _, limit := range []int{255, 128, 64, 43} {
+			truncated := got
+			if len(truncated) > limit {
+				truncated = truncated[:limit]
+			}
+			matches := contentHashPattern.FindStringSubmatch(truncated)
+			require.Len(t, matches, 2, "hash must survive truncation at %d", limit)
+			assert.Equal(t, hash, matches[1])
+		}
+	})
+
+	t.Run("empty operator message leaves no stray separator", func(t *testing.T) {
+		assert.Equal(t, "[v"+hash+"]", formatVersionMessage("", hash))
+	})
+
+	t.Run("operator message is preserved", func(t *testing.T) {
+		got := formatVersionMessage("published by CI", hash)
+		assert.Equal(t, "[v"+hash+"] published by CI", got)
+	})
+
+	t.Run("round trips through the reader", func(t *testing.T) {
+		for _, msg := range []string{"", "published by CI", "[brackets] and (parens)"} {
+			matches := contentHashPattern.FindStringSubmatch(formatVersionMessage(msg, hash))
+			require.Len(t, matches, 2, "message %q must round trip", msg)
+			assert.Equal(t, hash, matches[1])
+		}
+	})
+}
+
+// TestContentHashPatternReadsLegacyTrailingTag pins backward compatibility:
+// pages stamped by an older mark carry the tag at the end. If those stopped
+// matching, every page in every space would take one spurious update on the
+// first run after upgrading.
+func TestContentHashPatternReadsLegacyTrailingTag(t *testing.T) {
+	const hash = "89abcdef0123456789abcdef0123456789abcdef"
+
+	legacy := fmt.Sprintf("%s [v%s]", "published by CI", hash)
+	matches := contentHashPattern.FindStringSubmatch(legacy)
+	require.Len(t, matches, 2, "the old trailing format must still be recognised")
+	assert.Equal(t, hash, matches[1])
+}
+
+// TestContentHashPatternIgnoresNonHashes guards against a version message that
+// merely looks tag-shaped being read as a fingerprint.
+func TestContentHashPatternIgnoresNonHashes(t *testing.T) {
+	for _, msg := range []string{
+		"[v123]", // too short
+		"[vZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ]", // not hex
+		"[v0123456789abcdef0123456789abcdef0123456]",  // 39 chars
+		"no tag at all",
+	} {
+		assert.Nil(t, contentHashPattern.FindStringSubmatch(msg),
+			"%q must not be read as a fingerprint", msg)
 	}
 }


### PR DESCRIPTION
## The bug

The `--changes-only` content hash was appended to the version message and matched with an **end-anchored** pattern:

```go
re := regexp.MustCompile(`\[v([a-f0-9]{40})]$`)
finalVersionMessage = fmt.Sprintf("%s [v%s]", config.VersionMessage, contentHash)
```

Confluence bounds the version message field. A long `--version-message` — a git commit subject, say — pushes the 43-character tag past the limit, and it gets truncated away. From that point the tag never matches again, and `--changes-only` quietly degrades to updating every page on every run.

It fails silently: there's nothing to observe but work that shouldn't have happened. Anyone using `--version-message` to carry commit metadata is the most likely to hit it, and the least likely to notice.

## The fix

**Lead with the tag.** Truncation then costs the operator's prose — visible and recoverable — rather than the machinery that has to round-trip.

**Drop the anchor.** Pages stamped by an older mark carry the tag at the end. If those stopped matching, the first run after upgrading would rewrite every page in every space exactly once, which is precisely what the flag exists to prevent. The unanchored pattern reads both layouts, so the upgrade is a no-op.

## Testing

Neither the writer nor the reader had any coverage. Now pinned:

- hash survives truncation at 255, 128, 64 and 43 characters
- round trips for empty, plain, and bracket-containing operator messages
- legacy trailing format still recognised
- tag-shaped strings that aren't 40 hex characters are rejected

The truncation test was confirmed to fail against the previous appended layout (it drops the hash at every limit tested). Full suite green, `-race` green, `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)