### PR TITLE
fix(confluence): make GetSpaceID's v1 lookup actually work

### DIFF
--- a/confluence/api.go
+++ b/confluence/api.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -1335,15 +1336,24 @@ func (api *API) GetFolderByID(folderID string) (*FolderInfo, error) {
 }
 
 func (api *API) GetSpaceID(spaceKey string) (string, error) {
-	// Try v1 API first (more reliable for space lookup by key)
-	v1Result := struct {
-		ID  string `json:"id"`
-		Key string `json:"key"`
-	}{}
+	// Try v1 first: it looks a space up by key directly, where v2 has to be
+	// asked for a filtered collection.
+	//
+	// The response is decoded into SpaceInfo rather than a struct declared
+	// here. The local one typed `id` as a string, but v1 returns it as a JSON
+	// *number*, so the decode failed on every single call, gopencils returned
+	// the error, and this branch was skipped every time -- making the v2
+	// "fallback" below the only path that had ever run. SpaceInfo already types
+	// the field correctly and is exercised against real Confluence by
+	// FindHomePage, so there is no reason for a second, divergent shape.
+	//
+	// v2 keeps its own string-typed struct: the two APIs genuinely disagree
+	// about this field, which is what made the mismatch easy to miss.
+	var v1Result SpaceInfo
 
 	request, err := api.rest.Res("space/"+spaceKey, &v1Result).Get()
-	if err == nil && request.Raw.StatusCode == http.StatusOK {
-		return v1Result.ID, nil
+	if err == nil && request.Raw.StatusCode == http.StatusOK && v1Result.ID != 0 {
+		return strconv.Itoa(v1Result.ID), nil
 	}
 
 	// Fallback to v2 API with query parameter

--- a/confluence/api_server_test.go
+++ b/confluence/api_server_test.go
@@ -338,16 +338,14 @@ func TestCreateAttachment(t *testing.T) {
 	assert.Equal(t, "mark:checksum: abc", stored[0].Comment)
 }
 
-// TestGetSpaceID documents current behaviour, which is not the intended
-// behaviour. GetSpaceID says it tries v1 "first (more reliable for space lookup
-// by key)" and falls back to v2, but its v1 struct decodes `id` as a string
-// while Confluence v1 returns a JSON number. The decode fails, gopencils
-// returns the error, and the v1 branch is skipped on every call -- so the
-// fallback is in fact the only path that ever succeeds.
+// TestGetSpaceID pins the v1-first behaviour GetSpaceID has always claimed.
 //
-// The assertion below is deliberately written against what happens today. When
-// the v1 decode is fixed, this test should start failing and be updated to
-// assert that no v2 request is made.
+// The v1 struct used to decode `id` as a string while Confluence v1 returns a
+// JSON number, so the decode failed on every call and the v2 "fallback" was the
+// only path that ever ran. The second assertion is the one that matters: it
+// fails if v1 silently stops working again, which is exactly how the bug hid --
+// the function still returned the right answer, just never by the route it said
+// it took.
 func TestGetSpaceID(t *testing.T) {
 	api, server := newAPI(t)
 	space := server.AddSpace("DOCS")
@@ -357,9 +355,36 @@ func TestGetSpaceID(t *testing.T) {
 	assert.Equal(t, space.ID, id)
 
 	assert.Equal(t, 1, server.CountRequests("GET", "/rest/api/space/DOCS"),
-		"the v1 lookup is attempted")
+		"the v1 lookup answers")
+	assert.Equal(t, 0, server.CountRequests("GET", "/api/v2/spaces"),
+		"so v2 must not be consulted at all")
+}
+
+// TestGetSpaceIDFallsBackToV2 keeps the fallback covered now that it is no
+// longer reached on every call: a scoped API token gets 404 from the v1 space
+// endpoint, the same shape FindHomePage handles.
+func TestGetSpaceIDFallsBackToV2(t *testing.T) {
+	api, server := newAPI(t)
+	space := server.AddSpace("DOCS")
+	server.SetFail(scopedTokenV1Gone(http.StatusNotFound))
+
+	id, err := api.GetSpaceID("DOCS")
+	require.NoError(t, err)
+	assert.Equal(t, space.ID, id)
+
 	assert.Equal(t, 1, server.CountRequests("GET", "/api/v2/spaces"),
-		"but its response cannot be decoded, so v2 is always used")
+		"v2 answers once v1 refuses")
+}
+
+// TestGetSpaceIDMissingSpace: neither API knows the space, and the error names
+// the key rather than surfacing a bare status.
+func TestGetSpaceIDMissingSpace(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddSpace("DOCS")
+
+	_, err := api.GetSpaceID("NOPE")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "NOPE")
 }
 
 // TestRetriesThroughTheRealClientStack drives a retry end to end: real


### PR DESCRIPTION
## The bug

`GetSpaceID` says it tries v1 first *"(more reliable for space lookup by key)"* and falls back to v2. It never did:

```go
v1Result := struct {
    ID  string `json:"id"`   // <- Confluence v1 returns a JSON *number*
    Key string `json:"key"`
}{}
```

The decode failed on every single call, gopencils returned the error, and the v1 branch was skipped every time. The v2 "fallback" was the only path that had ever run — and every folder operation paid a wasted round trip to learn that.

`SpaceInfo` at `api.go:145` already types the same field as `int`, correctly, and has been exercised against real Confluence by `FindHomePage` the whole time. The two shapes of one response drifted apart, and only the divergent copy was wrong.

## Why it hid for so long

The function still returned the right answer — just never by the route it claimed. There is no wrong output to notice, only a redundant request. It surfaced only once the fake Confluence server made request counts assertable, and the test added then was deliberately written to document the broken behaviour and ask to be rewritten when the decode was fixed:

> The assertion below is deliberately written against what happens today. When the v1 decode is fixed, this test should start failing and be updated to assert that no v2 request is made.

This is that change.

## The fix

Decode into `SpaceInfo` rather than a struct declared at the call site. No new type, and the correctly-typed shape becomes the only one. The v2 struct keeps its `string` — the two APIs genuinely disagree about this field, which is exactly what made the mismatch easy to miss.

## Testing

- `TestGetSpaceID` now asserts **zero** v2 requests, so it fails if v1 silently stops working again. Confirmed to fail against the old decode.
- `TestGetSpaceIDFallsBackToV2` keeps the fallback covered now that it is no longer reached on every call, using the same scoped-token 404 shape `FindHomePage` handles.
- `TestGetSpaceIDMissingSpace` covers neither API knowing the key.

Two of those three paths were unreachable by any test before: the broken decode meant v1 never succeeded, so the fallback was all that ever ran.

Full suite green under `-race`, `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)