### PR TITLE
fix: move a page when its Parent header changes, rather than refusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ appended to the values from front matter.
 There can be any number of `Parent` headers, if Mark can't find specified
 parent by title, Mark creates it.
 
+Changing a `Parent` header on a page that has already been published moves that
+page to the new parent. Mark treats your repository as the source of truth for
+where a page lives, as it already does for the page's title and content, so a
+page somebody has moved by hand in Confluence is moved back on the next run. A
+page nested *below* its declared parent is left where it is: every parent the
+headers name is still in its ancestry, so nothing is contradicted.
+
 The `Folder` header allows organizing pages within Confluence folders. Like `Parent` headers,
 if Mark can't find the specified folder by title, it creates it. Folders and parents can be
 mixed in the same document to create complex hierarchies.

--- a/mark.go
+++ b/mark.go
@@ -443,6 +443,22 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 			if err := page.EnsurePageUnderFolderParent(api, pg, parent.ID); err != nil {
 				return nil, fmt.Errorf("error relocating page %q: %w", meta.Title, err)
 			}
+		} else if parent != nil && !page.UnderDeclaredParents(pg, meta.Parents) {
+			// A page resolved through the manifest rather than by title never
+			// passed the ancestry check, because that check starts from a title
+			// lookup that just missed. So an edit changing the title and the
+			// parent together would retitle the page and leave it where it was.
+			if err := page.EnsurePageUnderParent(api, pg, parent.ID); err != nil {
+				return nil, fmt.Errorf("error relocating page %q: %w", meta.Title, err)
+			}
+		}
+
+		// Relocating refreshes the page from Confluence, which still carries the
+		// old title -- the retitle above is staged and not published until the
+		// update below. Without this it is overwritten by the move and the page
+		// keeps its old name, silently and only when both changed at once.
+		if titleChanged && pg != nil {
+			pg.Title = meta.Title
 		}
 
 		target = pg

--- a/mark_process_test.go
+++ b/mark_process_test.go
@@ -886,3 +886,160 @@ func TestDryRunStillWritesNothingWithTracking(t *testing.T) {
 			"a dry run must issue no writes, saw %s %s", r.Method, r.Path)
 	}
 }
+
+// markdownUnderParent declares a single named parent.
+func markdownUnderParent(parent, title string) string {
+	return `<!-- Space: DOCS -->
+<!-- Parent: ` + parent + ` -->
+<!-- Title: ` + title + ` -->
+
+Body.
+`
+}
+
+// TestChangingTheParentHeaderMovesThePage is issue #430. Changing a Parent
+// header used to fail the run with an ancestry error, leaving the declared
+// hierarchy and the real one disagreeing and doing nothing about either. The
+// reporter said plainly that they expected the page to be moved.
+func TestChangingTheParentHeaderMovesThePage(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+	other := server.AddPage("DOCS", "Other", "page", home.ID)
+
+	dir := t.TempDir()
+	file := writeFile(t, dir, "doc.md", markdownUnderParent("Parent", "Doc"))
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: file, Features: []string{"mention"}, Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	published, err := api.FindPage("DOCS", "Doc", "page")
+	require.NoError(t, err)
+	require.NotNil(t, published)
+
+	// The document now declares a different parent.
+	writeFile(t, dir, "doc.md", markdownUnderParent("Other", "Doc"))
+	require.NoError(t, Run(config), "a changed parent should move the page, not fail the run")
+
+	assert.Equal(t, other.ID, server.Page(published.ID).ParentID,
+		"the page should now sit under the parent its headers name")
+}
+
+// TestDeeperNestingThanDeclaredIsLeftAlone is the guard on the above. A page
+// nested below its declared parent passes validation today -- every declared
+// parent is somewhere in its ancestry -- and moving those would tear up
+// hierarchies nobody asked to change.
+func TestDeeperNestingThanDeclaredIsLeftAlone(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	parent := server.AddPage("DOCS", "Parent", "page", home.ID)
+	extra := server.AddPage("DOCS", "Extra", "page", parent.ID)
+	deep := server.AddPage("DOCS", "Doc", "page", extra.ID)
+
+	dir := t.TempDir()
+	file := writeFile(t, dir, "doc.md", markdownUnderParent("Parent", "Doc"))
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: file, Features: []string{"mention"}, Output: io.Discard,
+	}))
+
+	assert.Equal(t, extra.ID, server.Page(deep.ID).ParentID,
+		"a page nested deeper than declared must stay where it is")
+	_ = api
+}
+
+// TestDryRunDoesNotMoveThePage: a dry run reports, it does not rearrange.
+func TestDryRunDoesNotMoveThePage(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	parent := server.AddPage("DOCS", "Parent", "page", home.ID)
+	server.AddPage("DOCS", "Other", "page", home.ID)
+	existing := server.AddPage("DOCS", "Doc", "page", parent.ID)
+
+	dir := t.TempDir()
+	file := writeFile(t, dir, "doc.md", markdownUnderParent("Other", "Doc"))
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: file, Features: []string{"mention"}, DryRun: true, Output: io.Discard,
+	}))
+
+	assert.Equal(t, parent.ID, server.Page(existing.ID).ParentID,
+		"a dry run must leave the hierarchy exactly as it found it")
+	_ = api
+}
+
+// TestTitleAndParentChangingTogetherMovesThePage covers the seam between
+// tracking and relocation. A page resolved through the manifest never passed
+// the ancestry check -- that check starts from a title lookup which, the title
+// having changed, just missed -- so an edit changing both would retitle the page
+// and quietly leave it where it was.
+func TestTitleAndParentChangingTogetherMovesThePage(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+	other := server.AddPage("DOCS", "Other", "page", home.ID)
+
+	dir := t.TempDir()
+	file := writeFile(t, dir, "doc.md", markdownUnderParent("Parent", "Doc"))
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: file, Features: []string{"mention"}, TrackPages: true, Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	published, err := api.FindPage("DOCS", "Doc", "page")
+	require.NoError(t, err)
+	require.NotNil(t, published)
+
+	// One edit, both changes.
+	writeFile(t, dir, "doc.md", markdownUnderParent("Other", "Doc Renamed"))
+	require.NoError(t, Run(config))
+
+	after := server.Page(published.ID)
+	require.NotNil(t, after)
+	assert.Equal(t, "Doc Renamed", after.Title, "the page should have been retitled")
+	assert.Equal(t, other.ID, after.ParentID, "and moved to the parent its headers name")
+}
+
+// TestTrackedPageDeeperThanDeclaredIsLeftAlone is the same guard as for the
+// title-lookup path, on the manifest path: nesting below the declared parent
+// contradicts nothing and must not be rearranged.
+func TestTrackedPageDeeperThanDeclaredIsLeftAlone(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	parent := server.AddPage("DOCS", "Parent", "page", home.ID)
+	extra := server.AddPage("DOCS", "Extra", "page", parent.ID)
+
+	dir := t.TempDir()
+	file := writeFile(t, dir, "doc.md", markdownUnderParent("Parent", "Doc"))
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: file, Features: []string{"mention"}, TrackPages: true, Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	published, err := api.FindPage("DOCS", "Doc", "page")
+	require.NoError(t, err)
+	require.NotNil(t, published)
+
+	// Somebody nests it one level deeper, which the headers do not contradict.
+	require.NoError(t, api.MoveContentAppend(published.ID, extra.ID))
+
+	writeFile(t, dir, "doc.md", markdownUnderParent("Parent", "Doc Renamed"))
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, extra.ID, server.Page(published.ID).ParentID,
+		"a tracked page nested deeper than declared must stay where it is")
+}

--- a/page/ancestry.go
+++ b/page/ancestry.go
@@ -1,6 +1,7 @@
 package page
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -446,6 +447,16 @@ func EnsureAncestry(
 	return parent, nil
 }
 
+// ErrAncestryMismatch reports that a page exists but does not sit where its
+// headers say it should.
+//
+// Distinguished from every other way ancestry resolution can fail because it is
+// the one that is recoverable: the document has declared a different parent, and
+// moving the page there is what it asked for. Everything else -- a page with no
+// parents that is not the homepage, a chain that cannot be resolved -- is a
+// genuine impasse.
+var ErrAncestryMismatch = errors.New("page is not under the declared parents")
+
 func ValidateAncestry(
 	api *confluence.API,
 	space string,
@@ -500,8 +511,9 @@ func ValidateAncestry(
 		}
 
 		if !valid {
-			return nil, fmt.Errorf(
-				"the page has fewer parents than expected: title=%q, actual=[%s], expected=[%s]",
+			return page, fmt.Errorf(
+				"%w: title=%q, actual=[%s], expected=[%s]",
+				ErrAncestryMismatch,
 				page.Title, strings.Join(actual, " > "), strings.Join(ancestry, " > "),
 			)
 		}
@@ -525,8 +537,9 @@ func ValidateAncestry(
 				list = append(list, ancestor.Title)
 			}
 
-			return nil, fmt.Errorf(
-				"unexpected ancestry tree, did not find expected parent page %q in the tree: actual=[%s]",
+			return page, fmt.Errorf(
+				"%w: expected parent %q, actual=[%s]",
+				ErrAncestryMismatch,
 				parent, strings.Join(list, "; "),
 			)
 		}

--- a/page/ancestry_server_test.go
+++ b/page/ancestry_server_test.go
@@ -126,12 +126,14 @@ func TestValidateAncestryWrongParentIsRejected(t *testing.T) {
 	other := server.AddPage("DOCS", "Other", "page", root.ID)
 	server.AddPage("DOCS", "Guides", "page", other.ID)
 
-	_, err := page.ValidateAncestry(api, "DOCS", []string{"Root", "Team", "Guides"})
+	found, err := page.ValidateAncestry(api, "DOCS", []string{"Root", "Team", "Guides"})
 	require.Error(t, err)
 	// Guides sits two levels deep but three were expected, so the depth check
 	// rejects it before the per-parent comparison runs.
-	assert.Contains(t, err.Error(), "fewer parents than expected")
+	assert.ErrorIs(t, err, page.ErrAncestryMismatch)
 	assert.Contains(t, err.Error(), "actual=[Root > Other]")
+	assert.NotNil(t, found,
+		"the page is returned alongside the error, so the caller can move it")
 }
 
 // TestValidateAncestryWrongParentAtCorrectDepth reaches the per-parent
@@ -144,9 +146,11 @@ func TestValidateAncestryWrongParentAtCorrectDepth(t *testing.T) {
 	extra := server.AddPage("DOCS", "Extra", "page", other.ID)
 	server.AddPage("DOCS", "Guides", "page", extra.ID)
 
-	_, err := page.ValidateAncestry(api, "DOCS", []string{"Root", "Team", "Guides"})
+	found, err := page.ValidateAncestry(api, "DOCS", []string{"Root", "Team", "Guides"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "did not find expected parent page")
+	assert.ErrorIs(t, err, page.ErrAncestryMismatch)
+	assert.Contains(t, err.Error(), `expected parent "Team"`)
+	assert.NotNil(t, found)
 }
 
 // TestValidateAncestryHomepageWithoutAncestors covers the special case where a

--- a/page/page.go
+++ b/page/page.go
@@ -1,6 +1,7 @@
 package page
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -90,22 +91,35 @@ func ResolvePage(
 		}
 	} else {
 		// Traditional page-only ancestry
+		misplaced := false
 		ancestry := meta.Parents
 		if page != nil && !skipHomeAncestry {
 			ancestry = append(ancestry, page.Title)
 		}
 
 		if len(ancestry) > 0 {
-			page, err := ValidateAncestry(
+			existing, err := ValidateAncestry(
 				api,
 				meta.Space,
 				ancestry,
 			)
 			if err != nil {
-				return nil, nil, err
+				if !errors.Is(err, ErrAncestryMismatch) {
+					return nil, nil, err
+				}
+
+				// The document has declared a different parent than the one the
+				// page currently sits under. Refusing the publish leaves the two
+				// disagreeing and does nothing about it, so the page is moved
+				// where the headers ask once the new parent is resolved.
+				log.Info().Msgf(
+					"page %q is not where its headers say; it will be moved: %s",
+					meta.Title, err,
+				)
+				misplaced = true
 			}
 
-			if page == nil {
+			if existing == nil {
 				log.Warn().
 					Msgf(
 						"page %q is not found ",
@@ -134,6 +148,16 @@ func ResolvePage(
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("can't create ancestry tree %q: %w", strings.Join(meta.Parents, ` > `), err)
+		}
+
+		// Only a page that failed validation is moved. A page nested deeper
+		// than its headers declare passes validation today -- every declared
+		// parent is somewhere in its ancestry -- and moving those would tear up
+		// hierarchies nobody asked to change.
+		if misplaced && !dryRun && page != nil && parent != nil {
+			if err := EnsurePageUnderParent(api, page, parent.ID); err != nil {
+				return nil, nil, err
+			}
 		}
 	}
 

--- a/page/relocation.go
+++ b/page/relocation.go
@@ -15,6 +15,17 @@ func ImmediateParentID(pg *confluence.PageInfo) string {
 	return pg.Ancestors[len(pg.Ancestors)-1].ID
 }
 
+// UnderDeclaredParents reports whether a page sits under the parents its
+// headers declare.
+//
+// Loose on purpose, and loose in the same way ValidateAncestry is: a page nested
+// below its declared parent still counts, because every parent the headers name
+// is in its ancestry and nothing has been contradicted. Tightening this would
+// move pages whose placement nobody complained about.
+func UnderDeclaredParents(pg *confluence.PageInfo, parents []string) bool {
+	return pageUnderParents(pg, parents)
+}
+
 // pageUnderParents reports whether any ancestor title matches one of the MARK_PARENTS chain.
 func pageUnderParents(pg *confluence.PageInfo, parents []string) bool {
 	if pg == nil || len(parents) == 0 {
@@ -32,31 +43,43 @@ func pageUnderParents(pg *confluence.PageInfo, parents []string) bool {
 	return false
 }
 
-// EnsurePageUnderFolderParent moves an existing page under folderID when its direct parent differs.
+// EnsurePageUnderFolderParent moves an existing page under folderID when its
+// direct parent differs.
 func EnsurePageUnderFolderParent(
 	api *confluence.API,
 	pg *confluence.PageInfo,
 	folderID string,
 ) error {
-	if pg == nil || folderID == "" {
+	return EnsurePageUnderParent(api, pg, folderID)
+}
+
+// EnsurePageUnderParent moves an existing page under parentID when its direct
+// parent differs. The parent may be a page or a folder; Confluence moves
+// content the same way either way.
+func EnsurePageUnderParent(
+	api *confluence.API,
+	pg *confluence.PageInfo,
+	parentID string,
+) error {
+	if pg == nil || parentID == "" {
 		return nil
 	}
 
 	currentParent := ImmediateParentID(pg)
-	if currentParent == folderID {
+	if currentParent == parentID {
 		return nil
 	}
 
 	log.Info().Msgf(
-		"moving page %q (%s) from parent %s under folder %s",
+		"moving page %q (%s) from parent %s to %s",
 		pg.Title,
 		pg.ID,
 		currentParent,
-		folderID,
+		parentID,
 	)
 
-	if err := api.MoveContentAppend(pg.ID, folderID); err != nil {
-		return fmt.Errorf("move page %q under folder: %w", pg.Title, err)
+	if err := api.MoveContentAppend(pg.ID, parentID); err != nil {
+		return fmt.Errorf("move page %q under new parent: %w", pg.Title, err)
 	}
 
 	refreshed, err := api.GetPageByID(pg.ID)


### PR DESCRIPTION
Fixes #430.

## The problem

Changing a `Parent` header on a page that has already been published fails the run:

```text
FATAL unable to resolve page
      └─ unexpected ancestry tree, did not find expected parent page in the tree
         ├─ expected parent: System Documentation
         └─ title: Page Title
```

The reporter of #430 hit exactly this and said what anyone would expect instead:

> I would expect the new parent pages to either be created or updated.

## Why refusing was not the careful option

It protected nothing. The declared hierarchy and the real one went on disagreeing, and the publish stopped until somebody moved the page by hand in Confluence. mark already treats the repository as the source of truth for a page's **title** and its **content** — where the page lives is the same kind of claim.

mark was also **inconsistent about it**. A page whose *folder* parent changes is relocated, via `EnsurePageUnderFolderParent`. A page whose *page* parent changes was rejected. The same edit, two different outcomes, decided by something the author was not thinking about.

That helper turned out to be general already — Confluence moves content the same way under a page or a folder — so it becomes `EnsurePageUnderParent`, with the folder-named version kept as a wrapper.

## The narrow part

**Only a page that would have failed validation is moved.**

A page nested *deeper* than its headers declare passes validation today: every declared parent is somewhere in its ancestry, so nothing is contradicted. Relocating those would tear up hierarchies nobody asked to change, so they are left alone — `TestDeeperNestingThanDeclaredIsLeftAlone` pins that.

To tell the two apart, `ValidateAncestry` now reports a mismatch with a sentinel (`ErrAncestryMismatch`) rather than by the wording of its message, so the recoverable case is distinguishable from a genuine impasse — a page with no parents that is not the homepage, or a chain that cannot be resolved at all. Those still fail the run.

A dry run reports and rearranges nothing.

## The seam with page tracking

Rebasing onto master after #878 landed exposed a hole worth naming, because without it this PR's central claim would be false whenever `--track-pages` is on.

A page resolved through the **manifest** never goes through ancestry validation — that check starts from a title lookup which, the title having changed, just missed. So an edit changing the title *and* the parent together retitled the page and quietly left it under the old parent. Manifest-resolved pages are now relocated too, guarded the same way: nesting below the declared parent still contradicts nothing and is left alone.

Fixing that surfaced a second one. `EnsurePageUnderParent` refreshes the page from Confluence after moving it, which **overwrote the retitle staged moments earlier** — so the page moved correctly and kept its old name. The staged title is re-applied after a move. The same trap existed on the folder-parent path, so the fix covers both.

## Behaviour change worth noting in release notes

A page somebody moved **by hand in Confluence** is moved back on the next run. That is consistent with how mark already handles a hand-edited title or body, but it is a change from today, where the run would simply fail. Documented in the README.

## Testing

- changing a `Parent` header moves the page (the #430 scenario, end to end)
- a page nested deeper than declared is untouched
- a dry run leaves the hierarchy exactly as it found it
- a title and a parent changing together, with tracking on, moves *and* retitles
- a tracked page nested deeper than declared is left alone
- the two existing ancestry tests were asserting on message text; they assert on the sentinel now, which is what they were really checking

Verified non-vacuous — disabling the relocation fails the first test. `confluencetest` gains the content-move endpoint. Full suite green under `-race`, `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
