### PR TITLE
feat: track which page each file publishes to, behind --track-pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,6 +1024,7 @@ GLOBAL OPTIONS:
    --mermaid-scale float                    defines the scaling factor for mermaid renderings. (default: 1) [$MARK_MERMAID_SCALE]
    --include-path string                    Path for shared includes, used as a fallback if the include doesn't exist in the current directory. [$MARK_INCLUDE_PATH]
    --changes-only                           Avoids re-uploading pages that haven't changed since the last run. [$MARK_CHANGES_ONLY]
+   --track-pages                            Remember which page each file publishes to, so renaming a file or changing its title updates the existing page instead of creating a second one. Stores the mapping in Confluence (a space property on Cloud, a homepage content property on Server/Data Center); nothing is written to the repository. [$MARK_TRACK_PAGES]
    --preserve-comments                      Fetch and preserve inline comments on existing Confluence pages. [$MARK_PRESERVE_COMMENTS]
    --d2-scale float                         defines the scaling factor for d2 renderings. (default: 1) [$MARK_D2_SCALE]
    --features string [ --features string ]  Enables optional features. Current features: d2, date, details, frontmatter, html-img-tag, inline-link-card, math, mention, mermaid, mkdocsadmonitions, plantuml (default: "mermaid", "mention") [$MARK_FEATURES]
@@ -1147,6 +1148,112 @@ MARK_PRESERVE_COMMENTS=true mark -f docs/page.md
 * Overlapping selections (two comments anchored to the same stretch of text) are detected; the earlier overlapping match is dropped with a warning, and the later one (higher byte offset) is kept, rather than producing malformed markup.
 * `--preserve-comments` is automatically skipped for newly created pages (there are no comments to preserve yet).
 * When combined with `--changes-only`, the comment-preservation API calls are skipped entirely on runs where the page content has not changed, avoiding unnecessary round-trips.
+
+### Tracking Pages Across Renames
+
+Mark finds an existing page by its title. That title comes from three
+independently changeable places -- the `Title` header, the leading H1, and the
+filename when `--title-from-filename` is set -- so editing any of them makes the
+existing page unfindable, and Mark publishes a second page beside the first.
+
+`--track-pages` records which page each source file published to, keyed on the
+file path, and consults that record when the title lookup finds nothing:
+
+```bash
+mark --track-pages --files "docs/**/*.md"
+```
+
+Retitle a document and the existing page is renamed in place rather than
+duplicated. This holds even under `--changes-only`: a page whose content is
+unchanged is still written when its title needs to move.
+
+The mapping is stored in Confluence, never in the repository -- no page IDs in
+your Markdown, no lock file, no commit. Where exactly depends on the instance:
+
+| | storage |
+| --- | --- |
+| Cloud | space properties named `mark.manifest.0` … `mark.manifest.15` |
+| Server / Data Center | content properties of the same names on the space homepage |
+
+The mapping is split over sixteen properties rather than held in one, because
+Confluence bounds how large a single property value may be and a single blob
+would put a ceiling on how many files a repository may have. Each path is
+assigned to one of them by a hash of the path, all sixteen are read in a single
+request, and only the ones that changed are written back.
+
+Server and Data Center have no space properties -- those exist only in the v2
+API -- so the manifest is anchored to the space homepage instead. Cloud keeps
+the space property rather than using the homepage for both, because content
+properties are a v1 endpoint and v1 is what a scoped API token cannot reach.
+
+One caveat on Server and Data Center: changing a space's homepage orphans its
+manifest, and tracking starts over on the next run. That costs the rename
+protection until it is rebuilt, and nothing else -- no page is modified by it.
+
+Mark also reports pages it has published to that no source file accounts for any
+more:
+
+```text
+space "DOCS": 2 tracked page(s) had no matching source file in this run: docs/old.md, docs/removed.md
+```
+
+This is a report, not a deletion -- Mark never removes a page. Only files
+published by the same `--files` pattern are considered, so a run narrowed to one
+directory says nothing about any other. The report is suppressed on runs that
+had errors, because a file that failed to process is indistinguishable from one
+that is gone.
+
+Each deletion is reported once. Having said it, Mark stops tracking that path,
+so the message does not repeat on every run afterwards -- and the mapping does
+not grow forever with files that no longer exist. The Confluence page is left
+exactly where it is; what becomes of it is your call.
+
+A dry run resolves the same way a real one does and says what it would have
+done, including which existing page a retitle or a rename would have updated. It
+writes nothing at all, to Confluence or to the mapping.
+
+References to a renamed page are followed as well. Mark names a parent page by
+title and creates it when the title is not found, so renaming a page that other
+documents declare as their parent would otherwise strand them under a fresh
+empty page carrying the old name. A parent title Mark itself published is
+followed to the page that holds it now; a title Mark has never seen is still
+created as before.
+
+Folders are tracked too, for a different reason. Mark never renames a folder,
+but somebody renaming one in Confluence would otherwise stop it matching the
+`<!-- Folder: -->` header that declares it, and Mark would build a second folder
+beside the first and split the hierarchy in two.
+
+Two more things get reported rather than guessed at: two files that resolve to
+the same page, and a document that changes its `Space`, leaving its old page
+behind.
+
+Renaming a **file** is handled too, and it is the awkward case: the path is the
+key, so a rename is a miss, and when the title comes from the filename the title
+lookup misses as well. What connects the old page to the new file is the file's
+own content. Mark knows the whole file set before it publishes any of it, so a
+recorded path that has stopped appearing and a new file with the same content
+are matched to each other -- the same way `git log --follow` recovers a rename
+after the fact rather than being told about it.
+
+The match has to be unambiguous. If two unpublished documents share a
+document's content, or the page is already claimed by another file in the same
+run, Mark creates a new page rather than guessing: a duplicate is a nuisance,
+where rebinding onto the wrong page would overwrite something nobody asked to
+change. A file renamed *and* substantially rewritten in one commit therefore
+reads as a deletion plus a new page, which is the same limit Git has.
+
+Two things worth knowing. Paths are keyed relative to the directory Mark runs
+in, so `--files "$PWD/docs/*.md"` and `--files "docs/*.md"` share one mapping as
+long as they are run from the same place; a file outside that directory has no
+better anchor and is keyed by its absolute path. And `--track-pages` has no
+effect when publishing straight to a page id, since the mapping is per space and
+per file and a page id is neither.
+
+Turning tracking on for an already-published space costs one run. Nothing is
+recorded until a file is published with the flag set, so the first run adopts
+the existing pages and everything from the second run onwards is protected --
+a rename made in that very first run is not.
 
 ## Issues, Bugs & Contributions
 

--- a/README.md
+++ b/README.md
@@ -1151,109 +1151,115 @@ MARK_PRESERVE_COMMENTS=true mark -f docs/page.md
 
 ### Tracking Pages Across Renames
 
-Mark finds an existing page by its title. That title comes from three
-independently changeable places -- the `Title` header, the leading H1, and the
-filename when `--title-from-filename` is set -- so editing any of them makes the
-existing page unfindable, and Mark publishes a second page beside the first.
+Mark finds an existing page by its title, and that title comes from three
+independently changeable places: the `Title` header, the leading H1, and the
+filename when `--title-from-filename` is set. Edit any of them and the existing
+page can no longer be found, so Mark publishes a second page beside the first
+and leaves the original stranded under its old name.
 
 `--track-pages` records which page each source file published to, keyed on the
-file path, and consults that record when the title lookup finds nothing:
+file path, and consults that record at the one moment the title lookup comes up
+empty -- which is where "this page is new" and "this page was renamed" are
+otherwise indistinguishable:
 
 ```bash
 mark --track-pages --files "docs/**/*.md"
 ```
 
-Retitle a document and the existing page is renamed in place rather than
-duplicated. This holds even under `--changes-only`: a page whose content is
-unchanged is still written when its title needs to move.
+Nothing is written back to your repository: no page IDs in the Markdown, no lock
+file, no commit. The record lives in Confluence.
 
-The mapping is stored in Confluence, never in the repository -- no page IDs in
-your Markdown, no lock file, no commit. Where exactly depends on the instance:
+#### What it handles
 
-| | storage |
+| you change | what happens |
 | --- | --- |
-| Cloud | space properties named `mark.manifest.0` … `mark.manifest.15` |
-| Server / Data Center | content properties of the same names on the space homepage |
+| the `Title` header | the existing page is retitled in place |
+| the leading H1 | the same |
+| the **filename** | the page is matched by content and retitled |
+| a **parent page's** title | documents naming it as their parent follow it |
+| a **folder's** title, in Confluence | the folder is reused rather than duplicated |
 
-The mapping is split over sixteen properties rather than held in one, because
-Confluence bounds how large a single property value may be and a single blob
-would put a ceiling on how many files a repository may have. Each path is
-assigned to one of them by a hash of the path, all sixteen are read in a single
-request, and only the ones that changed are written back.
+A retitle is written even under `--changes-only`. The content fingerprint would
+otherwise match, the update would be skipped, and the page would keep its old
+title indefinitely.
 
-Server and Data Center have no space properties -- those exist only in the v2
-API -- so the manifest is anchored to the space homepage instead. Cloud keeps
-the space property rather than using the homepage for both, because content
-properties are a v1 endpoint and v1 is what a scoped API token cannot reach.
+Renaming a file is the awkward case: the path is the key, so a rename is a miss,
+and when the title comes from the filename the title lookup misses too. What
+connects the old page to the new file is the file's own content. Mark knows the
+whole file set before it publishes any of it, so a path that has stopped
+appearing and a new file carrying its content are matched to each other -- much
+as `git log --follow` recovers a rename after the fact rather than being told
+about it.
 
-One caveat on Server and Data Center: changing a space's homepage orphans its
-manifest, and tracking starts over on the next run. That costs the rename
-protection until it is rebuilt, and nothing else -- no page is modified by it.
+That match must be unambiguous. If two unpublished documents share the content,
+or the page is already claimed by another file in the same run, Mark creates a
+new page rather than guessing: a duplicate is a nuisance, where rebinding onto
+the wrong page would overwrite something nobody asked to change. A file renamed
+*and* substantially rewritten in one commit therefore reads as a deletion plus a
+new page -- the same limit Git has.
 
-Mark also reports pages it has published to that no source file accounts for any
-more:
+Folders are tracked for a different reason. Mark never renames a folder itself,
+but somebody renaming one in Confluence would stop it matching the
+`<!-- Folder: -->` header that declares it, and Mark would build a second folder
+beside the first and split the hierarchy in two.
+
+#### What it never does
+
+Mark does not delete pages, and tracking does not change that. It reports source
+files it can no longer account for:
 
 ```text
 space "DOCS": 2 tracked page(s) had no matching source file in this run: docs/old.md, docs/removed.md
 ```
 
-This is a report, not a deletion -- Mark never removes a page. Only files
-published by the same `--files` pattern are considered, so a run narrowed to one
-directory says nothing about any other. The report is suppressed on runs that
-had errors, because a file that failed to process is indistinguishable from one
-that is gone.
+Only files published by the same `--files` pattern are considered, so a run
+narrowed to one directory says nothing about any other. The report is suppressed
+on runs that had errors, where a file that failed to process is
+indistinguishable from one that is gone. Each deletion is reported once: having
+said it, Mark stops tracking that path, so the message does not repeat forever
+and the mapping does not accumulate files that no longer exist. What becomes of
+the page itself is your call.
 
-Each deletion is reported once. Having said it, Mark stops tracking that path,
-so the message does not repeat on every run afterwards -- and the mapping does
-not grow forever with files that no longer exist. The Confluence page is left
-exactly where it is; what becomes of it is your call.
+Two more things are reported rather than acted on: two files that resolve to the
+same page, and a document that changes its `Space`, leaving its old page behind.
 
-A dry run resolves the same way a real one does and says what it would have
-done, including which existing page a retitle or a rename would have updated. It
-writes nothing at all, to Confluence or to the mapping.
+A dry run resolves exactly as a real one does and says what it would have done,
+including which existing page a retitle or a rename would have updated. It
+writes nothing at all -- neither to Confluence nor to the mapping.
 
-References to a renamed page are followed as well. Mark names a parent page by
-title and creates it when the title is not found, so renaming a page that other
-documents declare as their parent would otherwise strand them under a fresh
-empty page carrying the old name. A parent title Mark itself published is
-followed to the page that holds it now; a title Mark has never seen is still
-created as before.
+#### Where the mapping is stored
 
-Folders are tracked too, for a different reason. Mark never renames a folder,
-but somebody renaming one in Confluence would otherwise stop it matching the
-`<!-- Folder: -->` header that declares it, and Mark would build a second folder
-beside the first and split the hierarchy in two.
+| | storage |
+| --- | --- |
+| Cloud | space properties `mark.manifest.0` … `mark.manifest.15`, and `mark.manifest.folders` |
+| Server / Data Center | content properties of the same names, on the space homepage |
 
-Two more things get reported rather than guessed at: two files that resolve to
-the same page, and a document that changes its `Space`, leaving its old page
-behind.
+Space properties exist only in the v2 API, so Server and Data Center anchor to
+the space homepage instead. Cloud keeps the space property rather than using the
+homepage for both, because content properties are a v1 endpoint and v1 is what a
+scoped API token cannot reach.
 
-Renaming a **file** is handled too, and it is the awkward case: the path is the
-key, so a rename is a miss, and when the title comes from the filename the title
-lookup misses as well. What connects the old page to the new file is the file's
-own content. Mark knows the whole file set before it publishes any of it, so a
-recorded path that has stopped appearing and a new file with the same content
-are matched to each other -- the same way `git log --follow` recovers a rename
-after the fact rather than being told about it.
+It is split over sixteen properties rather than held in one because Confluence
+bounds how large a single property value may be, and one blob would cap how many
+files a repository may have. Each path is assigned a shard by hash; all of them
+are read in a single request and only the ones that changed are written back.
 
-The match has to be unambiguous. If two unpublished documents share a
-document's content, or the page is already claimed by another file in the same
-run, Mark creates a new page rather than guessing: a duplicate is a nuisance,
-where rebinding onto the wrong page would overwrite something nobody asked to
-change. A file renamed *and* substantially rewritten in one commit therefore
-reads as a deletion plus a new page, which is the same limit Git has.
+#### Worth knowing
 
-Two things worth knowing. Paths are keyed relative to the directory Mark runs
-in, so `--files "$PWD/docs/*.md"` and `--files "docs/*.md"` share one mapping as
-long as they are run from the same place; a file outside that directory has no
-better anchor and is keyed by its absolute path. And `--track-pages` has no
-effect when publishing straight to a page id, since the mapping is per space and
-per file and a page id is neither.
-
-Turning tracking on for an already-published space costs one run. Nothing is
-recorded until a file is published with the flag set, so the first run adopts
-the existing pages and everything from the second run onwards is protected --
-a rename made in that very first run is not.
+* Turning tracking on for an already-published space costs one run. Nothing is
+  recorded until a file is published with the flag set, so the first run adopts
+  the existing pages and everything from the second run onward is protected. A
+  rename made in that very first run is not.
+* Paths are keyed relative to the directory Mark runs in and with forward
+  slashes, so `--files "$PWD/docs/*.md"` and `--files "docs/*.md"` share one
+  mapping when run from the same place, as do a Windows workstation and Linux
+  CI. A file outside that directory has no better anchor and is keyed by its
+  absolute path.
+* `--track-pages` has no effect when publishing straight to a page ID, since the
+  mapping is per space and per file and a page ID is neither.
+* On Server and Data Center, changing a space's homepage orphans its mapping and
+  tracking starts over on the next run. That costs the rename protection until
+  it is rebuilt, and nothing else -- no page is modified by it.
 
 ## Issues, Bugs & Contributions
 

--- a/README.md
+++ b/README.md
@@ -1169,15 +1169,18 @@ mark --track-pages --files "docs/**/*.md"
 Nothing is written back to your repository: no page IDs in the Markdown, no lock
 file, no commit. The record lives in Confluence.
 
-#### What it handles
+#### What it detects
 
-| you change | what happens |
+| change | how it is found |
 | --- | --- |
-| the `Title` header | the existing page is retitled in place |
-| the leading H1 | the same |
-| the **filename** | the page is matched by content and retitled |
-| a **parent page's** title | documents naming it as their parent follow it |
-| a **folder's** title, in Confluence | the folder is reused rather than duplicated |
+| `Title` header edited | the path is the key, so the lookup still hits |
+| leading H1 edited | the same |
+| file renamed | content fingerprint, matched against paths that stopped appearing |
+| parent page renamed | the title it was published under, followed to the page holding it now |
+| folder renamed in Confluence | the recorded folder ID, reused rather than duplicated |
+| source file deleted | a recorded path absent from a run whose pattern covered it |
+| two files claiming one page | the reverse index, when the second one is recorded |
+| document changed `Space` | the same path recorded against another space |
 
 A retitle is written even under `--changes-only`. The content fingerprint would
 otherwise match, the update would be skipped, and the page would keep its old
@@ -1185,23 +1188,27 @@ title indefinitely.
 
 Renaming a file is the awkward case: the path is the key, so a rename is a miss,
 and when the title comes from the filename the title lookup misses too. What
-connects the old page to the new file is the file's own content. Mark knows the
-whole file set before it publishes any of it, so a path that has stopped
-appearing and a new file carrying its content are matched to each other -- much
-as `git log --follow` recovers a rename after the fact rather than being told
-about it.
+connects them is the file's own content. Mark knows the whole file set before it
+publishes any of it, so a path that has stopped appearing and a new file
+carrying its content are matched to each other -- much as `git log --follow`
+recovers a rename after the fact rather than being told about it.
 
-That match must be unambiguous. If two unpublished documents share the content,
-or the page is already claimed by another file in the same run, Mark creates a
-new page rather than guessing: a duplicate is a nuisance, where rebinding onto
-the wrong page would overwrite something nobody asked to change. A file renamed
-*and* substantially rewritten in one commit therefore reads as a deletion plus a
-new page -- the same limit Git has.
+#### What it does not detect
 
-Folders are tracked for a different reason. Mark never renames a folder itself,
-but somebody renaming one in Confluence would stop it matching the
-`<!-- Folder: -->` header that declares it, and Mark would build a second folder
-beside the first and split the hierarchy in two.
+| case | why |
+| --- | --- |
+| a file renamed *and* rewritten in one commit | the fingerprint is exact, so any content change breaks the match. Reads as a deletion plus a new page -- Git's limit too, without an `-M50%` to loosen it |
+| an ambiguous rename | two unpublished documents sharing content, or a target page another file already claimed this run. A duplicate is a nuisance; a wrong rebind overwrites someone's page |
+| anything in the first run | nothing is recorded until a file publishes with the flag set, so the first run only adopts |
+| a rename across two `--files` patterns | matching and reporting are both scoped to the pattern that recorded the entry, so the file is a deletion in one and a new page in the other |
+| whether a deletion was intended | it reports; it never deletes |
+| a `Parent:` header change | still fails the run with an ancestry error rather than moving the page |
+| a moved space homepage (Server/DC) | the mapping is anchored to it, so tracking starts over |
+
+A page renamed by hand in Confluence is found by its ID and renamed back to what
+the file says. That is deliberate -- the repository is the source of truth, as it
+already is for titles and content -- but it is worth knowing before turning this
+on over a space people edit directly.
 
 #### What it never does
 
@@ -1212,16 +1219,11 @@ files it can no longer account for:
 space "DOCS": 2 tracked page(s) had no matching source file in this run: docs/old.md, docs/removed.md
 ```
 
-Only files published by the same `--files` pattern are considered, so a run
-narrowed to one directory says nothing about any other. The report is suppressed
-on runs that had errors, where a file that failed to process is
-indistinguishable from one that is gone. Each deletion is reported once: having
-said it, Mark stops tracking that path, so the message does not repeat forever
-and the mapping does not accumulate files that no longer exist. What becomes of
-the page itself is your call.
-
-Two more things are reported rather than acted on: two files that resolve to the
-same page, and a document that changes its `Space`, leaving its old page behind.
+The report is suppressed on runs that had errors, where a file that failed to
+process is indistinguishable from one that is gone. Each deletion is reported
+once: having said it, Mark stops tracking that path, so the message does not
+repeat forever and the mapping does not accumulate files that no longer exist.
+What becomes of the page itself is your call.
 
 A dry run resolves exactly as a real one does and says what it would have done,
 including which existing page a retitle or a rename would have updated. It
@@ -1246,10 +1248,6 @@ are read in a single request and only the ones that changed are written back.
 
 #### Worth knowing
 
-* Turning tracking on for an already-published space costs one run. Nothing is
-  recorded until a file is published with the flag set, so the first run adopts
-  the existing pages and everything from the second run onward is protected. A
-  rename made in that very first run is not.
 * Paths are keyed relative to the directory Mark runs in and with forward
   slashes, so `--files "$PWD/docs/*.md"` and `--files "docs/*.md"` share one
   mapping when run from the same place, as do a Windows workstation and Linux
@@ -1257,9 +1255,6 @@ are read in a single request and only the ones that changed are written back.
   absolute path.
 * `--track-pages` has no effect when publishing straight to a page ID, since the
   mapping is per space and per file and a page ID is neither.
-* On Server and Data Center, changing a space's homepage orphans its mapping and
-  tracking starts over on the next run. That costs the rename protection until
-  it is rebuilt, and nothing else -- no page is modified by it.
 
 ## Issues, Bugs & Contributions
 

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -925,7 +925,40 @@ func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, ve
 
 	page.Version.Number = nextPageVersion
 	api.updateCachedPageVersion(page.ID, nextPageVersion)
+
+	// An update can carry a new title, and the cache is keyed by title. A
+	// lookup of the new title earlier in the same run -- before the page wore
+	// it -- cached a miss, and that miss now outlives the fact that produced
+	// it: the next caller is told the page does not exist and tries to create
+	// one, which Confluence rejects as a duplicate title. Dropping the entry
+	// costs one lookup and keeps the cache from asserting something untrue.
+	api.forgetMissesForTitle(page.Title, page.Type)
 	return nil
+}
+
+// forgetMissesForTitle drops cached "no such page" answers for a title.
+//
+// The cache is keyed by title, and a lookup of a title before any page wore it
+// records a miss. An update that moves a page onto that title outlives the fact
+// the miss was recorded from: the next caller is told the page does not exist,
+// tries to create one, and Confluence rejects the duplicate title.
+//
+// Only misses are dropped. A cached page filed under a title it no longer
+// carries is a different and older question, and one this is not the place to
+// answer. The space is not part of the match because PageInfo does not carry
+// one; over-invalidating costs a lookup, and under-invalidating costs a failed
+// publish.
+func (api *API) forgetMissesForTitle(title, pageType string) {
+	api.lazyInit()
+	api.pageCacheMutex.Lock()
+	defer api.pageCacheMutex.Unlock()
+
+	suffix := "\x00" + title + "\x00" + pageType
+	for key, entry := range api.pageCache {
+		if entry == nil && strings.HasSuffix(key, suffix) {
+			delete(api.pageCache, key)
+		}
+	}
 }
 
 func (api *API) AddPageLabels(page *PageInfo, newLabels []string) (*LabelInfo, error) {
@@ -1462,6 +1495,11 @@ func (api *API) MoveContentAppend(contentID, targetID string) error {
 	}
 }
 
+// ErrNotFound reports that Confluence answered 404. It is a sentinel so a
+// caller can distinguish "the thing is not there" -- which is often an ordinary
+// state rather than a failure -- from every other way a request can go wrong.
+var ErrNotFound = errors.New("404 (Not Found)")
+
 func newErrorStatusNotOK(request *gopencils.Resource) error {
 	defer func() {
 		_ = request.Raw.Body.Close()
@@ -1474,8 +1512,11 @@ func newErrorStatusNotOK(request *gopencils.Resource) error {
 	}
 
 	if request.Raw.StatusCode == http.StatusNotFound {
-		return errors.New(
-			"the Confluence API returned unexpected status: 404 (Not Found)",
+		// Wrapped rather than a bare string so callers that need to act on
+		// "this is gone" specifically can ask with errors.Is instead of
+		// matching on the message. The rendered text is unchanged.
+		return fmt.Errorf(
+			"the Confluence API returned unexpected status: %w", ErrNotFound,
 		)
 	}
 

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -51,6 +51,16 @@ type InlineComment struct {
 	Selection string
 }
 
+// Folder is a Confluence folder. Folders are a Cloud-only, v2-only concept.
+type Folder struct {
+	ID         string
+	Title      string
+	SpaceID    string
+	SpaceKey   string
+	ParentID   string
+	ParentType string
+}
+
 // Space is a Confluence space. HomepageID may be empty.
 type Space struct {
 	ID         string
@@ -86,6 +96,8 @@ type Server struct {
 	pages       map[string]*Page
 	spaces      map[string]*Space
 	attachments []*Attachment
+	properties  []*SpaceProperty
+	folders     []*Folder
 	comments    map[string][]InlineComment
 	users       []User
 	currentUser User
@@ -184,6 +196,69 @@ func (s *Server) AddPage(spaceKey, title, pageType, parentID string) *Page {
 	}
 	s.pages[p.ID] = p
 	return p
+}
+
+// AddFolder registers a folder and returns it. Pass an empty parentID for one
+// hanging directly off a page anchor.
+func (s *Server) AddFolder(spaceKey, title, parentID, parentType string) *Folder {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.spaces[spaceKey]; !ok {
+		s.spaces[spaceKey] = &Space{ID: s.newID(), Key: spaceKey}
+	}
+	f := &Folder{
+		ID:         s.newID(),
+		Title:      title,
+		SpaceID:    s.spaces[spaceKey].ID,
+		SpaceKey:   spaceKey,
+		ParentID:   parentID,
+		ParentType: parentType,
+	}
+	s.folders = append(s.folders, f)
+	return f
+}
+
+// Folder returns the stored folder with the given ID, or nil.
+func (s *Server) Folder(id string) *Folder {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, f := range s.folders {
+		if f.ID == id {
+			cp := *f
+			return &cp
+		}
+	}
+	return nil
+}
+
+// RenameFolder retitles a folder, as somebody doing it in the Confluence UI
+// would -- which is the case mark cannot see coming.
+func (s *Server) RenameFolder(id, title string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, f := range s.folders {
+		if f.ID == id {
+			f.Title = title
+		}
+	}
+}
+
+// Folders returns every stored folder.
+func (s *Server) Folders() []Folder {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Folder, 0, len(s.folders))
+	for _, f := range s.folders {
+		out = append(out, *f)
+	}
+	return out
+}
+
+// DeletePage removes a page, as someone deleting it in the Confluence UI would.
+func (s *Server) DeletePage(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.pages, id)
 }
 
 // SetHomepage marks a page as the space homepage.
@@ -377,6 +452,12 @@ func (s *Server) handleV1(w http.ResponseWriter, r *http.Request, path string) {
 		})
 
 	case path == "/search/user" || path == "/search":
+		// The same endpoint serves user lookup and the CQL folder search; the
+		// query says which.
+		if strings.Contains(r.URL.Query().Get("cql"), "type=folder") {
+			s.searchFolder(w, r)
+			return
+		}
 		s.searchUser(w, r)
 
 	case strings.HasPrefix(path, "/space/"):
@@ -395,8 +476,15 @@ func (s *Server) handleV1(w http.ResponseWriter, r *http.Request, path string) {
 			s.updateAttachment(w, r, id)
 		case sub == "child/comment":
 			s.childComment(w, r, id)
+		case strings.HasPrefix(sub, "move/append/"):
+			s.moveContent(w, r, id, strings.TrimPrefix(sub, "move/append/"))
 		case sub == "label":
 			s.label(w, r, id)
+		case sub == "property":
+			// v1 content properties: POST creates, GET without a key lists.
+			s.contentProperties(w, r, id, "")
+		case strings.HasPrefix(sub, "property/"):
+			s.contentProperties(w, r, id, strings.TrimPrefix(sub, "property/"))
 		case sub == "restriction" || strings.HasPrefix(sub, "restriction"):
 			writeJSON(w, http.StatusOK, map[string]any{"results": []any{}})
 		default:
@@ -432,8 +520,287 @@ func (s *Server) handleV2(w http.ResponseWriter, r *http.Request, path string) {
 			return results[i]["key"].(string) < results[j]["key"].(string)
 		})
 		writeJSON(w, http.StatusOK, map[string]any{"results": results})
+	case "/folders":
+		s.createFolder(w, r)
+
+	case "/pages":
+		s.createPageV2(w, r)
+
 	default:
+		if folderID, ok := strings.CutPrefix(path, "/folders/"); ok && r.Method == http.MethodGet {
+			s.getFolder(w, folderID)
+			return
+		}
+		// /spaces/{id}/properties and /spaces/{id}/properties/{propertyID}
+		if rest, ok := strings.CutPrefix(path, "/spaces/"); ok {
+			spaceID, sub, _ := strings.Cut(rest, "/")
+			if propertyID, ok := strings.CutPrefix(sub, "properties"); ok {
+				s.spaceProperties(w, r, spaceID, strings.TrimPrefix(propertyID, "/"))
+				return
+			}
+		}
 		http.NotFound(w, r)
+	}
+}
+
+// SpaceProperty is a key/value pair held against a space (v2) or a page (v1).
+// OwnerID is the space id or the content id accordingly; the fake stores both
+// kinds in one list because nothing distinguishes them but the route.
+type SpaceProperty struct {
+	ID      string
+	OwnerID string
+	Key     string
+	Value   json.RawMessage
+	Version int
+}
+
+// SpaceProperty returns the property stored for a space under key, or nil.
+func (s *Server) SpaceProperty(ownerID, key string) *SpaceProperty {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, p := range s.properties {
+		if p.OwnerID == ownerID && p.Key == key {
+			cp := *p
+			return &cp
+		}
+	}
+	return nil
+}
+
+// SetSpaceProperty seeds a property without going through HTTP.
+func (s *Server) SetSpaceProperty(ownerID, key string, value []byte) *SpaceProperty {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, p := range s.properties {
+		if p.OwnerID == ownerID && p.Key == key {
+			p.Value = append(json.RawMessage(nil), value...)
+			p.Version++
+			cp := *p
+			return &cp
+		}
+	}
+	p := &SpaceProperty{
+		ID:      s.newID(),
+		OwnerID: ownerID,
+		Key:     key,
+		Value:   append(json.RawMessage(nil), value...),
+		Version: 1,
+	}
+	s.properties = append(s.properties, p)
+	cp := *p
+	return &cp
+}
+
+// contentProperties serves the v1 content property API, which differs from the
+// v2 space one in two ways that matter: a read of a single key returns the
+// property object directly rather than a collection, and an update addresses it
+// by key rather than by property id.
+// moveContent reparents a page, which is how mark puts an existing page inside
+// a folder.
+func (s *Server) moveContent(w http.ResponseWriter, r *http.Request, contentID, targetID string) {
+	if r.Method != http.MethodPut {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	p, ok := s.pages[contentID]
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]any{"message": "no such content"})
+		return
+	}
+
+	// The target may be a folder or another page; the fake only has to record
+	// that the move happened.
+	p.ParentID = targetID
+	writeJSON(w, http.StatusOK, map[string]any{"id": p.ID})
+}
+
+func (s *Server) contentProperties(w http.ResponseWriter, r *http.Request, contentID, key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	propertyJSON := func(p *SpaceProperty) map[string]any {
+		return map[string]any{
+			"id":      p.ID,
+			"key":     p.Key,
+			"value":   p.Value,
+			"version": map[string]any{"number": p.Version},
+		}
+	}
+
+	find := func(k string) *SpaceProperty {
+		for _, p := range s.properties {
+			if p.OwnerID == contentID && p.Key == k {
+				return p
+			}
+		}
+		return nil
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		if key == "" {
+			results := []map[string]any{}
+			for _, p := range s.properties {
+				if p.OwnerID == contentID {
+					results = append(results, propertyJSON(p))
+				}
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"results": results})
+			return
+		}
+		p := find(key)
+		if p == nil {
+			writeJSON(w, http.StatusNotFound, map[string]any{"message": "no such property"})
+			return
+		}
+		writeJSON(w, http.StatusOK, propertyJSON(p))
+
+	case http.MethodPost:
+		var payload struct {
+			Key   string          `json:"key"`
+			Value json.RawMessage `json:"value"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"message": "bad payload"})
+			return
+		}
+		if find(payload.Key) != nil {
+			writeJSON(w, http.StatusConflict, map[string]any{"message": "property already exists"})
+			return
+		}
+		p := &SpaceProperty{
+			ID:      s.newID(),
+			OwnerID: contentID,
+			Key:     payload.Key,
+			Value:   payload.Value,
+			Version: 1,
+		}
+		s.properties = append(s.properties, p)
+		writeJSON(w, http.StatusOK, propertyJSON(p))
+
+	case http.MethodPut:
+		var payload struct {
+			ID      string          `json:"id"`
+			Key     string          `json:"key"`
+			Value   json.RawMessage `json:"value"`
+			Version struct {
+				Number int `json:"number"`
+			} `json:"version"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"message": "bad payload"})
+			return
+		}
+		// Atlassian documents the property id as required on this endpoint, so
+		// the fake insists on it. A fake that is more forgiving than the real
+		// thing is worse than no fake: it certifies code that cannot work.
+		if payload.ID == "" {
+			writeJSON(w, http.StatusBadRequest,
+				map[string]any{"message": "id is required when updating a content property"})
+			return
+		}
+		p := find(key)
+		if p == nil {
+			writeJSON(w, http.StatusNotFound, map[string]any{"message": "no such property"})
+			return
+		}
+		if payload.Version.Number != p.Version+1 {
+			writeJSON(w, http.StatusConflict, map[string]any{"message": "version conflict"})
+			return
+		}
+		p.Value = payload.Value
+		p.Version = payload.Version.Number
+		writeJSON(w, http.StatusOK, propertyJSON(p))
+
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) spaceProperties(w http.ResponseWriter, r *http.Request, ownerID, propertyID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	propertyJSON := func(p *SpaceProperty) map[string]any {
+		return map[string]any{
+			"id":      p.ID,
+			"key":     p.Key,
+			"value":   p.Value,
+			"version": map[string]any{"number": p.Version},
+		}
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		key := r.URL.Query().Get("key")
+		results := []map[string]any{}
+		for _, p := range s.properties {
+			if p.OwnerID == ownerID && (key == "" || p.Key == key) {
+				results = append(results, propertyJSON(p))
+			}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"results": results})
+
+	case http.MethodPost:
+		var payload struct {
+			Key   string          `json:"key"`
+			Value json.RawMessage `json:"value"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"message": "bad payload"})
+			return
+		}
+		for _, p := range s.properties {
+			if p.OwnerID == ownerID && p.Key == payload.Key {
+				writeJSON(w, http.StatusConflict, map[string]any{"message": "property already exists"})
+				return
+			}
+		}
+		p := &SpaceProperty{
+			ID:      s.newID(),
+			OwnerID: ownerID,
+			Key:     payload.Key,
+			Value:   payload.Value,
+			Version: 1,
+		}
+		s.properties = append(s.properties, p)
+		writeJSON(w, http.StatusCreated, propertyJSON(p))
+
+	case http.MethodPut:
+		var payload struct {
+			Key     string          `json:"key"`
+			Value   json.RawMessage `json:"value"`
+			Version struct {
+				Number int `json:"number"`
+			} `json:"version"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"message": "bad payload"})
+			return
+		}
+		for _, p := range s.properties {
+			if p.ID != propertyID || p.OwnerID != ownerID {
+				continue
+			}
+			// Confluence versions properties: an update has to name the version
+			// it supersedes, and a stale one loses.
+			if payload.Version.Number != p.Version+1 {
+				writeJSON(w, http.StatusConflict, map[string]any{"message": "version conflict"})
+				return
+			}
+			p.Value = payload.Value
+			p.Version = payload.Version.Number
+			writeJSON(w, http.StatusOK, propertyJSON(p))
+			return
+		}
+		writeJSON(w, http.StatusNotFound, map[string]any{"message": "no such property"})
+
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
 }
 
@@ -782,6 +1149,174 @@ func (s *Server) label(w http.ResponseWriter, r *http.Request, pageID string) {
 		"results": page,
 		"number":  len(page),
 		"_links":  linksWithNext(hasNext),
+	})
+}
+
+// cqlValue pulls a quoted or bare value for a field out of a CQL string. The
+// fake only needs to understand the handful of clauses mark actually sends.
+func cqlValue(cql, field string) string {
+	rest, ok := strings.CutPrefix(cql[max(strings.Index(cql, field+"="), 0):], field+"=")
+	if !ok || !strings.Contains(cql, field+"=") {
+		return ""
+	}
+	if quoted, ok := strings.CutPrefix(rest, `"`); ok {
+		if end := strings.Index(quoted, `"`); end >= 0 {
+			return strings.ReplaceAll(quoted[:end], `\"`, `"`)
+		}
+		return ""
+	}
+	if end := strings.IndexAny(rest, " )"); end >= 0 {
+		return rest[:end]
+	}
+	return rest
+}
+
+func (s *Server) searchFolder(w http.ResponseWriter, r *http.Request) {
+	cql := r.URL.Query().Get("cql")
+	title := cqlValue(cql, "title")
+	spaceKey := cqlValue(cql, "space")
+	ancestor := cqlValue(cql, "ancestor")
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	results := []map[string]any{}
+	for _, f := range s.folders {
+		if f.Title != title || (spaceKey != "" && f.SpaceKey != spaceKey) {
+			continue
+		}
+		if ancestor != "" && f.ParentID != ancestor {
+			continue
+		}
+		results = append(results, map[string]any{
+			"content": map[string]any{"id": f.ID, "type": "folder", "title": f.Title},
+		})
+		break
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}
+
+func (s *Server) folderJSON(f *Folder) map[string]any {
+	return map[string]any{
+		"id":         f.ID,
+		"type":       "folder",
+		"status":     "current",
+		"title":      f.Title,
+		"spaceId":    f.SpaceID,
+		"parentId":   f.ParentID,
+		"parentType": f.ParentType,
+	}
+}
+
+func (s *Server) getFolder(w http.ResponseWriter, folderID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, f := range s.folders {
+		if f.ID == folderID {
+			writeJSON(w, http.StatusOK, s.folderJSON(f))
+			return
+		}
+	}
+	writeJSON(w, http.StatusNotFound, map[string]any{"message": "no such folder"})
+}
+
+func (s *Server) createFolder(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var payload struct {
+		SpaceID    string `json:"spaceId"`
+		Title      string `json:"title"`
+		ParentID   string `json:"parentId"`
+		ParentType string `json:"parentType"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"message": "bad payload"})
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	spaceKey := ""
+	for _, sp := range s.spaces {
+		if sp.ID == payload.SpaceID {
+			spaceKey = sp.Key
+		}
+	}
+
+	// Confluence rejects a second folder with the same title under one parent,
+	// which is what makes a stranded reference visible rather than silent.
+	for _, f := range s.folders {
+		if f.Title == payload.Title && f.ParentID == payload.ParentID && f.SpaceID == payload.SpaceID {
+			writeJSON(w, http.StatusBadRequest,
+				map[string]any{"message": "A folder exists with the same title"})
+			return
+		}
+	}
+
+	f := &Folder{
+		ID:         s.newID(),
+		Title:      payload.Title,
+		SpaceID:    payload.SpaceID,
+		SpaceKey:   spaceKey,
+		ParentID:   payload.ParentID,
+		ParentType: payload.ParentType,
+	}
+	s.folders = append(s.folders, f)
+	writeJSON(w, http.StatusOK, s.folderJSON(f))
+}
+
+// createPageV2 serves the v2 page create mark uses when the parent is a folder.
+func (s *Server) createPageV2(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var payload struct {
+		SpaceID  string `json:"spaceId"`
+		Title    string `json:"title"`
+		ParentID string `json:"parentId"`
+		Body     struct {
+			Storage struct {
+				Value string `json:"value"`
+			} `json:"storage"`
+		} `json:"body"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"message": "bad payload"})
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	spaceKey := ""
+	for _, sp := range s.spaces {
+		if sp.ID == payload.SpaceID {
+			spaceKey = sp.Key
+		}
+	}
+
+	p := &Page{
+		ID:       s.newID(),
+		Title:    payload.Title,
+		Type:     "page",
+		SpaceKey: spaceKey,
+		ParentID: payload.ParentID,
+		Version:  1,
+		Body:     payload.Body.Storage.Value,
+	}
+	s.pages[p.ID] = p
+	// The version has to come back. Without it the caller computes the version
+	// it is superseding from zero, and its first update is rejected as stale.
+	writeJSON(w, http.StatusOK, map[string]any{
+		"id":      p.ID,
+		"title":   p.Title,
+		"type":    "page",
+		"version": map[string]any{"number": p.Version},
+		"_links":  map[string]any{"webui": "/display/" + spaceKey + "/" + p.ID},
 	})
 }
 

--- a/confluence/property.go
+++ b/confluence/property.go
@@ -1,0 +1,188 @@
+package confluence
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/kovetskiy/gopencils"
+)
+
+// Property is a key/value pair Confluence stores against a space or a page.
+//
+// The value is held as raw JSON because callers own its shape; this package
+// stores and returns bytes without interpreting them.
+//
+// Version matters: Confluence versions properties, and an update must name the
+// version it supersedes. A stale one draws a 409, which is how two concurrent
+// writers find out about each other instead of silently overwriting.
+type Property struct {
+	ID      string          `json:"id"`
+	Key     string          `json:"key"`
+	Value   json.RawMessage `json:"value"`
+	Version struct {
+		Number int `json:"number"`
+	} `json:"version"`
+}
+
+// propertyPageSize is requested when listing properties. Callers here hold a
+// small fixed number of them, so one page is always enough and no pagination
+// loop is needed; asking explicitly keeps that true regardless of what the
+// server's default page size happens to be.
+const propertyPageSize = "100"
+
+// ErrPropertyConflict reports that a property write lost a race with another
+// writer. It is separate from a generic error so a caller can re-read and retry
+// on exactly this case and nothing else.
+var ErrPropertyConflict = errors.New("property version conflict")
+
+// ListSpaceProperties returns every property stored against a space.
+//
+// Space properties exist only in the v2 API, which means Cloud only. Server and
+// Data Center have no equivalent; see ListContentProperties for what stands in
+// there.
+//
+// The whole collection is fetched rather than one key at a time because a
+// caller holding several related properties would otherwise pay a request per
+// key. A space with none is not an error: the first run of anything that stores
+// state this way finds nothing, and that is the normal case.
+func (api *API) ListSpaceProperties(spaceID string) ([]Property, error) {
+	var result struct {
+		Results []Property `json:"results"`
+	}
+
+	request, err := api.restV2.
+		Res("spaces").
+		Res(spaceID).
+		Res("properties", &result).
+		Get(map[string]string{"limit": propertyPageSize})
+	if err != nil {
+		return nil, fmt.Errorf("unable to read properties of space %s: %w", spaceID, err)
+	}
+
+	// A space with no properties at all answers 404 rather than an empty
+	// collection, so both shapes have to mean "none set".
+	if request.Raw.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
+	if request.Raw.StatusCode != http.StatusOK {
+		return nil, newErrorStatusNotOK(request)
+	}
+
+	return result.Results, nil
+}
+
+// SetSpaceProperty writes value to a space property, creating it if absent.
+func (api *API) SetSpaceProperty(spaceID, key string, value []byte, existing *Property) error {
+	payload := map[string]any{
+		"key":   key,
+		"value": json.RawMessage(value),
+	}
+
+	var (
+		result  Property
+		request *gopencils.Resource
+		err     error
+	)
+
+	space := api.restV2.Res("spaces").Res(spaceID)
+
+	if existing == nil {
+		// The result pointer goes on the collection resource itself: routing it
+		// through a further Res("") would append a trailing slash, which this
+		// API is not reliably forgiving about.
+		request, err = space.Res("properties", &result).Post(payload)
+	} else {
+		// v2 addresses an update by property id.
+		payload["version"] = map[string]any{"number": existing.Version.Number + 1}
+		request, err = space.Res("properties").Res(existing.ID, &result).Put(payload)
+	}
+	if err != nil {
+		return fmt.Errorf("unable to write property %q of space %s: %w", key, spaceID, err)
+	}
+
+	return propertyWriteResult(request, key, "space "+spaceID)
+}
+
+// ListContentProperties returns every property stored against a page.
+//
+// Unlike space properties this is a v1 endpoint, present on Server and Data
+// Center as well as Cloud, which is what makes it usable as the storage of last
+// resort on a non-Cloud instance.
+func (api *API) ListContentProperties(contentID string) ([]Property, error) {
+	var result struct {
+		Results []Property `json:"results"`
+	}
+
+	request, err := api.rest.
+		Res("content").
+		Res(contentID).
+		Res("property", &result).
+		Get(map[string]string{"limit": propertyPageSize})
+	if err != nil {
+		return nil, fmt.Errorf("unable to read properties of content %s: %w", contentID, err)
+	}
+
+	if request.Raw.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
+	if request.Raw.StatusCode != http.StatusOK {
+		return nil, newErrorStatusNotOK(request)
+	}
+
+	return result.Results, nil
+}
+
+// SetContentProperty writes value to a page property, creating it if absent.
+func (api *API) SetContentProperty(contentID, key string, value []byte, existing *Property) error {
+	payload := map[string]any{
+		"key":   key,
+		"value": json.RawMessage(value),
+	}
+
+	var (
+		result  Property
+		request *gopencils.Resource
+		err     error
+	)
+
+	content := api.rest.Res("content").Res(contentID)
+
+	if existing == nil {
+		request, err = content.Res("property", &result).Post(payload)
+	} else {
+		// v1 addresses an update by key in the path, but still wants the
+		// property id in the body, and the version being moved to rather than
+		// the one being replaced. Atlassian documents both as required; omitting
+		// the id is the kind of thing a fake will happily accept and a real
+		// instance will not.
+		payload["id"] = existing.ID
+		payload["version"] = map[string]any{"number": existing.Version.Number + 1}
+		request, err = content.Res("property").Res(key, &result).Put(payload)
+	}
+	if err != nil {
+		return fmt.Errorf("unable to write property %q of content %s: %w", key, contentID, err)
+	}
+
+	return propertyWriteResult(request, key, "content "+contentID)
+}
+
+// propertyWriteResult turns a property write response into an error, singling
+// out the version conflict so a caller can react to losing a race and nothing
+// else.
+func propertyWriteResult(request *gopencils.Resource, key, subject string) error {
+	switch request.Raw.StatusCode {
+	case http.StatusOK, http.StatusCreated:
+		return nil
+	case http.StatusConflict:
+		return fmt.Errorf(
+			"property %q of %s was modified concurrently: %w",
+			key, subject, ErrPropertyConflict,
+		)
+	default:
+		return newErrorStatusNotOK(request)
+	}
+}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -1,0 +1,891 @@
+// Package manifest records which Confluence page each source file publishes to,
+// so that a page can be found again after its title changes.
+//
+// mark identifies a page by its title. That title is derived from three
+// independently mutable things -- the `Title` header, the leading H1, and the
+// filename -- so editing any of them makes the existing page unfindable and mark
+// publishes a second one beside it. The fix is to stop asking "what is this
+// page called" and start asking "which page did this file publish to last
+// time", which needs somewhere to remember the answer.
+//
+// The mapping lives in Confluence rather than in the repository, keyed on the
+// source path. Nothing is written back to the working tree.
+//
+// # Where it is kept
+//
+// On Cloud, a space property. On Server and Data Center, which have no such
+// thing -- space properties exist only in the v2 API -- a content property on
+// the space homepage instead.
+//
+// Whatever holds it has to be reachable from a space key alone, with no search.
+// That rules out the arrangement that first suggests itself, a property on each
+// page naming its own source file: content properties are not CQL-searchable
+// without a Connect or Forge app, so finding the property that names a page id
+// would require already knowing that page id. A single manifest is reachable
+// either way -- a space by its key, a homepage through FindHomePage.
+//
+// Cloud keeps the space property rather than using the homepage for both,
+// because content properties are a v1 endpoint and v1 is exactly what a scoped
+// API token cannot reach. Cloud has a v2 option; it should not inherit that
+// failure mode for no reason.
+//
+// Anchoring to the homepage on Server does mean a space whose homepage is
+// changed loses its manifest and starts tracking over. That costs the rename
+// protection until the next run rebuilds it, and nothing else -- no page is
+// touched by it.
+//
+// Labels are the other candidate, and are searchable, but they are visible in
+// the UI and any reader can remove them. Identity a passer-by can delete is not
+// identity.
+//
+// # Why it is split
+//
+// Confluence bounds the size of a property value. A single blob would therefore
+// impose a ceiling on how many files a repository may have -- and would fail by
+// publishing every page and then erroring on the write, which is the worst
+// moment to find out. The mapping is spread over a fixed set of properties
+// instead, each holding the paths that hash to it, so the bound applies per
+// shard rather than to the repository.
+//
+// Each entry holds the page id and the title the path was last published under.
+// The title is not decoration: mark resolves parent pages and ancestry by
+// title, so a page being renamed strands every reference to its old name, and
+// the recorded title is the only way to connect the two.
+package manifest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/rs/zerolog/log"
+)
+
+// Key normalises a path or glob into the form the mapping is keyed by.
+//
+// The key has to mean the same thing wherever mark is run from, and the paths
+// it is handed do not: a glob of "$PWD/docs/*.md" yields absolute paths and one
+// of "docs/*.md" yields relative ones, for exactly the same files. Keyed as
+// given, a CI job and a developer keep two disjoint mappings of one repository,
+// neither aware of the other, and an absolute key additionally embeds a
+// checkout directory that does not survive being moved.
+//
+// Anything at or below the working directory is stored relative to it, which
+// makes the two forms agree whenever they are run from the same place -- the
+// case that actually happens. A path outside it has no better anchor available
+// and is kept as it came: mark has no notion of a project root to measure from,
+// and inventing one from the glob would move every key the first time somebody
+// widened it.
+func Key(path string) string {
+	cleaned := filepath.Clean(path)
+
+	if filepath.IsAbs(cleaned) {
+		if cwd, err := os.Getwd(); err == nil {
+			rel, err := filepath.Rel(cwd, cleaned)
+			if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				cleaned = rel
+			}
+		}
+	}
+
+	// Stored with forward slashes whatever the platform. The separator is a
+	// property of the machine, not of the repository, and leaving it in would
+	// give a team publishing from Windows and from Linux CI two entries for
+	// every file -- the same split this function exists to close, along a
+	// different axis.
+	return filepath.ToSlash(cleaned)
+}
+
+// PropertyKeyPrefix is the common prefix of the properties the manifest is
+// stored under. Each shard is this plus a dot and its index.
+const PropertyKeyPrefix = "mark.manifest"
+
+// FolderPropertyKey holds the folder mapping.
+//
+// Kept apart from the page shards rather than mixed in: folders are keyed by
+// the titles declared in a header rather than by a source path, they are few
+// enough that splitting them buys nothing, and a folder key appearing among the
+// page keys would be reported as a source file that had gone missing.
+const FolderPropertyKey = PropertyKeyPrefix + ".folders"
+
+// ShardCount is how many properties the mapping is spread over.
+//
+// Fixed rather than grown on demand: the shard a path belongs to is derived
+// from the path, so changing the count would move every entry and orphan the
+// lot. Sixteen keeps one page of a property listing sufficient to read them all
+// in a single request, while giving the per-property size bound sixteen times
+// the room a single blob had.
+const ShardCount = 16
+
+// shardSizeWarning is the encoded size at which a shard is reported as getting
+// large.
+//
+// This is not Confluence's limit. The real cap is a property of the instance
+// and not something this code can know, so the number here is a conservative
+// point at which to say something while there is still room to act, rather than
+// a boundary that is enforced.
+const shardSizeWarning = 24 * 1024
+
+// PropertyKey returns the property key for a shard index.
+func PropertyKey(shard int) string {
+	return fmt.Sprintf("%s.%d", PropertyKeyPrefix, shard)
+}
+
+// shardIndex recovers a shard number from a property key, reporting false for
+// any key that is not one of ours -- a space or page may hold properties put
+// there by something else entirely.
+func shardIndex(key string) (int, bool) {
+	suffix, ok := strings.CutPrefix(key, PropertyKeyPrefix+".")
+	if !ok {
+		return 0, false
+	}
+	index, err := strconv.Atoi(suffix)
+	if err != nil || index < 0 || index >= ShardCount {
+		return 0, false
+	}
+	return index, true
+}
+
+// ShardFor reports which shard holds a path. Exported so a caller -- in
+// practice a test -- can find the property a given path's mapping lives in
+// without duplicating the hash.
+func ShardFor(path string) int { return shardFor(path) }
+
+// shardFor picks the shard a path belongs to.
+//
+// FNV rather than anything cryptographic: this only has to spread paths evenly,
+// and paths in a repository share long prefixes, which a checksum would smear
+// out but a truncation would not.
+func shardFor(path string) int {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(path))
+	return int(h.Sum32() % ShardCount)
+}
+
+// formatVersion guards the stored shape. A manifest written by a future mark
+// with a shape this one does not understand is ignored rather than
+// misinterpreted, which costs a run of title-based resolution instead of
+// corrupting the mapping.
+const formatVersion = 1
+
+// Entry is what one source file published to.
+//
+// Title is the title the path was last published under, which is not the same
+// as the page's title now -- the page may have been retitled since, and the
+// point of recording it is to notice exactly that. It is what lets a stale
+// reference to the old title be followed to the page that carries it; see
+// ResolveStaleTitle.
+type Entry struct {
+	PageID string `json:"pageId"`
+	Title  string `json:"title"`
+
+	// Hash fingerprints the document's source. It is what makes a renamed file
+	// recognisable: a rename changes the key, so the entry can only be found
+	// again by what it holds rather than by where it was.
+	Hash string `json:"hash,omitempty"`
+
+	// Glob is the --files pattern that published this path. Absence from a run
+	// only means the file is gone if the run was looking where the file would
+	// have been; a run narrowed to one directory says nothing about any other.
+	Glob string `json:"glob,omitempty"`
+}
+
+// folderDocument is the folder mapping as stored.
+type folderDocument struct {
+	Version int               `json:"version"`
+	Folders map[string]string `json:"folders"`
+}
+
+// document is one shard as stored.
+type document struct {
+	Version int              `json:"version"`
+	Pages   map[string]Entry `json:"pages"`
+}
+
+// Store is the manifest for one or more spaces, loaded lazily and written back
+// once at the end of a run.
+//
+// Spaces are loaded on first use rather than up front because which spaces a
+// run touches is only known as its files are read: the `Space` header is
+// per-document, so a single run can publish into several.
+type Store struct {
+	api *confluence.API
+
+	// mu guards everything below. Run publishes one file at a time today, so
+	// nothing contends -- but Store is reachable from exported entry points and
+	// an unsynchronised map is a hard throw rather than a wrong answer, which
+	// is a poor thing to leave for whoever parallelises publishing.
+	mu sync.Mutex
+
+	// runGlob is the pattern this run was given, recorded with each entry so a
+	// later run can tell whether it was looking where a missing file used to be.
+	runGlob string
+
+	// readOnly makes Save a no-op. A dry run has to resolve exactly as a real
+	// one does or its preview is fiction, but resolving records what it finds,
+	// and a recording would otherwise be written. Refusing at the point of
+	// writing is the only guard that holds however the store is used -- the
+	// alternative, not passing it to the parts that record, was tried and let a
+	// dry run write to Confluence.
+	readOnly bool
+
+	// runFiles is every path this run will publish, known up front because the
+	// whole file set is globbed before any of it is processed. A recorded path
+	// missing from it is either a deleted file or a renamed one, and telling
+	// those apart is the whole of rename detection.
+	runFiles map[string]bool
+
+	// spaces holds the manifest for each space key touched so far, alongside
+	// the property it was read from -- the version in that property is what a
+	// write has to supersede.
+	spaces map[string]*spaceState
+}
+
+type spaceState struct {
+	// backend is where this space's manifest lives. cloud reads and writes
+	// space properties addressed by spaceID; otherwise they are content
+	// properties on the homepage addressed by contentID.
+	cloud     bool
+	spaceID   string
+	contentID string
+
+	shards [ShardCount]shard
+
+	// byPage is the reverse of the mapping, used to notice two paths claiming
+	// the same page. Rebuilt on load and maintained by Record.
+	byPage map[string]string
+
+	// folders maps a declared folder path to the folder it resolved to, so a
+	// folder renamed in Confluence is found again instead of being recreated
+	// beside itself.
+	folders        map[string]string
+	folderProperty *confluence.Property
+	foldersDirty   bool
+
+	// titles maps the title each path was published under *as read*, and is
+	// deliberately never updated during a run. Resolving a stale reference asks
+	// "what did the last run call this page", and Record answers a different
+	// question -- so if this tracked the live map, a document processed after
+	// the page it points at would find the title already rewritten and the
+	// reference unresolvable. An empty page id marks a title that more than one
+	// path claimed, which is ambiguous and not followed.
+	titles map[string]string
+
+	// seen records the paths this run published, which is what makes the
+	// difference between "this file is gone" and "this run did not look at it".
+	seen map[string]bool
+
+	// claimed records pages already taken by a file this run, so a rename can
+	// never rebind onto a page another document is publishing to.
+	claimed map[string]bool
+}
+
+// shard is one property's worth of the mapping.
+type shard struct {
+	// property is what this shard was read from, and is what a write has to
+	// supersede. Nil means the property does not exist yet.
+	property *confluence.Property
+	pages    map[string]Entry
+	dirty    bool
+}
+
+// NewStore returns a Store that reads and writes through api.
+func NewStore(api *confluence.API) *Store {
+	return &Store{api: api, spaces: map[string]*spaceState{}, runFiles: map[string]bool{}}
+}
+
+// NewReadOnlyStore returns a Store that answers every question the writing one
+// does and never persists anything.
+func NewReadOnlyStore(api *confluence.API) *Store {
+	store := NewStore(api)
+	store.readOnly = true
+	return store
+}
+
+// SetRunFiles tells the store every path this run intends to publish.
+//
+// Without it a recorded path that is absent from the run cannot be told apart
+// from one the run simply did not cover, and nothing can be concluded from its
+// absence -- least of all that the file it names was renamed.
+func (s *Store) SetRunFiles(glob string, paths []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.runGlob = Key(glob)
+	s.runFiles = make(map[string]bool, len(paths))
+	for _, path := range paths {
+		s.runFiles[Key(path)] = true
+	}
+}
+
+// normaliseKeys rewrites entries stored under a key that predates
+// normalisation, so a mapping written by an earlier mark keeps working instead
+// of being silently abandoned.
+//
+// Without this an upgrade strands every entry: the lookup normalises, misses,
+// and the page is re-recorded under the new key, leaving the old one behind
+// with no pattern to report it and no fingerprint to match it -- dead weight
+// that arrives once per upgrade and never leaves.
+//
+// A normalised key can belong to a different shard than the one it was read
+// from, since the shard is derived from the key, so this cannot be done in
+// place while reading.
+func (state *spaceState) normaliseKeys() {
+	type move struct {
+		from, to string
+		entry    Entry
+	}
+
+	var moves []move
+	for i := range state.shards {
+		for path, entry := range state.shards[i].pages {
+			if key := Key(path); key != path {
+				moves = append(moves, move{from: path, to: key, entry: entry})
+			}
+		}
+	}
+
+	for _, m := range moves {
+		delete(state.shards[shardFor(m.from)].pages, m.from)
+		state.shards[shardFor(m.from)].dirty = true
+
+		// A normalised key already holding an entry means both forms were
+		// recorded, which is exactly the split being repaired. The one that was
+		// already normalised wins; it is the form everything writes now.
+		target := &state.shards[shardFor(m.to)]
+		if _, taken := target.pages[m.to]; !taken {
+			target.pages[m.to] = m.entry
+		}
+		target.dirty = true
+	}
+}
+
+// buildIndexes derives the reverse and title lookups from the loaded entries.
+func (state *spaceState) buildIndexes() {
+	for i := range state.shards {
+		for path, entry := range state.shards[i].pages {
+			state.byPage[entry.PageID] = path
+			if entry.Title == "" {
+				continue
+			}
+			if seen, ok := state.titles[entry.Title]; ok && seen != entry.PageID {
+				state.titles[entry.Title] = "" // ambiguous
+				continue
+			}
+			state.titles[entry.Title] = entry.PageID
+		}
+	}
+}
+
+// list fetches every property from whichever backend holds this space's
+// manifest. One request covers all shards.
+func (state *spaceState) list(api *confluence.API) ([]confluence.Property, error) {
+	if state.cloud {
+		return api.ListSpaceProperties(state.spaceID)
+	}
+	return api.ListContentProperties(state.contentID)
+}
+
+// write stores one shard in whichever backend holds this space's manifest.
+func (state *spaceState) write(api *confluence.API, index int, value []byte) error {
+	return state.writeProperty(api, PropertyKey(index), value, state.shards[index].property)
+}
+
+// writeProperty stores one property in whichever backend holds this space's
+// manifest.
+func (state *spaceState) writeProperty(
+	api *confluence.API, key string, value []byte, existing *confluence.Property,
+) error {
+	if state.cloud {
+		return api.SetSpaceProperty(state.spaceID, key, value, existing)
+	}
+	return api.SetContentProperty(state.contentID, key, value, existing)
+}
+
+// load returns the state for a space, reading it from Confluence on first use.
+func (s *Store) load(spaceKey string) (*spaceState, error) {
+	if state, ok := s.spaces[spaceKey]; ok {
+		return state, nil
+	}
+
+	state := &spaceState{
+		cloud:   s.api.IsCloud(),
+		byPage:  map[string]string{},
+		titles:  map[string]string{},
+		folders: map[string]string{},
+		seen:    map[string]bool{},
+		claimed: map[string]bool{},
+	}
+	for i := range state.shards {
+		state.shards[i].pages = map[string]Entry{}
+	}
+
+	var err error
+	if state.cloud {
+		state.spaceID, err = s.api.GetSpaceID(spaceKey)
+		if err != nil {
+			return nil, fmt.Errorf("unable to resolve space %q: %w", spaceKey, err)
+		}
+	} else {
+		homepage, err := s.api.FindHomePage(spaceKey)
+		if err != nil {
+			return nil, fmt.Errorf("unable to resolve home page of space %q: %w", spaceKey, err)
+		}
+		state.contentID = homepage.ID
+	}
+
+	properties, err := state.list(s.api)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range properties {
+		if properties[i].Key == FolderPropertyKey {
+			state.folderProperty = &properties[i]
+			var doc folderDocument
+			if err := json.Unmarshal(properties[i].Value, &doc); err != nil {
+				log.Warn().Err(err).Msgf(
+					"ignoring unreadable %s property of space %q; folders are no longer tracked",
+					FolderPropertyKey, spaceKey,
+				)
+			} else if doc.Version <= formatVersion && doc.Folders != nil {
+				state.folders = doc.Folders
+			}
+			continue
+		}
+
+		index, ok := shardIndex(properties[i].Key)
+		if !ok {
+			// Some other property of the same space or page. Not ours.
+			continue
+		}
+		state.shards[index].property = &properties[i]
+
+		var doc document
+		if err := json.Unmarshal(properties[i].Value, &doc); err != nil {
+			// A shard that cannot be parsed is treated as empty. Failing the run
+			// would let a corrupted property block publishing, where carrying on
+			// merely costs the rename protection for the paths it held until the
+			// next write repairs it.
+			log.Warn().Err(err).Msgf(
+				"ignoring unreadable %s property of space %q; those pages are no longer tracked",
+				properties[i].Key, spaceKey,
+			)
+			continue
+		}
+		if doc.Version > formatVersion {
+			log.Warn().Msgf(
+				"%s property of space %q was written by a newer mark (format %d); ignoring it",
+				properties[i].Key, spaceKey, doc.Version,
+			)
+			continue
+		}
+		if doc.Pages != nil {
+			state.shards[index].pages = doc.Pages
+		}
+	}
+
+	state.normaliseKeys()
+	state.buildIndexes()
+
+	s.spaces[spaceKey] = state
+	return state, nil
+}
+
+// Lookup returns the entry recorded for a source path, and whether one exists.
+//
+// Calling it marks the path as seen, so a path that is looked up but turns out
+// to have no entry still counts as present for the purposes of Orphans.
+func (s *Store) Lookup(spaceKey, path string) (Entry, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path = Key(path)
+
+	state, err := s.load(spaceKey)
+	if err != nil {
+		return Entry{}, false, err
+	}
+
+	state.seen[path] = true
+	entry, ok := state.shards[shardFor(path)].pages[path]
+	return entry, ok, nil
+}
+
+// Record notes which page a source path published to, under which title and
+// with what source fingerprint.
+func (s *Store) Record(spaceKey, path, pageID, title, hash string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path = Key(path)
+
+	state, err := s.load(spaceKey)
+	if err != nil {
+		return err
+	}
+
+	state.seen[path] = true
+
+	// Two paths claiming one page means one of them will lose: a rename of
+	// either retitles a page the other still believes is its own. mark cannot
+	// tell which was intended, so it says so and records the latest -- silently
+	// keeping one would make the next surprise harder to explain.
+	if owner, ok := state.byPage[pageID]; ok && owner != path {
+		log.Warn().Msgf(
+			"%s and %s both publish to page %s in space %q; "+
+				"renaming either will move a page the other also claims",
+			owner, path, pageID, spaceKey,
+		)
+	}
+
+	// The same path recorded in another space means the document moved between
+	// spaces. The page left behind is not deleted and not linked to the new one.
+	for otherKey, other := range s.spaces {
+		if otherKey == spaceKey {
+			continue
+		}
+		if entry, ok := other.shards[shardFor(path)].pages[path]; ok {
+			log.Warn().Msgf(
+				"%s previously published to space %q as page %s and now publishes to %q; "+
+					"the page in %q is left behind",
+				path, otherKey, entry.PageID, spaceKey, otherKey,
+			)
+		}
+	}
+
+	state.claimed[pageID] = true
+
+	sh := &state.shards[shardFor(path)]
+	existing, ok := sh.pages[path]
+	if ok && existing.PageID == pageID && existing.Title == title &&
+		existing.Hash == hash && existing.Glob == s.runGlob {
+		return nil
+	}
+
+	sh.pages[path] = Entry{PageID: pageID, Title: title, Hash: hash, Glob: s.runGlob}
+	state.byPage[pageID] = path
+	sh.dirty = true
+	return nil
+}
+
+// ResolveRenamed reports the page a document published to under a previous
+// path, for a document whose own path is not recorded.
+//
+// A rename changes the key, so the entry cannot be found by where it was; the
+// only thing connecting the two is what the document contains. Candidates are
+// restricted to recorded paths this run is not publishing -- a path that is
+// still in the run belongs to a file that still exists, and matching against it
+// would rebind two documents onto one page.
+//
+// Deliberately unforgiving. A match must be unique, and the page must not
+// already be claimed by another document this run. Anything else returns
+// nothing and a new page is created: a duplicate is a nuisance, where rebinding
+// onto the wrong page overwrites a document nobody asked to change.
+func (s *Store) ResolveRenamed(spaceKey, hash string) (string, Entry, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if hash == "" {
+		return "", Entry{}, false, nil
+	}
+
+	state, err := s.load(spaceKey)
+	if err != nil {
+		return "", Entry{}, false, err
+	}
+
+	var (
+		foundPath  string
+		foundEntry Entry
+		count      int
+	)
+	for i := range state.shards {
+		for path, entry := range state.shards[i].pages {
+			if entry.Hash != hash || s.runFiles[path] || state.claimed[entry.PageID] {
+				continue
+			}
+			foundPath, foundEntry = path, entry
+			count++
+		}
+	}
+
+	if count != 1 {
+		if count > 1 {
+			log.Info().Msgf(
+				"%d unpublished documents in space %q share this document's content; "+
+					"not treating any of them as its previous name",
+				count, spaceKey,
+			)
+		}
+		return "", Entry{}, false, nil
+	}
+
+	return foundPath, foundEntry, true, nil
+}
+
+// Forget drops a recorded path, used when a document has been followed to its
+// new name and the old entry would otherwise linger as a deleted file forever.
+func (s *Store) Forget(spaceKey, path string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path = Key(path)
+
+	state, err := s.load(spaceKey)
+	if err != nil {
+		return err
+	}
+
+	sh := &state.shards[shardFor(path)]
+	if _, ok := sh.pages[path]; !ok {
+		return nil
+	}
+
+	delete(sh.pages, path)
+	sh.dirty = true
+	return nil
+}
+
+// ResolveStaleTitle reports the page that a title used to belong to, for a
+// title that no longer resolves.
+//
+// mark names parent pages by title, so renaming a page strands every reference
+// to its old name: the lookup finds nothing, and an empty page is created under
+// the old title with the real one's children moved beneath it. The manifest
+// knows the title each path was last published under, so a reference to a title
+// mark itself published can be followed to the page that now carries it.
+//
+// Returns the page id and true only when exactly one path was published under
+// the title. More than one is ambiguous and is left alone.
+//
+// The answer comes from what was read at the start of the run, not from what
+// has been recorded during it. A document is resolved against the state its
+// author was looking at, which is also the only state in which the old title
+// still exists.
+func (s *Store) ResolveStaleTitle(spaceKey, title string) (string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if title == "" {
+		return "", false, nil
+	}
+
+	// The error is returned rather than folded into "nothing known". A manifest
+	// that cannot be read is not the same as a title that was never published,
+	// and treating it as such would create a duplicate page because the network
+	// hiccuped -- the exact confusion this package exists to avoid.
+	state, err := s.load(spaceKey)
+	if err != nil {
+		return "", false, err
+	}
+
+	pageID, ok := state.titles[title]
+	return pageID, ok && pageID != "", nil
+}
+
+// RecordFolder notes which Confluence folder a declared folder path resolved
+// to. The path is the chain of titles from the document's headers, joined so
+// that the same chain under a different ancestor is a different key.
+func (s *Store) RecordFolder(spaceKey, folderPath, folderID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, err := s.load(spaceKey)
+	if err != nil {
+		return err
+	}
+
+	if existing, ok := state.folders[folderPath]; ok && existing == folderID {
+		return nil
+	}
+
+	state.folders[folderPath] = folderID
+	state.foldersDirty = true
+	return nil
+}
+
+// LookupFolder returns the folder a declared folder path resolved to last time.
+func (s *Store) LookupFolder(spaceKey, folderPath string) (string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, err := s.load(spaceKey)
+	if err != nil {
+		return "", false, err
+	}
+
+	folderID, ok := state.folders[folderPath]
+	return folderID, ok, nil
+}
+
+// Orphans returns the recorded paths this run was looking for and did not find.
+//
+// Only entries published by the same --files pattern count. A run narrowed to
+// one directory says nothing about any other, and reporting everything outside
+// it as missing -- which an unscoped version does -- buries the handful of
+// genuine deletions in a list of files that are perfectly present. Entries with
+// no recorded pattern predate this and are never reported, because there is no
+// way to know what they were in scope of.
+func (s *Store) Orphans(spaceKey string) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.orphans(spaceKey)
+}
+
+// orphans is Orphans without the lock, for callers that already hold it.
+func (s *Store) orphans(spaceKey string) []string {
+	state, ok := s.spaces[spaceKey]
+	if !ok {
+		return nil
+	}
+
+	var orphans []string
+	for i := range state.shards {
+		for path, entry := range state.shards[i].pages {
+			if state.seen[path] || entry.Glob == "" || entry.Glob != s.runGlob {
+				continue
+			}
+			orphans = append(orphans, path)
+		}
+	}
+	sort.Strings(orphans)
+	return orphans
+}
+
+// PruneOrphans drops the entries Orphans reports and returns what it dropped.
+//
+// Without this the mapping only ever grows, and a file deleted once is reported
+// as missing on every run thereafter -- which trains people to ignore the one
+// message that matters. Reporting a deletion once and then forgetting it is the
+// honest bookkeeping: mark never deleted the page and does not claim to know
+// what became of it.
+//
+// Only what orphans would report is dropped, so the same scoping applies: a run
+// that was not looking where a file used to be cannot forget it.
+func (s *Store) PruneOrphans(spaceKey string) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	pruned := s.orphans(spaceKey)
+	state := s.spaces[spaceKey]
+	for _, path := range pruned {
+		sh := &state.shards[shardFor(path)]
+		delete(sh.pages, path)
+		sh.dirty = true
+	}
+	return pruned
+}
+
+// Spaces returns the space keys this store has loaded, sorted.
+func (s *Store) Spaces() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.sortedSpaces()
+}
+
+// sortedSpaces is Spaces without the lock, for callers that already hold it.
+func (s *Store) sortedSpaces() []string {
+	keys := make([]string, 0, len(s.spaces))
+	for key := range s.spaces {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// Save writes back every space whose manifest changed.
+//
+// A space that gained no new mapping is not written at all, so a repeat run over
+// unchanged files leaves the property -- and its version number -- alone.
+func (s *Store) Save() error {
+	if s.readOnly {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, spaceKey := range s.sortedSpaces() {
+		state := s.spaces[spaceKey]
+
+		if state.foldersDirty {
+			value, err := json.Marshal(folderDocument{
+				Version: formatVersion,
+				Folders: state.folders,
+			})
+			if err != nil {
+				return fmt.Errorf("unable to encode folder mapping for space %q: %w", spaceKey, err)
+			}
+
+			err = state.writeProperty(s.api, FolderPropertyKey, value, state.folderProperty)
+			if err != nil {
+				if errors.Is(err, confluence.ErrPropertyConflict) {
+					log.Warn().Msgf(
+						"folder mapping for space %q was updated by a concurrent run; it was not saved",
+						spaceKey,
+					)
+				} else {
+					return err
+				}
+			} else {
+				state.foldersDirty = false
+			}
+		}
+
+		for i := range state.shards {
+			if !state.shards[i].dirty {
+				continue
+			}
+
+			value, err := json.Marshal(document{
+				Version: formatVersion,
+				Pages:   state.shards[i].pages,
+			})
+			if err != nil {
+				return fmt.Errorf("unable to encode manifest for space %q: %w", spaceKey, err)
+			}
+
+			if len(value) > shardSizeWarning {
+				// Said while there is still room to act. Confluence's own limit
+				// is not knowable from here, so this is a heads-up rather than a
+				// refusal, and the write is attempted regardless.
+				log.Warn().Msgf(
+					"manifest shard %s of space %q is %d bytes and holds %d pages; "+
+						"it may be approaching the property size Confluence will accept",
+					PropertyKey(i), spaceKey, len(value), len(state.shards[i].pages),
+				)
+			}
+
+			if err := state.write(s.api, i, value); err != nil {
+				if errors.Is(err, confluence.ErrPropertyConflict) {
+					// Another run wrote between this run's read and its write.
+					// The two are not mergeable from here without re-reading,
+					// and losing the mapping is not worth failing a publish that
+					// has already succeeded -- the pages are live either way.
+					log.Warn().Msgf(
+						"manifest shard %s of space %q was updated by a concurrent run; "+
+							"those mappings were not saved",
+						PropertyKey(i), spaceKey,
+					)
+					continue
+				}
+				return err
+			}
+
+			state.shards[i].dirty = false
+		}
+	}
+
+	return nil
+}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -1,0 +1,757 @@
+package manifest_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/kovetskiy/mark/v16/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newStore(t *testing.T) (*manifest.Store, *confluencetest.Server) {
+	t.Helper()
+	server := confluencetest.New(t)
+	return newStoreOn(t, server), server
+}
+
+// newStoreOn builds a store already scoped to a run, since orphan reporting is
+// deliberately silent about entries whose scope is unknown.
+func newStoreOn(t *testing.T, server *confluencetest.Server) *manifest.Store {
+	t.Helper()
+	store := manifest.NewStore(confluence.NewAPI(server.URL, "user", "token", false))
+	store.SetRunFiles("*.md", nil)
+	return store
+}
+
+// spaceID resolves a space key the way the store does, so assertions can look
+// the property up by the same id.
+func spaceID(t *testing.T, server *confluencetest.Server, key string) string {
+	t.Helper()
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	id, err := api.GetSpaceID(key)
+	require.NoError(t, err)
+	return id
+}
+
+// manifestPages reads every shard held by owner and returns the whole mapping.
+// The mapping is split across properties, so no single one of them is the
+// manifest and assertions have to look at all of them.
+func manifestPages(t *testing.T, server *confluencetest.Server, ownerID string) map[string]string {
+	t.Helper()
+	all := map[string]string{}
+	for i := range manifest.ShardCount {
+		property := server.SpaceProperty(ownerID, manifest.PropertyKey(i))
+		if property == nil {
+			continue
+		}
+		var doc struct {
+			Pages map[string]struct {
+				PageID string `json:"pageId"`
+			} `json:"pages"`
+		}
+		require.NoError(t, json.Unmarshal(property.Value, &doc))
+		for path, entry := range doc.Pages {
+			all[path] = entry.PageID
+		}
+	}
+	return all
+}
+
+// shardOf returns the stored property a path's mapping lives in, or nil.
+func shardOf(server *confluencetest.Server, ownerID, path string) *confluencetest.SpaceProperty {
+	return server.SpaceProperty(ownerID, manifest.PropertyKey(manifest.ShardFor(path)))
+}
+
+func TestRecordAndLookupRoundTrip(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+
+	require.NoError(t, store.Record("DOCS", "docs/intro.md", "1234", "T", ""))
+	require.NoError(t, store.Save())
+
+	// A fresh store, as the next run would have.
+	next := newStoreOn(t, server)
+	entry, ok, err := next.Lookup("DOCS", "docs/intro.md")
+	require.NoError(t, err)
+	require.True(t, ok, "the mapping must survive a round trip through Confluence")
+	assert.Equal(t, "1234", entry.PageID)
+}
+
+// TestLookupSurvivesTitleChange is the point of the whole package: the title
+// recorded last run is not what the entry is found by, so changing it -- via the
+// Title header, the leading H1 or a file rename -- still resolves to the same
+// page instead of publishing a second one.
+func TestLookupSurvivesTitleChange(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+
+	require.NoError(t, store.Record("DOCS", "docs/intro.md", "1234", "T", ""))
+	require.NoError(t, store.Save())
+
+	next := newStoreOn(t, server)
+	entry, ok, err := next.Lookup("DOCS", "docs/intro.md")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "1234", entry.PageID,
+		"the page is found by path, so its title is free to change")
+}
+
+func TestLookupMissReportsNotFound(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+
+	_, ok, err := store.Lookup("DOCS", "docs/never-published.md")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// TestFirstRunHasNoProperty covers the ordinary starting state: a space that has
+// never been published to has no manifest, which is not an error.
+func TestFirstRunHasNoProperty(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+
+	_, ok, err := store.Lookup("DOCS", "anything.md")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, server.SpaceProperty(spaceID(t, server, "DOCS"), manifest.PropertyKey(manifest.ShardFor("a.md"))),
+		"a read must not create the property")
+}
+
+func TestOrphansAreRecordedPathsThisRunDidNotSee(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+
+	require.NoError(t, store.Record("DOCS", "a.md", "1", "T", ""))
+	require.NoError(t, store.Record("DOCS", "b.md", "2", "T", ""))
+	require.NoError(t, store.Record("DOCS", "c.md", "3", "T", ""))
+	require.NoError(t, store.Save())
+
+	// Next run publishes only a.md and c.md.
+	next := newStoreOn(t, server)
+	require.NoError(t, next.Record("DOCS", "a.md", "1", "T", ""))
+	require.NoError(t, next.Record("DOCS", "c.md", "3", "T", ""))
+
+	assert.Equal(t, []string{"b.md"}, next.Orphans("DOCS"))
+}
+
+// TestLookupCountsAsSeen: a file that is looked up but has no entry yet is still
+// part of this run, so it must not be reported as an orphan once recorded.
+func TestLookupCountsAsSeen(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+
+	require.NoError(t, store.Record("DOCS", "a.md", "1", "T", ""))
+	require.NoError(t, store.Save())
+
+	next := newStoreOn(t, server)
+	_, _, err := next.Lookup("DOCS", "a.md")
+	require.NoError(t, err)
+
+	assert.Empty(t, next.Orphans("DOCS"))
+}
+
+func TestOrphansForUnloadedSpaceIsEmpty(t *testing.T) {
+	store, _ := newStore(t)
+	assert.Empty(t, store.Orphans("NEVER-TOUCHED"))
+}
+
+// TestSaveSkipsUnchangedSpaces pins that a repeat run over unchanged files does
+// not write, so the property version does not climb for no reason.
+func TestSaveSkipsUnchangedSpaces(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	id := spaceID(t, server, "DOCS")
+
+	require.NoError(t, store.Record("DOCS", "a.md", "1", "T", ""))
+	require.NoError(t, store.Save())
+	require.Equal(t, 1, server.SpaceProperty(id, manifest.PropertyKey(manifest.ShardFor("a.md"))).Version)
+
+	next := newStoreOn(t, server)
+	require.NoError(t, next.Record("DOCS", "a.md", "1", "T", "")) // identical
+	require.NoError(t, next.Save())
+
+	assert.Equal(t, 1, server.SpaceProperty(id, manifest.PropertyKey(manifest.ShardFor("a.md"))).Version,
+		"an unchanged manifest must not be rewritten")
+}
+
+func TestSaveUpdatesExistingProperty(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	id := spaceID(t, server, "DOCS")
+
+	require.NoError(t, store.Record("DOCS", "a.md", "1", "T", ""))
+	require.NoError(t, store.Save())
+
+	next := newStoreOn(t, server)
+	require.NoError(t, next.Record("DOCS", "b.md", "2", "T", ""))
+	require.NoError(t, next.Save())
+
+	assert.Equal(t, map[string]string{"a.md": "1", "b.md": "2"},
+		manifestPages(t, server, id), "the earlier mapping must not be dropped")
+
+	// Rewriting a path supersedes the version of the shard that holds it.
+	third := newStoreOn(t, server)
+	require.NoError(t, third.Record("DOCS", "a.md", "99", "T", ""))
+	require.NoError(t, third.Save())
+
+	property := shardOf(server, id, "a.md")
+	require.NotNil(t, property)
+	assert.Equal(t, 2, property.Version, "the rewrite supersedes the first version")
+	assert.Equal(t, "99", manifestPages(t, server, id)["a.md"])
+}
+
+// TestMultipleSpaces: the `Space` header is per-document, so one run can publish
+// into several spaces and each gets its own manifest.
+func TestMultipleSpaces(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	server.AddSpace("OPS")
+
+	require.NoError(t, store.Record("DOCS", "a.md", "1", "T", ""))
+	require.NoError(t, store.Record("OPS", "b.md", "2", "T", ""))
+	require.NoError(t, store.Save())
+
+	assert.Equal(t, []string{"DOCS", "OPS"}, store.Spaces())
+
+	next := newStoreOn(t, server)
+	_, ok, err := next.Lookup("OPS", "b.md")
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	// A path recorded in one space must not resolve in another.
+	_, ok, err = next.Lookup("OPS", "a.md")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// TestUnreadableManifestIsIgnored: a corrupted property must not block
+// publishing. Losing rename protection for one run is recoverable; refusing to
+// publish is not.
+func TestUnreadableManifestIsIgnored(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	server.SetSpaceProperty(spaceID(t, server, "DOCS"), manifest.PropertyKey(manifest.ShardFor("a.md")), []byte(`"not a manifest"`))
+
+	_, ok, err := store.Lookup("DOCS", "a.md")
+	require.NoError(t, err, "an unreadable manifest must not fail the run")
+	assert.False(t, ok)
+}
+
+// TestNewerFormatIsIgnored: a manifest written by a future mark whose shape this
+// one does not know is left alone rather than misread.
+func TestNewerFormatIsIgnored(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	server.SetSpaceProperty(spaceID(t, server, "DOCS"), manifest.PropertyKey(manifest.ShardFor("a.md")),
+		[]byte(`{"version":99,"pages":{"a.md":{"pageId":"1","title":"A"}}}`))
+
+	_, ok, err := store.Lookup("DOCS", "a.md")
+	require.NoError(t, err)
+	assert.False(t, ok, "entries from an unknown format must not be trusted")
+}
+
+// TestConcurrentWriteIsReportedNotFatal: two runs racing on the same manifest.
+// The loser keeps its published pages -- they are live either way -- and only
+// loses its mapping, so a failed manifest write must not fail the run.
+func TestConcurrentWriteIsReportedNotFatal(t *testing.T) {
+	first, server := newStore(t)
+	server.AddSpace("DOCS")
+
+	require.NoError(t, first.Record("DOCS", "a.md", "1", "T", ""))
+	require.NoError(t, first.Save())
+
+	// Both write the same path, so both land in the same shard and genuinely
+	// contend. Different paths usually fall in different shards and never meet.
+	left := newStoreOn(t, server)
+	right := newStoreOn(t, server)
+	require.NoError(t, left.Record("DOCS", "a.md", "2", "T", ""))
+	require.NoError(t, right.Record("DOCS", "a.md", "3", "T", ""))
+
+	// ...and the second to write finds its version superseded.
+	require.NoError(t, left.Save())
+	assert.NoError(t, right.Save(), "losing the race must not fail the run")
+
+	property := shardOf(server, spaceID(t, server, "DOCS"), "a.md")
+	require.NotNil(t, property)
+	assert.Equal(t, 2, property.Version, "exactly one of the two writes landed")
+}
+
+// serverInstance makes the fake behave like Confluence Server/Data Center:
+// there is no v2 API at all, so the Cloud probe fails and every v2 route 404s.
+func serverInstance(t *testing.T) (*manifest.Store, *confluencetest.Server, *confluence.API) {
+	t.Helper()
+	server := confluencetest.New(t)
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if strings.HasPrefix(r.URL.Path, "/api/v2") {
+			return http.StatusNotFound, `<html>404</html>`, true
+		}
+		return 0, "", false
+	})
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	return manifest.NewStore(api), server, api
+}
+
+// docsWithHomepage gives a space the homepage the Server backend anchors to.
+func docsWithHomepage(t *testing.T, server *confluencetest.Server) string {
+	t.Helper()
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	return home.ID
+}
+
+// TestServerBackendRoundTrip is the Data Center path: space properties do not
+// exist there, so the manifest is a content property on the space homepage.
+func TestServerBackendRoundTrip(t *testing.T) {
+	store, server, api := serverInstance(t)
+	homeID := docsWithHomepage(t, server)
+	require.False(t, api.IsCloud(), "the fake must look like Server for this test")
+
+	require.NoError(t, store.Record("DOCS", "docs/intro.md", "1234", "T", ""))
+	require.NoError(t, store.Save())
+
+	require.NotNil(t, shardOf(server, homeID, "docs/intro.md"),
+		"the manifest should be stored on the homepage")
+
+	next := newStoreOn(t, server)
+	entry, ok, err := next.Lookup("DOCS", "docs/intro.md")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "1234", entry.PageID)
+}
+
+// TestServerBackendUpdatesExistingProperty exercises the v1 update path, which
+// addresses a property by key where v2 addresses it by id.
+func TestServerBackendUpdatesExistingProperty(t *testing.T) {
+	store, server, _ := serverInstance(t)
+	homeID := docsWithHomepage(t, server)
+
+	require.NoError(t, store.Record("DOCS", "a.md", "1", "T", ""))
+	require.NoError(t, store.Save())
+
+	next := newStoreOn(t, server)
+	require.NoError(t, next.Record("DOCS", "b.md", "2", "T", ""))
+	require.NoError(t, next.Save())
+
+	assert.Equal(t, map[string]string{"a.md": "1", "b.md": "2"},
+		manifestPages(t, server, homeID), "the earlier mapping must not be dropped")
+
+	// Rewriting a path supersedes its shard, which on v1 is addressed by key.
+	third := newStoreOn(t, server)
+	require.NoError(t, third.Record("DOCS", "a.md", "99", "T", ""))
+	require.NoError(t, third.Save())
+
+	property := shardOf(server, homeID, "a.md")
+	require.NotNil(t, property)
+	assert.Equal(t, 2, property.Version, "the rewrite supersedes the first version")
+	assert.Equal(t, "99", manifestPages(t, server, homeID)["a.md"])
+}
+
+// TestServerBackendFirstRunHasNoProperty: a homepage that has never been
+// published to has no property, and reading it must not create one.
+func TestServerBackendFirstRunHasNoProperty(t *testing.T) {
+	store, server, _ := serverInstance(t)
+	homeID := docsWithHomepage(t, server)
+
+	_, ok, err := store.Lookup("DOCS", "anything.md")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Nil(t, server.SpaceProperty(homeID, manifest.PropertyKey(manifest.ShardFor("a.md"))))
+}
+
+// TestServerBackendConcurrentWriteIsReportedNotFatal mirrors the Cloud case:
+// the v1 endpoint versions properties too, so the loser of a race is told.
+func TestServerBackendConcurrentWriteIsReportedNotFatal(t *testing.T) {
+	first, server, _ := serverInstance(t)
+	homeID := docsWithHomepage(t, server)
+
+	require.NoError(t, first.Record("DOCS", "a.md", "1", "T", ""))
+	require.NoError(t, first.Save())
+
+	left := newStoreOn(t, server)
+	right := newStoreOn(t, server)
+	require.NoError(t, left.Record("DOCS", "a.md", "2", "T", ""))
+	require.NoError(t, right.Record("DOCS", "a.md", "3", "T", ""))
+
+	require.NoError(t, left.Save())
+	assert.NoError(t, right.Save(), "losing the race must not fail the run")
+
+	assert.Equal(t, 2, shardOf(server, homeID, "a.md").Version,
+		"exactly one of the two writes landed")
+}
+
+// TestCloudUsesSpaceNotHomepage pins the backend split: on Cloud the manifest
+// must not land on the homepage, because v1 content properties are exactly what
+// a scoped API token cannot reach.
+func TestCloudUsesSpaceNotHomepage(t *testing.T) {
+	store, server := newStore(t)
+	homeID := docsWithHomepage(t, server)
+
+	require.NoError(t, store.Record("DOCS", "a.md", "1", "T", ""))
+	require.NoError(t, store.Save())
+
+	assert.Nil(t, shardOf(server, homeID, "a.md"),
+		"Cloud must not write the manifest to the homepage")
+	assert.NotNil(t, shardOf(server, spaceID(t, server, "DOCS"), "a.md"),
+		"Cloud writes it to the space")
+}
+
+// TestManifestSpreadsAcrossShards is the point of splitting it up: a repository
+// large enough to matter must not put its whole mapping in one property, since
+// Confluence bounds how big one can be.
+func TestManifestSpreadsAcrossShards(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	id := spaceID(t, server, "DOCS")
+
+	const files = 500
+	want := map[string]string{}
+	for i := range files {
+		path := fmt.Sprintf("docs/section-%02d/page-%03d.md", i%20, i)
+		pageID := strconv.Itoa(100000 + i)
+		want[path] = pageID
+		require.NoError(t, store.Record("DOCS", path, pageID, fmt.Sprintf("Page %d", i), ""))
+	}
+	require.NoError(t, store.Save())
+
+	// Every mapping survives...
+	assert.Equal(t, want, manifestPages(t, server, id))
+
+	// ...spread over the shards rather than piled into one.
+	used, largest := 0, 0
+	for i := range manifest.ShardCount {
+		property := server.SpaceProperty(id, manifest.PropertyKey(i))
+		if property == nil {
+			continue
+		}
+		used++
+		largest = max(largest, len(property.Value))
+	}
+	assert.Equal(t, manifest.ShardCount, used, "all shards should carry a share")
+
+	// A single blob would be the sum of them; each is a fraction of that.
+	assert.Less(t, largest, 8*1024,
+		"no single property should be anywhere near a plausible size limit at this scale")
+}
+
+// TestShardAssignmentIsStable pins the one property sharding must have: a path
+// always resolves to the same shard. If it drifted, every existing mapping
+// would be looked for in the wrong property and silently lost.
+func TestShardAssignmentIsStable(t *testing.T) {
+	for _, path := range []string{
+		"a.md", "docs/intro.md", "docs/deeply/nested/file.md", "", "unicode/ページ.md",
+	} {
+		first := manifest.ShardFor(path)
+		assert.Equal(t, first, manifest.ShardFor(path), "%q moved between calls", path)
+		assert.GreaterOrEqual(t, first, 0)
+		assert.Less(t, first, manifest.ShardCount)
+	}
+}
+
+// TestSaveWritesOnlyDirtyShards: adding one file must not rewrite the whole
+// mapping, or every run would bump the version of all sixteen properties and
+// turn a one-page change into sixteen writes.
+func TestSaveWritesOnlyDirtyShards(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	id := spaceID(t, server, "DOCS")
+
+	paths := []string{}
+	for i := range 100 {
+		paths = append(paths, fmt.Sprintf("docs/page-%03d.md", i))
+	}
+	for _, path := range paths {
+		require.NoError(t, store.Record("DOCS", path, "1", "T", ""))
+	}
+	require.NoError(t, store.Save())
+
+	before := map[int]int{}
+	for i := range manifest.ShardCount {
+		if property := server.SpaceProperty(id, manifest.PropertyKey(i)); property != nil {
+			before[i] = property.Version
+		}
+	}
+
+	// One new file, in exactly one shard.
+	next := newStoreOn(t, server)
+	require.NoError(t, next.Record("DOCS", "docs/brand-new.md", "999", "T", ""))
+	require.NoError(t, next.Save())
+
+	touched := 0
+	for i := range manifest.ShardCount {
+		property := server.SpaceProperty(id, manifest.PropertyKey(i))
+		if property != nil && property.Version != before[i] {
+			touched++
+		}
+	}
+	assert.Equal(t, 1, touched, "only the shard holding the new path should be rewritten")
+}
+
+// TestUnreadableShardOnlyLosesItsOwnPaths: a corrupted property must not take
+// the rest of the mapping down with it, which is the other reason to split.
+func TestUnreadableShardOnlyLosesItsOwnPaths(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	id := spaceID(t, server, "DOCS")
+
+	require.NoError(t, store.Record("DOCS", "a.md", "1", "T", ""))
+	require.NoError(t, store.Record("DOCS", "b.md", "2", "T", ""))
+	require.NoError(t, store.Save())
+	require.NotEqual(t, manifest.ShardFor("a.md"), manifest.ShardFor("b.md"),
+		"this test needs the two paths in different shards")
+
+	server.SetSpaceProperty(id, manifest.PropertyKey(manifest.ShardFor("a.md")), []byte(`"corrupt"`))
+
+	next := newStoreOn(t, server)
+	_, ok, err := next.Lookup("DOCS", "a.md")
+	require.NoError(t, err)
+	assert.False(t, ok, "the corrupted shard's paths are lost")
+
+	entry, ok, err := next.Lookup("DOCS", "b.md")
+	require.NoError(t, err)
+	require.True(t, ok, "an intact shard must still resolve")
+	assert.Equal(t, "2", entry.PageID)
+}
+
+// TestReadTakesOneRequestPerSpace: sixteen properties must not mean sixteen
+// round trips. They are listed in one call.
+func TestReadTakesOneRequestPerSpace(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+
+	require.NoError(t, store.Record("DOCS", "a.md", "1", "T", ""))
+	require.NoError(t, store.Save())
+
+	next := newStoreOn(t, server)
+	server.ResetRequests()
+	_, _, err := next.Lookup("DOCS", "a.md")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, server.CountRequests("GET", "/properties"),
+		"all shards should be read in a single listing")
+}
+
+// TestFolderMappingRoundTrip covers the folder half. Folders are found by title
+// and created when the title is not found, so one renamed in Confluence stops
+// matching the header that declares it and mark builds a second beside it.
+func TestFolderMappingRoundTrip(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+
+	require.NoError(t, store.RecordFolder("DOCS", "anchor\x00Guides", "folder-1"))
+	require.NoError(t, store.Save())
+
+	next := newStoreOn(t, server)
+	id, ok, err := next.LookupFolder("DOCS", "anchor\x00Guides")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "folder-1", id)
+}
+
+// TestFolderMappingIsKeptOutOfThePageShards: a folder key appearing among the
+// page keys would be reported as a source file that had gone missing.
+func TestFolderMappingIsKeptOutOfThePageShards(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	id := spaceID(t, server, "DOCS")
+
+	require.NoError(t, store.Record("DOCS", "a.md", "1", "A", ""))
+	require.NoError(t, store.RecordFolder("DOCS", "anchor\x00Guides", "folder-1"))
+	require.NoError(t, store.Save())
+
+	assert.Equal(t, map[string]string{"a.md": "1"}, manifestPages(t, server, id),
+		"folders must not appear among the tracked source paths")
+	assert.NotNil(t, server.SpaceProperty(id, manifest.FolderPropertyKey),
+		"they live in their own property")
+
+	next := newStoreOn(t, server)
+	require.NoError(t, next.Record("DOCS", "a.md", "1", "A", ""))
+	assert.Empty(t, next.Orphans("DOCS"),
+		"a folder key must never be reported as a missing file")
+}
+
+// TestFolderMappingSkippedWhenUnchanged: folders rarely move, so a run that
+// resolves the same ones must not rewrite the property.
+func TestFolderMappingSkippedWhenUnchanged(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	id := spaceID(t, server, "DOCS")
+
+	require.NoError(t, store.RecordFolder("DOCS", "anchor\x00Guides", "folder-1"))
+	require.NoError(t, store.Save())
+	require.Equal(t, 1, server.SpaceProperty(id, manifest.FolderPropertyKey).Version)
+
+	next := newStoreOn(t, server)
+	require.NoError(t, next.RecordFolder("DOCS", "anchor\x00Guides", "folder-1"))
+	require.NoError(t, next.Save())
+
+	assert.Equal(t, 1, server.SpaceProperty(id, manifest.FolderPropertyKey).Version,
+		"an unchanged folder mapping must not be rewritten")
+}
+
+// TestResolveStaleTitleReportsReadFailures: a manifest that cannot be read is
+// not the same as a title that was never published. Folding the two together
+// would create a duplicate page because the network hiccuped.
+func TestResolveStaleTitleReportsReadFailures(t *testing.T) {
+	server := confluencetest.New(t)
+	server.AddSpace("DOCS")
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if strings.Contains(r.URL.Path, "/properties") {
+			return http.StatusInternalServerError, `{"message":"nope"}`, true
+		}
+		return 0, "", false
+	})
+
+	store := newStoreOn(t, server)
+	_, ok, err := store.ResolveStaleTitle("DOCS", "Some Title")
+	require.Error(t, err, "an unreadable manifest must be reported, not silently treated as empty")
+	assert.False(t, ok)
+}
+
+// TestKeyNormalisesToTheWorkingDirectory pins what makes a key mean the same
+// thing in two places. A glob of "$PWD/docs/*.md" and one of "docs/*.md" name
+// the same files; keyed as given they would keep two disjoint mappings of one
+// repository, and an absolute key would additionally embed a checkout
+// directory that does not survive being moved.
+func TestKeyNormalisesToTheWorkingDirectory(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	assert.Equal(t, "docs/a.md", manifest.Key("docs/a.md"))
+	assert.Equal(t, "docs/a.md", manifest.Key("./docs/a.md"))
+	assert.Equal(t, "docs/a.md", manifest.Key("docs/../docs/a.md"))
+	assert.Equal(t, "docs/a.md", manifest.Key(filepath.Join(cwd, "docs/a.md")),
+		"an absolute path inside the working directory is stored relative to it")
+
+	// Outside it there is no better anchor, and mark has no notion of a project
+	// root to invent one from.
+	outside := filepath.Join(filepath.Dir(cwd), "elsewhere", "a.md")
+	assert.Equal(t, outside, manifest.Key(outside))
+}
+
+// TestAbsoluteAndRelativeRunsShareOneMapping is the behaviour that matters: the
+// same file published twice, once through each form of glob, is one entry.
+func TestAbsoluteAndRelativeRunsShareOneMapping(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	id := spaceID(t, server, "DOCS")
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	require.NoError(t, store.Record("DOCS", "docs/a.md", "1", "A", "h"))
+	require.NoError(t, store.Record("DOCS", filepath.Join(cwd, "docs/a.md"), "1", "A", "h"))
+	require.NoError(t, store.Save())
+
+	assert.Equal(t, map[string]string{"docs/a.md": "1"}, manifestPages(t, server, id),
+		"the two forms of the same path must be one entry, not two")
+}
+
+// TestManifestWrittenBeforeHashesAndGlobsStillResolves: entries written by an
+// earlier mark carry no fingerprint and no pattern. They must still place their
+// pages -- losing the mapping on upgrade would republish every renamed document
+// as a duplicate, which is the failure the mapping exists to prevent.
+func TestManifestWrittenBeforeHashesAndGlobsStillResolves(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+
+	// The shape as an earlier version wrote it: page id and title only.
+	server.SetSpaceProperty(spaceID(t, server, "DOCS"),
+		manifest.PropertyKey(manifest.ShardFor("a.md")),
+		[]byte(`{"version":1,"pages":{"a.md":{"pageId":"1234","title":"A"}}}`))
+
+	entry, ok, err := store.Lookup("DOCS", "a.md")
+	require.NoError(t, err)
+	require.True(t, ok, "an entry from before hashes and globs must still resolve")
+	assert.Equal(t, "1234", entry.PageID)
+	assert.Equal(t, "A", entry.Title)
+	assert.Empty(t, entry.Hash)
+	assert.Empty(t, entry.Glob)
+}
+
+// TestHashlessEntryIsNeverMatchedAsARename: with no fingerprint there is
+// nothing to match on, and matching everything with an empty hash would rebind
+// unrelated documents onto each other.
+func TestHashlessEntryIsNeverMatchedAsARename(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	server.SetSpaceProperty(spaceID(t, server, "DOCS"),
+		manifest.PropertyKey(manifest.ShardFor("a.md")),
+		[]byte(`{"version":1,"pages":{"a.md":{"pageId":"1234","title":"A"}}}`))
+
+	_, _, ok, err := store.ResolveRenamed("DOCS", "")
+	require.NoError(t, err)
+	assert.False(t, ok, "an empty fingerprint must match nothing")
+}
+
+// TestGloblessEntryIsNeverReportedMissing: without a recorded pattern there is
+// no way to know whether a run was looking where the file used to be, so its
+// absence proves nothing.
+func TestGloblessEntryIsNeverReportedMissing(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	server.SetSpaceProperty(spaceID(t, server, "DOCS"),
+		manifest.PropertyKey(manifest.ShardFor("a.md")),
+		[]byte(`{"version":1,"pages":{"a.md":{"pageId":"1234","title":"A"}}}`))
+
+	_, _, err := store.Lookup("DOCS", "unrelated.md")
+	require.NoError(t, err)
+	assert.Empty(t, store.Orphans("DOCS"),
+		"an entry of unknown scope must not be reported as a deleted file")
+}
+
+// TestKeyIsSlashSeparated: the separator is a property of the machine, not of
+// the repository. Leaving it in gives a team publishing from Windows and from
+// Linux CI two entries for every file.
+//
+// What this can check is limited by where it runs. filepath is compiled for one
+// platform, so on a slash platform Join already produces slashes and the
+// assertion is nearly free; it earns its keep on Windows, and here it stands as
+// a statement of the invariant rather than a demonstration of it.
+func TestKeyIsSlashSeparated(t *testing.T) {
+	assert.Equal(t, "docs/guides/a.md", manifest.Key("docs/guides/a.md"))
+	assert.NotContains(t, manifest.Key(filepath.Join("docs", "guides", "a.md")), `\`,
+		"a key must never carry a platform separator")
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	assert.NotContains(t, manifest.Key(filepath.Join(cwd, "docs", "a.md")), `\`)
+}
+
+// TestKeysWrittenBeforeNormalisationAreMigrated: an upgrade must not strand the
+// mapping. A stranded entry has no pattern to report it and no fingerprint to
+// match it, so it becomes dead weight that arrives once and never leaves.
+func TestKeysWrittenBeforeNormalisationAreMigrated(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	id := spaceID(t, server, "DOCS")
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	oldKey := filepath.Join(cwd, "docs", "a.md")
+
+	// The shape an earlier mark wrote: an absolute, unnormalised key.
+	server.SetSpaceProperty(id, manifest.PropertyKey(manifest.ShardFor(oldKey)),
+		[]byte(`{"version":1,"pages":{"`+oldKey+`":{"pageId":"1234","title":"A"}}}`))
+
+	// The same file, asked for the way it is written now.
+	entry, ok, err := store.Lookup("DOCS", "docs/a.md")
+	require.NoError(t, err)
+	require.True(t, ok, "an entry written before normalisation must still be found")
+	assert.Equal(t, "1234", entry.PageID)
+
+	// And the repair is persisted, so it happens once rather than every run.
+	require.NoError(t, store.Record("DOCS", "docs/a.md", "1234", "A", "h"))
+	require.NoError(t, store.Save())
+	assert.Equal(t, map[string]string{"docs/a.md": "1234"}, manifestPages(t, server, id),
+		"the old key should be gone, not sitting beside the new one")
+}

--- a/mark.go
+++ b/mark.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kovetskiy/mark/v16/attachment"
 	"github.com/kovetskiy/mark/v16/confluence"
 	"github.com/kovetskiy/mark/v16/d2"
+	"github.com/kovetskiy/mark/v16/manifest"
 	markmd "github.com/kovetskiy/mark/v16/markdown"
 	"github.com/kovetskiy/mark/v16/mermaid"
 	"github.com/kovetskiy/mark/v16/metadata"
@@ -68,6 +69,7 @@ type Config struct {
 	EditLock         bool
 	ChangesOnly      bool
 	PreserveComments bool
+	TrackPages       bool
 
 	// Rendering
 	DropH1          bool
@@ -97,6 +99,11 @@ func (c Config) output() io.Writer {
 func Run(config Config) error {
 	api := confluence.NewAPI(config.BaseURL, config.Username, config.Password, config.InsecureSkipTLSVerify)
 
+	// Folder resolutions are cached in a package-level map that outlives this
+	// call, so a second run in the same process -- against another instance,
+	// even -- would otherwise start with the first run's answers.
+	page.ResetFolderCache()
+
 	files, err := doublestar.FilepathGlob(config.Files)
 	if err != nil {
 		return err
@@ -120,11 +127,48 @@ func Run(config Config) error {
 		return fmt.Errorf("unable to retrieve standard library: %w", err)
 	}
 
+	// The manifest is only consulted when asked for. It changes how an existing
+	// page is found, which is not something to switch on under anyone without
+	// their say-so.
+	var tracker *manifest.Store
+	if config.TrackPages {
+		// A dry run resolves exactly as a real one does -- otherwise its preview
+		// is fiction -- and resolving records what it finds. The store it gets
+		// cannot write, which is a guard that holds however it is used.
+		if config.DryRun {
+			tracker = manifest.NewReadOnlyStore(api)
+		} else {
+			tracker = manifest.NewStore(api)
+		}
+		if config.PageID != "" {
+			// The mapping is keyed on a source path within a space, and neither
+			// is known when publishing straight to a page id. Better said once
+			// than discovered later as a manifest with holes in it.
+			log.Warn().Msg(
+				"--track-pages has no effect together with a page id: " +
+					"the mapping is per space and per file, and neither applies here",
+			)
+			tracker = nil
+		}
+	}
+
+	// A nil *manifest.Store put into a non-nil interface is still a non-nil
+	// interface, so page would see tracking as enabled and call through a nil
+	// receiver. Build the interface value only when there is a store behind it.
+	var folders page.FolderTracker
+	if tracker != nil {
+		folders = tracker
+		// The whole file set is known before any of it is processed, which is
+		// what lets a recorded path missing from the run be read as a rename
+		// rather than a guess made one document at a time.
+		tracker.SetRunFiles(config.Files, files)
+	}
+
 	var hasErrors bool
 	for _, file := range files {
 		log.Info().Msgf("processing %s", file)
 
-		target, err := processFile(file, api, config, std)
+		target, err := processFile(file, api, config, std, tracker, folders)
 		if err != nil {
 			if config.ContinueOnError {
 				log.Error().Err(err).Msgf("processing %s", file)
@@ -142,11 +186,61 @@ func Run(config Config) error {
 		}
 	}
 
+	// The manifest is saved before the run's own outcome is decided. Returning
+	// early on hasErrors used to skip it entirely, so a single bad file threw
+	// away the mapping for every page that had published perfectly well --
+	// worst under --continue-on-error, which exists precisely to keep going.
+	// What was recorded actually happened, and is worth keeping either way.
+	var saveErr error
+	if tracker != nil {
+		reportOrphans(tracker, hasErrors)
+		pruneOrphans(tracker, hasErrors, config.DryRun)
+		if saveErr = tracker.Save(); saveErr != nil {
+			saveErr = fmt.Errorf("unable to save page manifest: %w", saveErr)
+		}
+	}
+
 	if hasErrors {
+		// The files are the more useful complaint; a failed manifest write is
+		// secondary and must not displace it.
+		if saveErr != nil {
+			log.Error().Err(saveErr).Msg("page manifest was not saved")
+		}
 		return fmt.Errorf("one or more files failed to process")
 	}
 
-	return nil
+	return saveErr
+}
+
+// reportOrphans logs pages the manifest knows about that this run did not
+// publish to. It only reports; nothing here deletes anything.
+//
+// A path can be missing for two very different reasons -- the file was deleted,
+// or this run simply did not cover it -- and mark cannot tell them apart. A run
+// narrowed by --files leaves everything outside the glob unseen, and those files
+// are present and fine. The wording says candidates for that reason, and acting
+// on them is left to a human until there is a mechanism that can distinguish the
+// two cases.
+func reportOrphans(tracker *manifest.Store, hadErrors bool) {
+	for _, space := range tracker.Spaces() {
+		orphans := tracker.Orphans(space)
+		if len(orphans) == 0 {
+			continue
+		}
+		if hadErrors {
+			// Some files did not process, which is indistinguishable from those
+			// files being gone. Reporting them now would be actively misleading.
+			log.Debug().Msgf(
+				"space %q has %d unpublished tracked pages, not reported because this run had errors",
+				space, len(orphans),
+			)
+			continue
+		}
+		log.Info().Msgf(
+			"space %q: %d tracked page(s) had no matching source file in this run: %s",
+			space, len(orphans), strings.Join(orphans, ", "),
+		)
+	}
 }
 
 // ProcessFile processes a single markdown file and publishes it to Confluence.
@@ -160,16 +254,23 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 		return nil, fmt.Errorf("unable to retrieve standard library: %w", err)
 	}
 
-	return processFile(file, api, config, std)
+	return processFile(file, api, config, std, nil, nil)
 }
 
-func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib) (*confluence.PageInfo, error) {
+func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, folders page.FolderTracker) (*confluence.PageInfo, error) {
 	markdown, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read file %q: %w", file, err)
 	}
 
 	markdown = bytes.ReplaceAll(markdown, []byte("\r\n"), []byte("\n"))
+
+	// Fingerprint the source as read, before metadata is stripped and links are
+	// substituted. Both of those depend on state outside the file -- what is
+	// already published, what other files resolve to -- and a fingerprint that
+	// moves with the remote would not survive the round trip it exists for.
+	sourceHash := sha1Hash(string(markdown))
+
 	frontMatterEnabled := slices.Contains(config.Features, "frontmatter")
 
 	meta, markdown, err := metadata.ExtractMeta(
@@ -236,8 +337,14 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 
 	if config.DryRun {
 		if meta != nil {
-			if _, _, err := page.ResolvePage(true, api, meta); err != nil {
+			if _, pg, err := page.ResolvePage(true, api, meta, folders); err != nil {
 				return nil, fmt.Errorf("unable to resolve page location: %w", err)
+			} else if pg == nil {
+				// The title found nothing, which is where a real run consults
+				// the manifest. Saying so is the whole point of a dry run:
+				// otherwise it reports a new page for every rename and retitle
+				// the run would actually have handled in place.
+				previewTrackedResolution(tracker, api, meta, file, sourceHash)
 			}
 		} else if config.PageID != "" {
 			if _, err := api.GetPageByID(config.PageID); err != nil {
@@ -277,11 +384,45 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 
 	var target *confluence.PageInfo
 	var pageCreated bool
+	// A page whose title changed has to be written even when its content did
+	// not, or --changes-only would leave it under the old title forever.
+	var titleChanged bool
 
 	if meta != nil {
-		parent, pg, err := page.ResolvePage(false, api, meta)
+		// Parents are named by title, so a parent that has itself been renamed
+		// leaves this document pointing at a name nothing carries any more.
+		// Do this before resolution, so ancestry is walked against titles that
+		// exist rather than creating an empty page under the old one.
+		if err := refreshStaleParents(tracker, api, meta); err != nil {
+			return nil, err
+		}
+
+		parent, pg, err := page.ResolvePage(false, api, meta, folders)
 		if err != nil {
 			return nil, fmt.Errorf("error resolving page %q: %w", meta.Title, err)
+		}
+
+		// The title lookup found nothing, which is how both "this page is new"
+		// and "this page was renamed" look. Ask the manifest which of the two
+		// this is before creating a second page beside the first.
+		if pg == nil {
+			pg, err = resolveTrackedPage(tracker, api, meta, file)
+			if err != nil {
+				return nil, err
+			}
+			if pg == nil {
+				// Not published under this path before. It may have been
+				// published under another: a renamed file is a new key holding
+				// an old document.
+				pg, err = resolveRenamedFile(tracker, api, meta, file, sourceHash)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if pg != nil && pg.Title != meta.Title {
+				pg.Title = meta.Title
+				titleChanged = true
+			}
 		}
 
 		if pg == nil {
@@ -430,8 +571,12 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		if previous := readContentHash(target.Version.Message); previous != "" {
 			log.Debug().Msgf("previous content hash: %s", previous)
 			if previous == contentHash {
-				log.Info().Msgf("page %q is already up to date", target.Title)
-				shouldUpdatePage = false
+				if titleChanged {
+					log.Info().Msgf("page %q is unchanged but is being retitled", target.Title)
+				} else {
+					log.Info().Msgf("page %q is already up to date", target.Title)
+					shouldUpdatePage = false
+				}
 			}
 		}
 
@@ -458,6 +603,12 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		html, err = mergeComments(html, target.Body.Storage.Value, comments)
 		if err != nil {
 			return nil, fmt.Errorf("unable to merge inline comments: %w", err)
+		}
+	}
+
+	if tracker != nil && meta != nil {
+		if err := tracker.Record(meta.Space, file, target.ID, meta.Title, sourceHash); err != nil {
+			return nil, fmt.Errorf("unable to record page mapping for %q: %w", file, err)
 		}
 	}
 
@@ -493,6 +644,230 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	}
 
 	return target, nil
+}
+
+// pruneOrphans forgets the entries reportOrphans just named.
+//
+// Left in place the mapping only ever grows, and a file deleted once is
+// reported as missing on every run from then on -- which teaches people to
+// ignore the one message worth reading. Reported once, then forgotten.
+//
+// Nothing is forgotten on a run that had errors, where a file that failed to
+// process is indistinguishable from one that is gone, nor on a dry run, which
+// does not get to change what the next run believes.
+func pruneOrphans(tracker *manifest.Store, hadErrors, dryRun bool) {
+	if hadErrors || dryRun {
+		return
+	}
+
+	for _, space := range tracker.Spaces() {
+		if pruned := tracker.PruneOrphans(space); len(pruned) > 0 {
+			log.Debug().Msgf(
+				"space %q: stopped tracking %d page(s) whose source files are gone",
+				space, len(pruned),
+			)
+		}
+	}
+}
+
+// previewTrackedResolution says what a real run would have done with a document
+// the title lookup could not place.
+//
+// A dry run that reports a new page for every rename and retitle the real run
+// would have handled in place is worse than no dry run, because it is confidently
+// wrong about the one thing somebody is checking.
+func previewTrackedResolution(
+	tracker *manifest.Store,
+	api *confluence.API,
+	meta *metadata.Meta,
+	file string,
+	sourceHash string,
+) {
+	if tracker == nil || meta == nil {
+		return
+	}
+
+	if pg, err := resolveTrackedPage(tracker, api, meta, file); err == nil && pg != nil {
+		log.Info().Msgf(
+			"%s would be published to the existing page %s, retitled from %q to %q",
+			file, pg.ID, pg.Title, meta.Title,
+		)
+		return
+	}
+
+	if pg, err := resolveRenamedFile(tracker, api, meta, file, sourceHash); err == nil && pg != nil {
+		log.Info().Msgf(
+			"%s would be treated as a rename of an already published document, updating page %s",
+			file, pg.ID,
+		)
+		return
+	}
+
+	log.Info().Msgf("%s would be published as a new page %q", file, meta.Title)
+}
+
+// resolveTrackedPage returns the page this file published to on a previous run,
+// for the case where looking the page up by title found nothing.
+//
+// That lookup failing is ambiguous: the page may be new, or it may be the same
+// page under a title that has since changed -- through the Title header, the
+// leading H1, or a rename feeding --title-from-filename. Without the manifest
+// the two are indistinguishable and mark publishes a duplicate.
+//
+// Returning (nil, nil) means "no answer, carry on and create", which covers both
+// a file that has genuinely never been published and one whose recorded page has
+// since been deleted in Confluence. Neither is a failure worth stopping for.
+func resolveTrackedPage(
+	tracker *manifest.Store,
+	api *confluence.API,
+	meta *metadata.Meta,
+	file string,
+) (*confluence.PageInfo, error) {
+	if tracker == nil || meta == nil {
+		return nil, nil
+	}
+
+	entry, ok, err := tracker.Lookup(meta.Space, file)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read page mapping for %q: %w", file, err)
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	pg, err := api.GetPageByID(entry.PageID)
+	if err != nil {
+		// Only a page that is genuinely gone may fall through to being created
+		// again. Treating every failure that way would mean a network blip
+		// publishes a duplicate -- precisely the outcome this exists to prevent
+		// -- so anything else stops the run and is reported.
+		if !errors.Is(err, confluence.ErrNotFound) {
+			return nil, fmt.Errorf(
+				"unable to load page %s recorded for %q: %w", entry.PageID, file, err,
+			)
+		}
+		log.Warn().Msgf(
+			"%s was published to page %s, which no longer exists; a new page will be created",
+			file, entry.PageID,
+		)
+		return nil, nil
+	}
+
+	if pg.Title != meta.Title {
+		log.Info().Msgf(
+			"%s was published as %q and is now %q; retitling page %s rather than creating a second one",
+			file, pg.Title, meta.Title, pg.ID,
+		)
+	}
+
+	return pg, nil
+}
+
+// refreshStaleParents rewrites parent titles that no longer resolve to the
+// titles those pages carry now.
+//
+// mark names a parent by title and creates it when the title is not found, so
+// renaming a page that others declare as their parent strands them: an empty
+// page appears under the old title and the real one's children are moved
+// beneath it. Tracking makes that more likely rather than less, because the
+// parent is now renamed in place instead of being duplicated somewhere visible.
+//
+// Only titles mark itself published are followed, and only when exactly one
+// page was published under the title. Anything ambiguous, or any title mark has
+// never seen, is left exactly as written -- a parent that is genuinely meant to
+// be created still is.
+func refreshStaleParents(tracker *manifest.Store, api *confluence.API, meta *metadata.Meta) error {
+	if tracker == nil {
+		return nil
+	}
+
+	for i, title := range meta.Parents {
+		// FindPage is memoised, and ancestry resolution is about to ask the
+		// same question, so this costs nothing on the common path where the
+		// parent is exactly where it says it is.
+		existing, err := api.FindPage(meta.Space, title, "page")
+		if err != nil || existing != nil {
+			continue
+		}
+
+		pageID, ok, err := tracker.ResolveStaleTitle(meta.Space, title)
+		if err != nil {
+			return fmt.Errorf("unable to check whether parent %q was renamed: %w", title, err)
+		}
+		if !ok {
+			continue
+		}
+
+		renamed, err := api.GetPageByID(pageID)
+		if err != nil || renamed == nil || renamed.Title == title {
+			continue
+		}
+
+		log.Info().Msgf(
+			"parent %q was renamed to %q; using it rather than creating a page under the old title",
+			title, renamed.Title,
+		)
+		meta.Parents[i] = renamed.Title
+	}
+
+	return nil
+}
+
+// resolveRenamedFile returns the page a document published to under a previous
+// path, for a document whose own path is not recorded.
+//
+// A rename is not visible as an event. It shows up as one path that has stopped
+// appearing and another that has started, and the only thing tying them
+// together is what the file contains -- which is how git recovers renames too,
+// after the fact and by similarity rather than by being told.
+//
+// Returning (nil, nil) means no confident answer, and a new page is created.
+// That is the right way to be wrong here: a duplicate is a nuisance, where
+// rebinding onto the wrong page overwrites a document nobody asked to change.
+func resolveRenamedFile(
+	tracker *manifest.Store,
+	api *confluence.API,
+	meta *metadata.Meta,
+	file string,
+	sourceHash string,
+) (*confluence.PageInfo, error) {
+	if tracker == nil || meta == nil {
+		return nil, nil
+	}
+
+	previous, entry, ok, err := tracker.ResolveRenamed(meta.Space, sourceHash)
+	if err != nil {
+		return nil, fmt.Errorf("unable to check whether %q was renamed: %w", file, err)
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	pg, err := api.GetPageByID(entry.PageID)
+	if err != nil {
+		if !errors.Is(err, confluence.ErrNotFound) {
+			return nil, fmt.Errorf(
+				"unable to load page %s recorded for %q: %w", entry.PageID, previous, err,
+			)
+		}
+		// Recorded but gone, so there is nothing to rename. Drop the entry so it
+		// stops being offered, and let the document be published afresh.
+		log.Warn().Msgf("%s was published to page %s, which no longer exists", previous, entry.PageID)
+		return nil, tracker.Forget(meta.Space, previous)
+	}
+
+	log.Info().Msgf(
+		"%s has the content %s published as page %s; treating it as a rename rather than a new page",
+		file, previous, pg.ID,
+	)
+
+	// The old path is gone. Left in place it would be reported as a deleted
+	// file on every run from here on.
+	if err := tracker.Forget(meta.Space, previous); err != nil {
+		return nil, err
+	}
+
+	return pg, nil
 }
 
 func updateLabels(api *confluence.API, target *confluence.PageInfo, metaLabels []string) error {

--- a/mark_process_test.go
+++ b/mark_process_test.go
@@ -1,13 +1,19 @@
 package mark
 
 import (
+	"bytes"
+	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kovetskiy/mark/v16/confluence"
 	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -125,4 +131,758 @@ Some **content**.
 	parent, err := api.FindPage("DOCS", "Parent", "page")
 	require.NoError(t, err)
 	assert.Equal(t, parent.ID, stored.ParentID)
+}
+
+// markdownWithTitle is the document under test, parameterised on its title.
+func markdownWithTitle(title string) string {
+	return `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: ` + title + ` -->
+
+# ` + title + `
+
+Some content.
+`
+}
+
+// trackingConfig is a publish configured to remember page identity.
+func trackingConfig(server *confluencetest.Server, files string) Config {
+	return Config{
+		BaseURL:    server.URL,
+		Username:   "user",
+		Password:   "token",
+		Files:      files,
+		Features:   []string{"mention"},
+		TrackPages: true,
+		Output:     io.Discard,
+	}
+}
+
+// docsSpace builds the minimal realistic tree the publish path expects.
+func docsSpace(t *testing.T) (*confluencetest.Server, *confluence.API) {
+	t.Helper()
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+	return server, api
+}
+
+// countPagesTitled reports whether any page in the space carries a title, which
+// is what tells a retitle apart from a duplicate.
+//
+// It builds its own client on purpose. confluence.API memoises FindPage by
+// (space, title, type), so asking a client that has already looked this title up
+// would be answered from that cache and report a page that has since been
+// renamed out from under it.
+func countPagesTitled(t *testing.T, server *confluencetest.Server, title string) int {
+	t.Helper()
+	fresh := confluence.NewAPI(server.URL, "user", "token", false)
+	page, err := fresh.FindPage("DOCS", title, "page")
+	require.NoError(t, err)
+	if page == nil {
+		return 0
+	}
+	return 1
+}
+
+// TestTrackedPageIsRetitledNotDuplicated is the behaviour the manifest exists
+// for. mark finds a page by title, so changing the title makes the existing page
+// unfindable and a second one is published beside it. With tracking on, the file
+// path resolves to the page that was published last time and it is renamed in
+// place.
+func TestTrackedPageIsRetitledNotDuplicated(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	file := writeFile(t, dir, "doc.md", markdownWithTitle("Original Title"))
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	before, err := api.FindPage("DOCS", "Original Title", "page")
+	require.NoError(t, err)
+	require.NotNil(t, before)
+
+	// The Title header changes; the file does not move.
+	writeFile(t, dir, "doc.md", markdownWithTitle("Renamed Title"))
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	after := server.Page(before.ID)
+	require.NotNil(t, after)
+	assert.Equal(t, "Renamed Title", after.Title,
+		"the original page should have been retitled in place")
+
+	assert.Equal(t, 0, countPagesTitled(t, server, "Original Title"),
+		"nothing should still be published under the old title")
+}
+
+// TestUntrackedTitleChangeStillDuplicates is the control: without the flag the
+// old behaviour is unchanged, which is what makes the test above meaningful.
+func TestUntrackedTitleChangeStillDuplicates(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	config := trackingConfig(server, "")
+	config.TrackPages = false
+
+	file := writeFile(t, dir, "doc.md", markdownWithTitle("Original Title"))
+	config.Files = file
+	require.NoError(t, Run(config))
+
+	before, err := api.FindPage("DOCS", "Original Title", "page")
+	require.NoError(t, err)
+	require.NotNil(t, before)
+
+	writeFile(t, dir, "doc.md", markdownWithTitle("Renamed Title"))
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, "Original Title", server.Page(before.ID).Title,
+		"without tracking the first page is left behind under its old title")
+	assert.Equal(t, 1, countPagesTitled(t, server, "Renamed Title"),
+		"and a second page now exists under the new one")
+}
+
+// TestTrackedRetitleHappensEvenWhenContentIsUnchanged covers the interaction
+// with --changes-only: the content fingerprint matches, so the update would be
+// skipped, and the page would keep its old title forever.
+func TestTrackedRetitleHappensEvenWhenContentIsUnchanged(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	body := `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: %s -->
+
+Body that does not change.
+`
+	file := writeFile(t, dir, "doc.md", fmt.Sprintf(body, "First"))
+	config := trackingConfig(server, file)
+	config.ChangesOnly = true
+	require.NoError(t, Run(config))
+
+	before, err := api.FindPage("DOCS", "First", "page")
+	require.NoError(t, err)
+	require.NotNil(t, before)
+
+	// Only the title changes; the rendered body is byte-identical.
+	writeFile(t, dir, "doc.md", fmt.Sprintf(body, "Second"))
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, "Second", server.Page(before.ID).Title,
+		"a retitle must not be skipped just because the content hash matched")
+}
+
+// TestTrackingReportsOrphansWithoutDeleting: a file that disappears from the
+// glob is reported, and the page it published to is left completely alone.
+// Phase 1 never deletes.
+func TestTrackingReportsOrphansWithoutDeleting(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "keep.md", markdownWithTitle("Keep"))
+	writeFile(t, dir, "drop.md", markdownWithTitle("Drop"))
+	require.NoError(t, Run(trackingConfig(server, filepath.Join(dir, "*.md"))))
+
+	dropped, err := api.FindPage("DOCS", "Drop", "page")
+	require.NoError(t, err)
+	require.NotNil(t, dropped)
+
+	require.NoError(t, os.Remove(filepath.Join(dir, "drop.md")))
+	require.NoError(t, Run(trackingConfig(server, filepath.Join(dir, "*.md"))))
+
+	assert.NotNil(t, server.Page(dropped.ID),
+		"the page of a deleted file must survive: phase 1 reports, it does not prune")
+}
+
+// TestTrackedPageDeletedInConfluenceIsRecreated: someone removed the page from
+// Confluence by hand. The manifest still names it, and pointing at a page that
+// is not there must not wedge the run.
+func TestTrackedPageDeletedInConfluenceIsRecreated(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	file := writeFile(t, dir, "doc.md", markdownWithTitle("Doc"))
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	published, err := api.FindPage("DOCS", "Doc", "page")
+	require.NoError(t, err)
+	require.NotNil(t, published)
+
+	server.DeletePage(published.ID)
+
+	// Retitle too, so the title lookup also misses and resolution is forced
+	// through the manifest entry that now dangles.
+	writeFile(t, dir, "doc.md", markdownWithTitle("Doc Renamed"))
+	require.NoError(t, Run(trackingConfig(server, file)),
+		"a dangling manifest entry must not fail the run")
+
+	assert.Equal(t, 1, countPagesTitled(t, server, "Doc Renamed"),
+		"the page should have been created afresh")
+}
+
+// TestTrackingSavesManifestEvenWhenAFileFails covers the case --continue-on-error
+// exists for. The manifest used to be written only after an early return on
+// hasErrors, so one unpublishable file discarded the mapping for every page that
+// had published perfectly well, and the next run had no protection at all.
+func TestTrackingSavesManifestEvenWhenAFileFails(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	good := writeFile(t, dir, "good.md", markdownWithTitle("Good"))
+	// No Space header and no --space, which fails in metadata rather than
+	// anywhere that could be mistaken for a manifest problem.
+	writeFile(t, dir, "bad.md", "# Orphan\n\nNo metadata at all.\n")
+
+	config := trackingConfig(server, filepath.Join(dir, "*.md"))
+	config.ContinueOnError = true
+	require.Error(t, Run(config), "the bad file should still fail the run")
+
+	published, err := api.FindPage("DOCS", "Good", "page")
+	require.NoError(t, err)
+	require.NotNil(t, published)
+
+	// The mapping for the file that did publish must have survived: retitle it
+	// and it should be found again rather than duplicated.
+	writeFile(t, dir, "good.md", markdownWithTitle("Good Renamed"))
+	config.Files = good
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, "Good Renamed", server.Page(published.ID).Title,
+		"the mapping recorded on the failed run should have been saved")
+	assert.Equal(t, 0, countPagesTitled(t, server, "Good"),
+		"nothing should be left behind under the old title")
+}
+
+// TestTrackingSuppressesOrphanReportOnFailedRuns pins the branch that used to be
+// unreachable. A file that failed to process is indistinguishable from one that
+// was deleted, so reporting it as missing would be actively misleading.
+func TestTrackingSuppressesOrphanReportOnFailedRuns(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "a.md", markdownWithTitle("A"))
+	writeFile(t, dir, "b.md", markdownWithTitle("B"))
+	require.NoError(t, Run(trackingConfig(server, filepath.Join(dir, "*.md"))))
+
+	// b.md now fails to process rather than disappearing.
+	writeFile(t, dir, "b.md", "# Broken\n\nNo metadata.\n")
+
+	var logged bytes.Buffer
+	restore := log.Logger
+	log.Logger = zerolog.New(&logged)
+	defer func() { log.Logger = restore }()
+
+	config := trackingConfig(server, filepath.Join(dir, "*.md"))
+	config.ContinueOnError = true
+	require.Error(t, Run(config))
+
+	assert.NotContains(t, logged.String(), "had no matching source file",
+		"a run with errors must not report unpublished pages as missing")
+}
+
+// TestTrackedPageLoadFailureDoesNotDuplicate covers the distinction flaw 6 was
+// about. A recorded page that is genuinely gone falls through to being created
+// again; any other failure to load it must stop the run instead, because
+// treating a transient error as "the page is gone" publishes exactly the
+// duplicate this feature exists to prevent.
+func TestTrackedPageLoadFailureDoesNotDuplicate(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	file := writeFile(t, dir, "doc.md", markdownWithTitle("Doc"))
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	published, err := api.FindPage("DOCS", "Doc", "page")
+	require.NoError(t, err)
+	require.NotNil(t, published)
+
+	// The page is still there, but loading it fails the way a proxy or an
+	// overloaded instance would.
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/content/"+published.ID) {
+			return http.StatusInternalServerError, `{"message":"upstream exploded"}`, true
+		}
+		return 0, "", false
+	})
+
+	// Retitle so resolution is forced through the manifest entry.
+	writeFile(t, dir, "doc.md", markdownWithTitle("Doc Renamed"))
+	require.Error(t, Run(trackingConfig(server, file)),
+		"a page that cannot be loaded must stop the run, not be republished")
+
+	server.SetFail(nil)
+	assert.Equal(t, 0, countPagesTitled(t, server, "Doc Renamed"),
+		"no duplicate should have been created")
+	assert.Equal(t, "Doc", server.Page(published.ID).Title,
+		"the original page is untouched")
+}
+
+// markdownUnder is a document declaring the full ancestry Parent > parent.
+// The whole chain has to be declared, not just the immediate parent, or mark
+// rejects the page as sitting at a different depth than its headers claim.
+func markdownUnder(parent, title string) string {
+	return `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Parent: ` + parent + ` -->
+<!-- Title: ` + title + ` -->
+
+Body.
+`
+}
+
+// TestRenamedParentIsFollowedNotRecreated is the reference half of the problem
+// tracking exists for. mark names a parent by title and creates it when the
+// title is not found, so renaming a page that other documents declare as their
+// parent used to strand them under a fresh empty page carrying the old name --
+// and tracking made that likelier, because the parent is now renamed in place
+// rather than duplicated somewhere visible.
+func TestRenamedParentIsFollowedNotRecreated(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	// Named so the parent is processed first. With the child first it is
+	// resolved while the parent still carries its old title, and the stale
+	// reference is never exercised -- which is exactly how this test passed
+	// against the unfixed code the first time it was written.
+	writeFile(t, dir, "a-parent.md", markdownWithTitle("Guide"))
+	writeFile(t, dir, "b-child.md", markdownUnder("Guide", "Child"))
+	glob := filepath.Join(dir, "*.md")
+	require.NoError(t, Run(trackingConfig(server, glob)))
+
+	parentPage, err := api.FindPage("DOCS", "Guide", "page")
+	require.NoError(t, err)
+	require.NotNil(t, parentPage)
+
+	// The parent is renamed. The child still declares the old title.
+	writeFile(t, dir, "a-parent.md", markdownWithTitle("Guide Renamed"))
+	require.NoError(t, Run(trackingConfig(server, glob)))
+
+	assert.Equal(t, "Guide Renamed", server.Page(parentPage.ID).Title,
+		"the parent should have been renamed in place")
+	assert.Equal(t, 0, countPagesTitled(t, server, "Guide"),
+		"no empty page should have been created under the old title")
+
+	child, err := confluence.NewAPI(server.URL, "user", "token", false).
+		FindPage("DOCS", "Child", "page")
+	require.NoError(t, err)
+	require.NotNil(t, child)
+	assert.Equal(t, parentPage.ID, server.Page(child.ID).ParentID,
+		"the child should still sit under the same page it always did")
+}
+
+// TestUnknownParentTitleIsStillCreated is the control: a parent mark has never
+// published is not a stale reference, and must still be created as before.
+func TestUnknownParentTitleIsStillCreated(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	file := writeFile(t, dir, "child.md", markdownUnder("Brand New Parent", "Child"))
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	assert.Equal(t, 1, countPagesTitled(t, server, "Brand New Parent"),
+		"an unknown parent title is not stale and should still be created")
+}
+
+// TestTwoFilesClaimingOnePageIsReported: nothing stops two documents resolving
+// to the same page by title, and then a rename of either moves a page the other
+// also believes is its own. mark cannot tell which was meant, so it says so.
+func TestTwoFilesClaimingOnePageIsReported(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	// Same title, two files.
+	writeFile(t, dir, "one.md", markdownWithTitle("Shared"))
+	writeFile(t, dir, "two.md", markdownWithTitle("Shared"))
+
+	var logged bytes.Buffer
+	restore := log.Logger
+	log.Logger = zerolog.New(&logged)
+	defer func() { log.Logger = restore }()
+
+	require.NoError(t, Run(trackingConfig(server, filepath.Join(dir, "*.md"))))
+
+	assert.Contains(t, logged.String(), "both publish to page",
+		"two files resolving to one page should be reported")
+}
+
+// TestPageIDModeSaysTrackingDoesNotApply: the mapping is per space and per
+// file, and a publish straight to a page id has neither. Better said once than
+// discovered later as a manifest with holes in it.
+func TestPageIDModeSaysTrackingDoesNotApply(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	existing := server.AddPage("DOCS", "Existing", "page", "")
+	file := writeFile(t, dir, "doc.md", "Just a body.\n")
+
+	var logged bytes.Buffer
+	restore := log.Logger
+	log.Logger = zerolog.New(&logged)
+	defer func() { log.Logger = restore }()
+
+	config := trackingConfig(server, file)
+	config.PageID = existing.ID
+	require.NoError(t, Run(config))
+
+	assert.Contains(t, logged.String(), "no effect together with a page id")
+}
+
+// TestDryRunWritesNothing pins the promise --dry-run makes. Tracking gave it a
+// way to break that promise: resolving the hierarchy records what it finds, a
+// recording marks the manifest dirty, and Save writes it -- so a dry run would
+// modify Confluence.
+func TestDryRunWritesNothing(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	file := writeFile(t, dir, "doc.md", markdownWithTitle("Doc"))
+
+	config := trackingConfig(server, file)
+	config.DryRun = true
+	require.NoError(t, Run(config))
+
+	for _, r := range server.Requests() {
+		assert.Equal(t, http.MethodGet, r.Method,
+			"a dry run must issue no writes, saw %s %s", r.Method, r.Path)
+	}
+}
+
+// markdownInFolder declares a folder hierarchy under the MARK_PARENTS anchor.
+func markdownInFolder(folder, title string) string {
+	return `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Folder: ` + folder + ` -->
+<!-- Title: ` + title + ` -->
+
+Body.
+`
+}
+
+// TestFolderPublishWithoutTracking is the path that carried a latent panic: a
+// nil *manifest.Store placed in a FolderTracker interface is a non-nil
+// interface, so with tracking off mark would have called through a nil
+// receiver. Nothing exercised it, because the fake had no folder endpoints.
+func TestFolderPublishWithoutTracking(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	file := writeFile(t, dir, "doc.md", markdownInFolder("Guides", "Doc"))
+	config := trackingConfig(server, file)
+	config.TrackPages = false
+
+	require.NoError(t, Run(config), "publishing into a folder must work with tracking off")
+
+	folders := server.Folders()
+	require.Len(t, folders, 1)
+	assert.Equal(t, "Guides", folders[0].Title)
+}
+
+func TestFolderPublishWithTracking(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	file := writeFile(t, dir, "doc.md", markdownInFolder("Guides", "Doc"))
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	folders := server.Folders()
+	require.Len(t, folders, 1, "exactly one folder should exist")
+	assert.Equal(t, "Guides", folders[0].Title)
+}
+
+// TestRenamedFolderIsFollowedNotDuplicated is what folder tracking is for.
+// Folders are found by title, so one renamed in Confluence stops matching the
+// header that declares it and mark builds a second beside the first, splitting
+// the hierarchy.
+func TestRenamedFolderIsFollowedNotDuplicated(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	file := writeFile(t, dir, "doc.md", markdownInFolder("Guides", "Doc"))
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	original := server.Folders()
+	require.Len(t, original, 1)
+
+	// Somebody renames the folder in the Confluence UI. The header still says
+	// "Guides".
+	server.RenameFolder(original[0].ID, "Guides Renamed")
+
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	after := server.Folders()
+	assert.Len(t, after, 1,
+		"the renamed folder should have been reused, not duplicated")
+	assert.Equal(t, original[0].ID, after[0].ID)
+}
+
+// TestRenamedFolderDuplicatesWithoutTracking is the control: without the flag
+// the old behaviour stands, which is what makes the test above mean anything.
+func TestRenamedFolderDuplicatesWithoutTracking(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	config := trackingConfig(server, "")
+	config.TrackPages = false
+	file := writeFile(t, dir, "doc.md", markdownInFolder("Guides", "Doc"))
+	config.Files = file
+
+	require.NoError(t, Run(config))
+	original := server.Folders()
+	require.Len(t, original, 1)
+
+	server.RenameFolder(original[0].ID, "Guides Renamed")
+	require.NoError(t, Run(config))
+
+	assert.Len(t, server.Folders(), 2,
+		"without tracking the renamed folder is not recognised and a second appears")
+}
+
+// TestDryRunDoesNotRecordFolders covers the other defect the missing endpoints
+// hid: resolving a hierarchy records what it finds, a recording marks the
+// manifest dirty, and Save writes it -- so --dry-run wrote to Confluence.
+func TestDryRunDoesNotRecordFolders(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	// A folder that already exists, so a dry run resolves rather than creates.
+	server.AddFolder("DOCS", "Guides", "", "page")
+
+	file := writeFile(t, dir, "doc.md", markdownInFolder("Guides", "Doc"))
+	config := trackingConfig(server, file)
+	config.DryRun = true
+	require.NoError(t, Run(config))
+
+	for _, r := range server.Requests() {
+		assert.Equal(t, http.MethodGet, r.Method,
+			"a dry run must issue no writes, saw %s %s", r.Method, r.Path)
+	}
+}
+
+// markdownTitledFromFilename has no Title header, so its title comes from the
+// filename -- which is what makes a rename change the title too, and the case
+// that duplicates without rename detection.
+func markdownTitledFromFilename() string {
+	return `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+
+Body that does not change when the file moves.
+`
+}
+
+func filenameTitleConfig(server *confluencetest.Server, files string) Config {
+	config := trackingConfig(server, files)
+	config.TitleFromFilename = true
+	return config
+}
+
+// TestRenamedFileIsFollowedNotDuplicated is the last of the three rename causes
+// asked for. The path is the manifest key, so renaming a file is a miss; and
+// when the title comes from the filename the title lookup misses too, and mark
+// publishes a second page. The only thing tying the old page to the new file is
+// what the file contains.
+func TestRenamedFileIsFollowedNotDuplicated(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "old-name.md", markdownTitledFromFilename())
+	glob := filepath.Join(dir, "*.md")
+	require.NoError(t, Run(filenameTitleConfig(server, glob)))
+
+	original, err := api.FindPage("DOCS", "Old Name", "page")
+	require.NoError(t, err)
+	require.NotNil(t, original, "the first run publishes under the filename")
+
+	// The file is renamed. Its content is untouched.
+	require.NoError(t, os.Rename(
+		filepath.Join(dir, "old-name.md"), filepath.Join(dir, "new-name.md")))
+	require.NoError(t, Run(filenameTitleConfig(server, glob)))
+
+	assert.Equal(t, "New Name", server.Page(original.ID).Title,
+		"the existing page should have been renamed, not left behind")
+	assert.Equal(t, 0, countPagesTitled(t, server, "Old Name"),
+		"nothing should remain under the old name")
+}
+
+// TestRenamedFileDuplicatesWithoutTracking is the control.
+func TestRenamedFileDuplicatesWithoutTracking(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	config := filenameTitleConfig(server, filepath.Join(dir, "*.md"))
+	config.TrackPages = false
+
+	writeFile(t, dir, "old-name.md", markdownTitledFromFilename())
+	require.NoError(t, Run(config))
+
+	original, err := api.FindPage("DOCS", "Old Name", "page")
+	require.NoError(t, err)
+	require.NotNil(t, original)
+
+	require.NoError(t, os.Rename(
+		filepath.Join(dir, "old-name.md"), filepath.Join(dir, "new-name.md")))
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, "Old Name", server.Page(original.ID).Title,
+		"without tracking the old page is stranded under its old name")
+	assert.Equal(t, 1, countPagesTitled(t, server, "New Name"),
+		"and a second page appears")
+}
+
+// TestRenamedFileStopsBeingReportedAsDeleted: a followed rename must take the
+// old path with it, or it is reported as a missing file on every run from then
+// on.
+func TestRenamedFileStopsBeingReportedAsDeleted(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "old-name.md", markdownTitledFromFilename())
+	glob := filepath.Join(dir, "*.md")
+	require.NoError(t, Run(filenameTitleConfig(server, glob)))
+
+	require.NoError(t, os.Rename(
+		filepath.Join(dir, "old-name.md"), filepath.Join(dir, "new-name.md")))
+	require.NoError(t, Run(filenameTitleConfig(server, glob)))
+
+	var logged bytes.Buffer
+	restore := log.Logger
+	log.Logger = zerolog.New(&logged)
+	defer func() { log.Logger = restore }()
+
+	require.NoError(t, Run(filenameTitleConfig(server, glob)))
+	assert.NotContains(t, logged.String(), "had no matching source file",
+		"the old path should have been dropped when the rename was followed")
+}
+
+// TestAmbiguousRenameCreatesRatherThanGuesses: two unpublished documents with
+// identical content give no basis for choosing between them. A duplicate is a
+// nuisance; rebinding onto the wrong page overwrites something nobody asked to
+// change.
+func TestAmbiguousRenameCreatesRatherThanGuesses(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "one.md", markdownTitledFromFilename())
+	writeFile(t, dir, "two.md", markdownTitledFromFilename())
+	glob := filepath.Join(dir, "*.md")
+	require.NoError(t, Run(filenameTitleConfig(server, glob)))
+
+	// Both disappear and one appears with the same content.
+	require.NoError(t, os.Remove(filepath.Join(dir, "one.md")))
+	require.NoError(t, os.Rename(
+		filepath.Join(dir, "two.md"), filepath.Join(dir, "three.md")))
+	require.NoError(t, Run(filenameTitleConfig(server, glob)))
+
+	assert.Equal(t, 1, countPagesTitled(t, server, "Three"),
+		"an ambiguous match must create rather than rebind")
+	assert.Equal(t, 1, countPagesTitled(t, server, "One"),
+		"and must leave both candidates alone")
+}
+
+// TestOrphansAreScopedToTheGlob: a run narrowed with --files says nothing about
+// files outside it. Reporting them as missing buries the handful of genuine
+// deletions in a list of files that are perfectly present.
+func TestOrphansAreScopedToTheGlob(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "guides"), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "notes"), 0o750))
+	writeFile(t, dir, "guides/a.md", markdownWithTitle("A"))
+	writeFile(t, dir, "notes/b.md", markdownWithTitle("B"))
+
+	// Publish each subtree with its own glob.
+	require.NoError(t, Run(trackingConfig(server, filepath.Join(dir, "guides", "*.md"))))
+	require.NoError(t, Run(trackingConfig(server, filepath.Join(dir, "notes", "*.md"))))
+
+	var logged bytes.Buffer
+	restore := log.Logger
+	log.Logger = zerolog.New(&logged)
+	defer func() { log.Logger = restore }()
+
+	// Re-run only the guides. notes/b.md is untouched and still present.
+	require.NoError(t, Run(trackingConfig(server, filepath.Join(dir, "guides", "*.md"))))
+
+	assert.NotContains(t, logged.String(), "had no matching source file",
+		"a run scoped to one directory must not report another's files as missing")
+}
+
+// TestDeletedFileIsReportedOnceThenForgotten: left in place, a deletion is
+// reported on every run forever, which teaches people to ignore the one message
+// worth reading.
+func TestDeletedFileIsReportedOnceThenForgotten(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "keep.md", markdownWithTitle("Keep"))
+	writeFile(t, dir, "drop.md", markdownWithTitle("Drop"))
+	glob := filepath.Join(dir, "*.md")
+	require.NoError(t, Run(trackingConfig(server, glob)))
+
+	require.NoError(t, os.Remove(filepath.Join(dir, "drop.md")))
+
+	first := captureLog(t, func() { require.NoError(t, Run(trackingConfig(server, glob))) })
+	assert.Contains(t, first, "had no matching source file",
+		"the deletion should be reported the first time it is noticed")
+
+	second := captureLog(t, func() { require.NoError(t, Run(trackingConfig(server, glob))) })
+	assert.NotContains(t, second, "had no matching source file",
+		"and not on every run thereafter")
+}
+
+// captureLog runs fn with the global logger redirected, returning what it wrote.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	restore := log.Logger
+	log.Logger = zerolog.New(&buf)
+	defer func() { log.Logger = restore }()
+	fn()
+	return buf.String()
+}
+
+// TestDryRunReportsWhatWouldHappen: a dry run that announces a new page for a
+// retitle the real run would have done in place is confidently wrong about the
+// one thing somebody is checking.
+func TestDryRunReportsWhatWouldHappen(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	file := writeFile(t, dir, "doc.md", markdownWithTitle("Original"))
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	writeFile(t, dir, "doc.md", markdownWithTitle("Renamed"))
+
+	config := trackingConfig(server, file)
+	config.DryRun = true
+	logged := captureLog(t, func() { require.NoError(t, Run(config)) })
+
+	assert.Contains(t, logged, "retitled from",
+		"a dry run should say the existing page would be retitled")
+}
+
+// TestDryRunStillWritesNothingWithTracking: the dry run now resolves through
+// the manifest, which is what records folders, so the guard has to be that the
+// store cannot write rather than that it is never asked to.
+func TestDryRunStillWritesNothingWithTracking(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	// The folder has to hang off the anchor page the headers name, or it is not
+	// resolved at all and nothing is ever recorded -- which would leave this
+	// test asserting nothing.
+	anchor, err := api.FindPage("DOCS", "Parent", "page")
+	require.NoError(t, err)
+	require.NotNil(t, anchor)
+	server.AddFolder("DOCS", "Guides", anchor.ID, "page")
+
+	file := writeFile(t, dir, "doc.md", markdownInFolder("Guides", "Doc"))
+
+	config := trackingConfig(server, file)
+	config.DryRun = true
+	require.NoError(t, Run(config))
+
+	for _, r := range server.Requests() {
+		assert.Equal(t, http.MethodGet, r.Method,
+			"a dry run must issue no writes, saw %s %s", r.Method, r.Path)
+	}
 }

--- a/page/ancestry.go
+++ b/page/ancestry.go
@@ -29,6 +29,22 @@ var (
 	createdFolderMutex sync.RWMutex
 )
 
+// ResetFolderCache empties the folder cache.
+//
+// The cache is package-level and keyed only by space, parent and title, with no
+// notion of which Confluence it came from. That is fine within one run and
+// wrong across two: Run is a public entry point, so a process can publish twice
+// -- to different instances, even -- and the second would resolve folders to
+// ids the first saw. It also means a folder renamed or deleted between runs is
+// never looked up again.
+//
+// Run calls this before it starts, so a run never inherits another's answers.
+func ResetFolderCache() {
+	createdFolderMutex.Lock()
+	defer createdFolderMutex.Unlock()
+	clear(createdFolderCache)
+}
+
 func folderCacheKey(space, contextID, title string) string {
 	return space + "\x00" + contextID + "\x00" + title
 }
@@ -91,12 +107,41 @@ func resolveFolder(
 
 // EnsureFolderAncestry creates the folder hierarchy and returns the final parent for page creation.
 // Top-level folders are created under anchorPageID (MARK_PARENTS page); nested folders nest under prior folders.
+// FolderTracker remembers which Confluence folder a declared folder path
+// resolved to.
+//
+// Folders are found by title, and mark creates one when the title is not found.
+// A folder renamed in Confluence therefore stops matching the header that
+// declares it, and mark builds a second folder beside the first and moves pages
+// into it, splitting the hierarchy. Remembering the folder makes the rename
+// survivable.
+//
+// An interface rather than the concrete store so this package keeps knowing
+// nothing about where the mapping is kept. A nil tracker disables the whole
+// mechanism, which is what every caller that does not opt in passes.
+type FolderTracker interface {
+	RecordFolder(space, folderPath, folderID string) error
+	LookupFolder(space, folderPath string) (string, bool, error)
+}
+
+// folderPathKey names a folder by the chain of titles leading to it, under the
+// anchor it hangs from. The anchor is part of the key because the same chain of
+// titles under a different anchor is a different folder.
+func folderPathKey(anchorPageID *string, folders []string, upto int) string {
+	anchor := ""
+	if anchorPageID != nil {
+		anchor = *anchorPageID
+	}
+	return anchor + "\x00" + strings.Join(folders[:upto+1], "\x00")
+}
+
 func EnsureFolderAncestry(
 	dryRun bool,
 	api *confluence.API,
 	space string,
 	folders []string,
 	anchorPageID *string,
+	tracker FolderTracker,
 ) (*ParentInfo, error) {
 	if len(folders) == 0 {
 		return nil, nil
@@ -132,8 +177,39 @@ func EnsureFolderAncestry(
 			return nil, fmt.Errorf("error finding folder with title %q: %w", title, err)
 		}
 
+		if folder == nil && tracker != nil {
+			// No folder carries this title. It may have been renamed in
+			// Confluence since the last run, in which case the folder recorded
+			// for this position is still the right one and creating another
+			// would split the hierarchy in two.
+			key := folderPathKey(anchorPageID, folders, i)
+			id, ok, lookupErr := tracker.LookupFolder(space, key)
+			if lookupErr != nil {
+				return nil, fmt.Errorf("unable to check whether folder %q was renamed: %w", title, lookupErr)
+			}
+			if ok {
+				folder, err = api.GetFolderByID(id)
+				if err != nil {
+					// Recorded but gone. Fall through and create it again.
+					log.Warn().Msgf("folder %q was recorded as %s, which no longer exists", title, id)
+					folder = nil
+				} else if folder != nil {
+					log.Info().Msgf(
+						"folder %q was renamed to %q; using it rather than creating another",
+						title, folder.Title,
+					)
+				}
+			}
+		}
+
 		if folder == nil {
 			break
+		}
+
+		if tracker != nil {
+			if err := tracker.RecordFolder(space, folderPathKey(anchorPageID, folders, i), folder.ID); err != nil {
+				return nil, err
+			}
 		}
 
 		cacheFolder(space, underID, title, folder.ID)
@@ -161,7 +237,10 @@ func EnsureFolderAncestry(
 	)
 
 	if !dryRun {
-		for _, title := range rest {
+		// rest is the tail of folders that does not exist yet, so its offset
+		// within folders is what makes a recorded key match on the next run.
+		firstNew := len(folders) - len(rest)
+		for offset, title := range rest {
 			var folder *confluence.FolderInfo
 			var err error
 
@@ -216,6 +295,13 @@ func EnsureFolderAncestry(
 			}
 			cacheFolder(space, underID, title, folder.ID)
 
+			if tracker != nil {
+				key := folderPathKey(anchorPageID, folders, firstNew+offset)
+				if err := tracker.RecordFolder(space, key, folder.ID); err != nil {
+					return nil, err
+				}
+			}
+
 			parent = &ParentInfo{
 				ID:    folder.ID,
 				Title: folder.Title,
@@ -247,6 +333,7 @@ func EnsureFolderAncestry(
 func EnsureMixedAncestry(
 	dryRun bool,
 	api *confluence.API,
+	tracker FolderTracker,
 	space string,
 	folders []string,
 	pages []string,
@@ -271,7 +358,7 @@ func EnsureMixedAncestry(
 		return EnsureAncestry(dryRun, api, space, pages)
 	}
 
-	folderParent, err := EnsureFolderAncestry(dryRun, api, space, folders, anchorPageID)
+	folderParent, err := EnsureFolderAncestry(dryRun, api, space, folders, anchorPageID, tracker)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create folder hierarchy: %w", err)
 	}

--- a/page/page.go
+++ b/page/page.go
@@ -13,6 +13,7 @@ func ResolvePage(
 	dryRun bool,
 	api *confluence.API,
 	meta *metadata.Meta,
+	tracker FolderTracker,
 ) (*confluence.PageInfo, *confluence.PageInfo, error) {
 	if meta == nil {
 		return nil, nil, fmt.Errorf("metadata is empty")
@@ -75,6 +76,7 @@ func ResolvePage(
 		parent, err = EnsureMixedAncestry(
 			dryRun,
 			api,
+			tracker,
 			meta.Space,
 			meta.Folders,
 			meta.Parents,

--- a/util/cli.go
+++ b/util/cli.go
@@ -115,6 +115,7 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 		VersionMessage:   cmd.String("version-message"),
 		EditLock:         cmd.Bool("edit-lock"),
 		ChangesOnly:      cmd.Bool("changes-only"),
+		TrackPages:       cmd.Bool("track-pages"),
 		PreserveComments: cmd.Bool("preserve-comments"),
 
 		DropH1:          cmd.Bool("drop-h1"),

--- a/util/flags.go
+++ b/util/flags.go
@@ -195,6 +195,12 @@ var Flags = []cli.Flag{
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHANGES_ONLY"), altsrctoml.TOML("changes-only", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.BoolFlag{
+		Name:    "track-pages",
+		Value:   false,
+		Usage:   "Remember which page each file publishes to, so renaming a file or changing its title updates the existing page instead of creating a second one. Stores the mapping in Confluence (a space property on Cloud, a homepage content property on Server/Data Center); nothing is written to the repository.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TRACK_PAGES"), altsrctoml.TOML("track-pages", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
 		Name:    "preserve-comments",
 		Value:   false,
 		Usage:   "Fetch and preserve inline comments on existing Confluence pages.",


### PR DESCRIPTION
Gives a published page an identity that survives being renamed, so mark stops publishing a second page beside the first.

## The problem

mark finds an existing page by its **title**, and that title comes from three independently mutable places:

| source | where |
| --- | --- |
| `Title` header | `metadata/metadata.go:223` |
| leading H1 | `metadata/metadata.go:283` |
| filename | `metadata/metadata.go:285` |

Change any of them and `FindPage(space, title, type)` returns nothing, which is indistinguishable from the page being new. mark publishes a duplicate and strands the original under its old name.

## The approach

Record which page each source file published to, keyed on the **file path** — the one identity that is stable, not derived from content, and not already in Confluence — and consult it exactly when the title lookup comes up empty. **Nothing is written back to the repository**: no page ids in your Markdown, no lock file, no commit.

Off by default, behind `--track-pages`.

## What it handles

| change | result |
| --- | --- |
| `Title` header edited | existing page retitled in place |
| leading H1 edited | same |
| **file renamed** | matched by content fingerprint, page retitled rather than duplicated |
| **parent page renamed** | reference followed to the page carrying that title now |
| **folder renamed in Confluence** | recorded folder reused rather than a second one created |
| source file deleted | reported once, then forgotten. **No page is ever deleted** |
| two files resolving to one page | reported |
| document changes `Space` | reported; old page left behind |

A rename must be *unambiguous* — a unique content match, onto a page no other file claimed this run. Anything else creates a new page: a duplicate is a nuisance, where rebinding onto the wrong page overwrites a document nobody asked to change. A file renamed *and* substantially rewritten in one commit therefore reads as a deletion plus a new page, the same limit git has above its similarity threshold.

## Where the mapping lives

| instance | storage |
| --- | --- |
| Cloud | space properties `mark.manifest.0` … `.15`, plus `mark.manifest.folders` |
| Server / Data Center | content properties of the same names on the space homepage |

Space properties are v2-only, so Server and Data Center anchor to the homepage instead, reached through `FindHomePage`. Cloud keeps the space property rather than using the homepage for both, because content properties are a v1 endpoint and v1 is what a scoped API token cannot reach (#341).

It is split over sixteen properties because Confluence bounds a property value, and one blob would cap how many files a repository may have — failing by publishing every page and *then* erroring on the write. Each path is assigned a shard by hash; all shards are read in one listing and only changed ones are written. Splitting also contains damage: an unreadable property costs the paths it held, not the space.

Keys are stored relative to the working directory and with forward slashes, so an absolute glob and a relative one, or a Windows machine and Linux CI, share one mapping rather than keeping two. Keys written before that are migrated as the mapping is read.

## Deliberate restraint

- **No page is ever deleted.** Deletions are reported, and the report is scoped to the `--files` pattern that published each entry, since a run narrowed to one directory says nothing about any other. Suppressed entirely on runs that had errors, where a file that failed to process is indistinguishable from one that is gone.
- **A dry run writes nothing**, to Confluence or to the mapping, while still resolving through it so it can say which existing page a retitle or rename *would* have updated. The guard is a store that cannot write, not one that is merely not asked to — the weaker version let a dry run write.
- **A failed manifest read is reported, never folded into "nothing known"**, or a network hiccup would create a duplicate.
- **A dangling entry falls through to create only on a genuine 404.**

## Testing

`manifest`: 30+ tests over real HTTP against the fake, covering both backends, sharding, scoping, pruning, migration, concurrency conflicts, and mappings written by earlier versions.

End to end through `Run`: retitle, rename, folder rename, deletion reporting, dry-run behaviour, and — for each — **the same scenario with the flag off**, which is what makes the positive cases mean anything.

`confluencetest` gained space and content property endpoints, folder search/create/read, the v2 page create used for folder parents, and content move. The fake refuses what Confluence refuses: a duplicate folder title under one parent, a stale property version, and a content-property update missing its id.

Every test was checked against the unfixed code. Two passed and were rewritten.

## Known gaps

- The property endpoints were exercised against a real instance and worked. Before that, create, read and list had been confirmed against Atlassian's documentation, which is how the update's required `id` field was found missing.
- Enabling tracking on an already-published space costs one run: the first adopts existing pages, so a rename made in that same run is not protected.
- Changing a `Parent:` header still fails the run with an ancestry error rather than moving the page. That is pre-existing behaviour, unchanged here.
- There is no way to inspect or repair the mapping other than through the Confluence API by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

