### PR TITLE
fix: anchor the fingerprint match to the two layouts mark writes

### DIFF
--- a/mark.go
+++ b/mark.go
@@ -427,9 +427,9 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		contentHash := sha1Hash(html)
 		log.Debug().Msgf("content hash: %s", contentHash)
 
-		if matches := contentHashPattern.FindStringSubmatch(target.Version.Message); len(matches) > 1 {
-			log.Debug().Msgf("previous content hash: %s", matches[1])
-			if matches[1] == contentHash {
+		if previous := readContentHash(target.Version.Message); previous != "" {
+			log.Debug().Msgf("previous content hash: %s", previous)
+			if previous == contentHash {
 				log.Info().Msgf("page %q is already up to date", target.Title)
 				shouldUpdatePage = false
 			}
@@ -578,13 +578,36 @@ func sha1Hash(input string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-// contentHashPattern finds the --changes-only fingerprint in a version message.
+var (
+	contentHashLeading  = regexp.MustCompile(`^\[v([a-f0-9]{40})]`)
+	contentHashTrailing = regexp.MustCompile(`\[v([a-f0-9]{40})]$`)
+)
+
+// readContentHash recovers the fingerprint formatVersionMessage wrote, or "" if
+// the message carries none.
 //
-// Deliberately unanchored. It used to require the tag at the very end, which
-// only held while the tag was written last; messages carrying it at the front
-// are still recognised, so pages stamped by an older mark keep matching and do
-// not all take one spurious update on the first run after upgrading.
-var contentHashPattern = regexp.MustCompile(`\[v([a-f0-9]{40})]`)
+// Both layouts have to be read: mark writes the tag first, but pages stamped
+// before that change carry it last, and if those stopped matching then the
+// first run after upgrading would rewrite every page in every space once --
+// exactly what --changes-only exists to prevent.
+//
+// Both are anchored. Matching the tag anywhere would also read one the operator
+// happened to put in --version-message -- someone quoting a previous message,
+// say -- and prefer it over the real one. The consequence is mild, an update
+// that was not needed rather than a change that was missed, but the position is
+// free information and there is no reason to discard it.
+//
+// Leading wins, because that is what mark writes now; trailing is only
+// consulted for pages it has not yet restamped.
+func readContentHash(message string) string {
+	if m := contentHashLeading.FindStringSubmatch(message); m != nil {
+		return m[1]
+	}
+	if m := contentHashTrailing.FindStringSubmatch(message); m != nil {
+		return m[1]
+	}
+	return ""
+}
 
 // formatVersionMessage puts the content fingerprint in front of the operator's
 // message.

--- a/mark_test.go
+++ b/mark_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kovetskiy/mark/v16/confluence"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // ---------------------------------------------------------------------------
@@ -420,7 +419,7 @@ func BenchmarkRunCompileOnly(b *testing.B) {
 
 // TestFormatVersionMessage covers the round trip --changes-only depends on:
 // whatever formatVersionMessage writes must be readable by
-// contentHashPattern on the next run, or the page updates every time.
+// readContentHash on the next run, or the page updates every time.
 func TestFormatVersionMessage(t *testing.T) {
 	const hash = "0123456789abcdef0123456789abcdef01234567"
 
@@ -439,9 +438,8 @@ func TestFormatVersionMessage(t *testing.T) {
 			if len(truncated) > limit {
 				truncated = truncated[:limit]
 			}
-			matches := contentHashPattern.FindStringSubmatch(truncated)
-			require.Len(t, matches, 2, "hash must survive truncation at %d", limit)
-			assert.Equal(t, hash, matches[1])
+			matches := readContentHash(truncated)
+			assert.Equal(t, hash, matches, "hash must survive truncation at %d", limit)
 		}
 	})
 
@@ -456,9 +454,8 @@ func TestFormatVersionMessage(t *testing.T) {
 
 	t.Run("round trips through the reader", func(t *testing.T) {
 		for _, msg := range []string{"", "published by CI", "[brackets] and (parens)"} {
-			matches := contentHashPattern.FindStringSubmatch(formatVersionMessage(msg, hash))
-			require.Len(t, matches, 2, "message %q must round trip", msg)
-			assert.Equal(t, hash, matches[1])
+			assert.Equal(t, hash, readContentHash(formatVersionMessage(msg, hash)),
+				"message %q must round trip", msg)
 		}
 	})
 }
@@ -471,9 +468,8 @@ func TestContentHashPatternReadsLegacyTrailingTag(t *testing.T) {
 	const hash = "89abcdef0123456789abcdef0123456789abcdef"
 
 	legacy := fmt.Sprintf("%s [v%s]", "published by CI", hash)
-	matches := contentHashPattern.FindStringSubmatch(legacy)
-	require.Len(t, matches, 2, "the old trailing format must still be recognised")
-	assert.Equal(t, hash, matches[1])
+	assert.Equal(t, hash, readContentHash(legacy),
+		"the old trailing format must still be recognised")
 }
 
 // TestContentHashPatternIgnoresNonHashes guards against a version message that
@@ -485,7 +481,35 @@ func TestContentHashPatternIgnoresNonHashes(t *testing.T) {
 		"[v0123456789abcdef0123456789abcdef0123456]",  // 39 chars
 		"no tag at all",
 	} {
-		assert.Nil(t, contentHashPattern.FindStringSubmatch(msg),
+		assert.Empty(t, readContentHash(msg),
 			"%q must not be read as a fingerprint", msg)
 	}
+}
+
+// TestReadContentHashIgnoresTagsInsideTheMessage pins the reason both patterns
+// are anchored.
+//
+// An operator's --version-message can itself contain something tag-shaped --
+// someone quoting a previous version message, most plausibly. An unanchored
+// search would find that copy first and prefer it over the real fingerprint at
+// the end. The result is only an update that was not needed, never a change
+// that was missed, but position is free information and discarding it makes
+// the wrong answer reachable for no benefit.
+func TestReadContentHashIgnoresTagsInsideTheMessage(t *testing.T) {
+	const real = "0123456789abcdef0123456789abcdef01234567"
+	const quoted = "89abcdef0123456789abcdef0123456789abcdef"
+
+	// A page still carrying the legacy trailing layout, whose operator message
+	// quotes an older tag.
+	legacy := fmt.Sprintf("re-publish of [v%s] [v%s]", quoted, real)
+	assert.Equal(t, real, readContentHash(legacy),
+		"the trailing fingerprint is the real one, not the quoted copy")
+
+	// The layout mark writes now: its own tag leads, so it wins outright.
+	current := fmt.Sprintf("[v%s] re-publish of [v%s]", real, quoted)
+	assert.Equal(t, real, readContentHash(current))
+
+	// A tag that is neither leading nor trailing is not a fingerprint at all.
+	buried := fmt.Sprintf("see [v%s] for context", quoted)
+	assert.Empty(t, readContentHash(buried))
 }


### PR DESCRIPTION
Follow-up to #875, which moved the `--changes-only` fingerprint to the front of the version message and dropped the end anchor to keep reading pages stamped in the old trailing layout.

Dropping the anchor entirely was too loose.

## The problem

An operator's `--version-message` can itself contain something tag-shaped — someone quoting a previous version message is the plausible case. An unanchored search finds that copy first and prefers it over the real fingerprint:

```
message: "re-publish of [v89abcdef…] [v01234567…]"
                          ^ quoted copy       ^ the real one
reads:   89abcdef…   (wrong)
```

The consequence is mild — a hash that does not match the current content means the page gets updated, so the failure mode is an update that was not needed, never a change that was missed. But position is free information, and discarding it made a wrong answer reachable for no benefit.

## The fix

Match the two layouts mark actually writes, and nothing else, behind a `readContentHash` helper:

- **leading** wins, since that is what mark writes now
- **trailing** is consulted only for pages it has not yet restamped — which is what keeps the upgrade from #875 a no-op
- anything buried mid-message is not a fingerprint

## Testing

`TestReadContentHashIgnoresTagsInsideTheMessage` covers all three: a legacy page whose operator message quotes an older tag (must find the real trailing one), the current layout (leading wins), and a tag that is neither (not a fingerprint at all).

Confirmed to fail against the unanchored version — it picks the quoted copy in the first case and treats the buried tag as a fingerprint in the third. The existing truncation, round-trip and legacy-format tests from #875 are carried over unchanged and still pass.

Full suite green under `-race`, `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)