### PR TITLE
feat(confluence): support the Max page width via Content-Appearance: max

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,16 @@ Also, optional following headers are supported:
 * blogpost: [Blog post](https://confluence.atlassian.com/doc/blog-posts-834222533.html) in `Space`.  Cannot have `Parent`(s)
 
 ```markdown
-<!-- Content-Appearance: (full-width|fixed|default) -->
+<!-- Content-Appearance: (full-width|fixed|default|max) -->
 ```
 
-* (default) full-width: content will fill the full page width
+The Confluence Cloud editor offers three widths — Narrow, Wide and Max — which
+map onto these values as `default`, `full-width` and `max`.
+
+* (default) full-width: content will fill the full page width. This is the Confluence UI's **Wide**.
 * fixed: content will be rendered in a fixed narrow view
-* default: sets the Confluence property value to `"default"`, which is the narrow layout as set by the Confluence UI. Note: `fixed` maps to a different Confluence property value and can cause misaligned page title and body content — use `default` instead for the narrow layout.
+* default: sets the Confluence property value to `"default"`, which is the Confluence UI's **Narrow** layout. Note: `fixed` maps to a different Confluence property value and can cause misaligned page title and body content — use `default` instead for the narrow layout.
+* max: the Confluence UI's **Max** layout, which is wider than `full-width`.
 
 ```markdown
 <!-- Sidebar: <h2>Test</h2> -->
@@ -1027,7 +1031,7 @@ GLOBAL OPTIONS:
    --space string                           use specified space key. If the space key is not specified, it must be set in the page metadata. [$MARK_SPACE]
    --parents string                         A list containing the parents of the document separated by parents-delimiter (default: '/'). These will be prepended to the ones defined in the document itself. [$MARK_PARENTS]
    --parents-delimiter string               The delimiter used for the parents list (default: "/") [$MARK_PARENTS_DELIMITER]
-   --content-appearance string              default content appearance for pages without a Content-Appearance header. Possible values: full-width, fixed, default. [$MARK_CONTENT_APPEARANCE]
+   --content-appearance string              default content appearance for pages without a Content-Appearance header. Possible values: full-width (Wide), fixed, default (Narrow), max (Max). [$MARK_CONTENT_APPEARANCE]
    --mermaid-scale float                    defines the scaling factor for mermaid renderings. (default: 1) [$MARK_MERMAID_SCALE]
    --include-path string                    Path for shared includes, used as a fallback if the include doesn't exist in the current directory. [$MARK_INCLUDE_PATH]
    --changes-only                           Avoids re-uploading pages that haven't changed since the last run. [$MARK_CHANGES_ONLY]

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -865,19 +865,27 @@ func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, ve
 		}
 	}
 
-	properties := map[string]any{
+	properties := map[string]any{}
+
+	// A page edited by id with no metadata in the file has no appearance to
+	// carry, and an empty value here would reset the width of a page nobody
+	// asked to restyle.
+	if appearance != "" {
 		// Fix to set full-width as has changed on Confluence APIs again.
 		// https://jira.atlassian.com/browse/CONFCLOUD-65447
 		//
-		"content-appearance-published": map[string]any{
+		properties["content-appearance-published"] = map[string]any{
 			"value": appearance,
-		},
-		// content-appearance-draft is set alongside published so that opening
-		// the page in the editor doesn't reintroduce the previous width. The
-		// Confluence editor writes both keys with the same value.
-		"content-appearance-draft": map[string]any{
+		}
+		// The draft key was previously left alone, because the user's editor
+		// defaults drove it and writing it produced sporadic published widths
+		// (the same CONFCLOUD-65447 above). Writing published on its own,
+		// though, leaves the two keys disagreeing, and the editor believes the
+		// draft: the width reverts as soon as anyone opens the page. The
+		// Confluence editor itself writes both keys with the same value.
+		properties["content-appearance-draft"] = map[string]any{
 			"value": appearance,
-		},
+		}
 	}
 
 	if emojiString != "" {

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -872,8 +872,12 @@ func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, ve
 		"content-appearance-published": map[string]any{
 			"value": appearance,
 		},
-		// content-appearance-draft should not be set as this is impacted by
-		// the user editor default configurations - which caused the sporadic published widths.
+		// content-appearance-draft is set alongside published so that opening
+		// the page in the editor doesn't reintroduce the previous width. The
+		// Confluence editor writes both keys with the same value.
+		"content-appearance-draft": map[string]any{
+			"value": appearance,
+		},
 	}
 
 	if emojiString != "" {

--- a/confluence/api_server_test.go
+++ b/confluence/api_server_test.go
@@ -131,6 +131,26 @@ func TestUpdatePageIncrementsVersion(t *testing.T) {
 	assert.Equal(t, "<p>new</p>", after.Body)
 }
 
+// TestUpdatePageWritesBothAppearanceProperties pins that the page width is
+// written to the draft property as well as the published one. Published alone
+// leaves the two disagreeing, and the editor takes the draft value, so the
+// width reverts as soon as anyone opens the page.
+func TestUpdatePageWritesBothAppearanceProperties(t *testing.T) {
+	api, server := newAPI(t)
+	stored := server.AddPage("DOCS", "Target", "page", "")
+
+	page, err := api.FindPage("DOCS", "Target", "page")
+	require.NoError(t, err)
+
+	require.NoError(t, api.UpdatePage(page, "<p>new</p>", false, "", "max", ""))
+
+	for _, key := range []string{"content-appearance-published", "content-appearance-draft"} {
+		prop := server.ContentProperty(stored.ID, key)
+		require.NotNil(t, prop, "%s was not written", key)
+		assert.JSONEq(t, `"max"`, string(prop.Value))
+	}
+}
+
 // TestUpdatePageKeepsVersionInSync pins the write-back at the end of
 // UpdatePage: the caller's PageInfo is advanced to the version just published,
 // so consecutive updates through the same value keep working.

--- a/confluence/api_server_test.go
+++ b/confluence/api_server_test.go
@@ -151,6 +151,27 @@ func TestUpdatePageWritesBothAppearanceProperties(t *testing.T) {
 	}
 }
 
+// TestUpdatePageWithoutAppearanceLeavesThePropertiesAlone covers editing a
+// page by id with a file that carries no metadata: there is no width to
+// publish, and writing an empty one would reset whatever the page already had.
+func TestUpdatePageWithoutAppearanceLeavesThePropertiesAlone(t *testing.T) {
+	api, server := newAPI(t)
+	stored := server.AddPage("DOCS", "Target", "page", "")
+	server.SetSpaceProperty(stored.ID, "content-appearance-published", []byte(`"max"`))
+	server.SetSpaceProperty(stored.ID, "content-appearance-draft", []byte(`"max"`))
+
+	page, err := api.FindPage("DOCS", "Target", "page")
+	require.NoError(t, err)
+
+	require.NoError(t, api.UpdatePage(page, "<p>new</p>", false, "", "", ""))
+
+	for _, key := range []string{"content-appearance-published", "content-appearance-draft"} {
+		prop := server.ContentProperty(stored.ID, key)
+		require.NotNil(t, prop, "%s went missing", key)
+		assert.JSONEq(t, `"max"`, string(prop.Value), "%s was overwritten", key)
+	}
+}
+
 // TestUpdatePageKeepsVersionInSync pins the write-back at the end of
 // UpdatePage: the caller's PageInfo is advanced to the version just published,
 // so consecutive updates through the same value keep working.

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -567,16 +567,30 @@ func (s *Server) SpaceProperty(ownerID, key string) *SpaceProperty {
 	return nil
 }
 
+// ContentProperty returns the property stored against a page under key, or
+// nil. Content and space properties share one store in the fake; they are
+// told apart by the owner id.
+func (s *Server) ContentProperty(pageID, key string) *SpaceProperty {
+	return s.SpaceProperty(pageID, key)
+}
+
 // SetSpaceProperty seeds a property without going through HTTP.
 func (s *Server) SetSpaceProperty(ownerID, key string, value []byte) *SpaceProperty {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	p := s.putContentProperty(ownerID, key, value)
+	cp := *p
+	return &cp
+}
+
+// putContentProperty upserts a property, bumping its version the way
+// Confluence does. The caller must hold the lock.
+func (s *Server) putContentProperty(ownerID, key string, value []byte) *SpaceProperty {
 	for _, p := range s.properties {
 		if p.OwnerID == ownerID && p.Key == key {
 			p.Value = append(json.RawMessage(nil), value...)
 			p.Version++
-			cp := *p
-			return &cp
+			return p
 		}
 	}
 	p := &SpaceProperty{
@@ -587,8 +601,7 @@ func (s *Server) SetSpaceProperty(ownerID, key string, value []byte) *SpacePrope
 		Version: 1,
 	}
 	s.properties = append(s.properties, p)
-	cp := *p
-	return &cp
+	return p
 }
 
 // contentProperties serves the v1 content property API, which differs from the
@@ -916,6 +929,11 @@ func (s *Server) contentByID(w http.ResponseWriter, r *http.Request, id string) 
 					Value string `json:"value"`
 				} `json:"storage"`
 			} `json:"body"`
+			Metadata struct {
+				Properties map[string]struct {
+					Value json.RawMessage `json:"value"`
+				} `json:"properties"`
+			} `json:"metadata"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			http.Error(w, "bad payload", http.StatusBadRequest)
@@ -934,6 +952,12 @@ func (s *Server) contentByID(w http.ResponseWriter, r *http.Request, id string) 
 		p.Body = payload.Body.Storage.Value
 		if payload.Title != "" {
 			p.Title = payload.Title
+		}
+		// Content properties ride along on the update payload rather than
+		// going through the property endpoints, which is how mark writes the
+		// page width and the emoji.
+		for key, prop := range payload.Metadata.Properties {
+			s.putContentProperty(id, key, prop.Value)
 		}
 		writeJSON(w, http.StatusOK, s.pageJSON(p))
 	default:

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -49,9 +49,13 @@ type Meta struct {
 }
 
 const (
+	// Confluence Cloud's editor shows three widths: Narrow, Wide and Max.
+	// They are stored as "default", "full-width" and "max" respectively.
+	// "fixed" is the legacy value for a narrow page.
 	FullWidthContentAppearance = "full-width"
 	FixedContentAppearance     = "fixed"
 	DefaultContentAppearance   = "default"
+	MaxContentAppearance       = "max"
 )
 
 func toStringSlice(val any) []string {
@@ -86,6 +90,8 @@ func setContentAppearance(meta *Meta, value string) {
 		meta.ContentAppearance = FixedContentAppearance
 	case DefaultContentAppearance:
 		meta.ContentAppearance = DefaultContentAppearance
+	case MaxContentAppearance:
+		meta.ContentAppearance = MaxContentAppearance
 	default:
 		meta.ContentAppearance = FullWidthContentAppearance
 	}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -111,6 +111,24 @@ func TestExtractMetaContentAppearance(t *testing.T) {
 		assert.NotNil(t, meta)
 		assert.Equal(t, DefaultContentAppearance, meta.ContentAppearance)
 	})
+
+	t.Run("max appearance via cli flag", func(t *testing.T) {
+		data := []byte("<!-- Space: DOC -->\n<!-- Title: Example -->\n\nbody\n")
+
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, MaxContentAppearance, false)
+		assert.NoError(t, err)
+		assert.NotNil(t, meta)
+		assert.Equal(t, MaxContentAppearance, meta.ContentAppearance)
+	})
+
+	t.Run("max appearance via header", func(t *testing.T) {
+		data := []byte("<!-- Space: DOC -->\n<!-- Title: Example -->\n<!-- Content-Appearance: max -->\n\nbody\n")
+
+		meta, _, err := ExtractMeta(data, "", false, false, "", nil, false, "", false)
+		assert.NoError(t, err)
+		assert.NotNil(t, meta)
+		assert.Equal(t, MaxContentAppearance, meta.ContentAppearance)
+	})
 }
 
 func TestExtractMetaYAMLFrontMatterDisabled(t *testing.T) {

--- a/util/cli_test.go
+++ b/util/cli_test.go
@@ -69,6 +69,13 @@ func TestContentAppearanceFlagValidation(t *testing.T) {
 		}
 	})
 
+	t.Run("max is accepted", func(t *testing.T) {
+		err := runWithArgs([]string{"cmd", "--content-appearance", "max"})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
 	t.Run("invalid value is rejected", func(t *testing.T) {
 		err := runWithArgs([]string{"cmd", "--content-appearance", "nope"})
 		if err == nil {

--- a/util/flags.go
+++ b/util/flags.go
@@ -169,7 +169,7 @@ var Flags = []cli.Flag{
 	&cli.StringFlag{
 		Name:  "content-appearance",
 		Value: "",
-		Usage: "default content appearance for pages without a Content-Appearance header. Possible values: full-width, fixed, default.",
+		Usage: "default content appearance for pages without a Content-Appearance header. Possible values: full-width (Wide), fixed, default (Narrow), max (Max).",
 		Sources: cli.NewValueSourceChain(
 			cli.EnvVar("MARK_CONTENT_APPEARANCE"),
 			altsrctoml.TOML("content-appearance", altsrc.NewStringPtrSourcer(&filename)),
@@ -242,11 +242,11 @@ func CheckFlags(context context.Context, command *cli.Command) (context.Context,
 	contentAppearance := strings.TrimSpace(command.String("content-appearance"))
 	if contentAppearance != "" {
 		switch contentAppearance {
-		case "full-width", "fixed", "default":
+		case "full-width", "fixed", "default", "max":
 			// ok
 		default:
 			return context, fmt.Errorf(
-				"invalid value for --content-appearance: %q (expected: full-width, fixed, or default)",
+				"invalid value for --content-appearance: %q (expected: full-width, fixed, default, or max)",
 				contentAppearance,
 			)
 		}


### PR DESCRIPTION
Confluence Cloud's editor offers three page widths — Narrow, Wide and Max — and `mark` can currently express only two of them.

Reading `content-appearance-published` / `content-appearance-draft` in Confluence Cloud pages shows the three widths are stored in those same property keys as `default`, `full-width` and `max`. So the editor's Wide is the `full-width` mark already writes, Narrow is `default`, and only `max` is a value mark has no way to produce. Pushing a Max page through `mark` today silently narrows it.

**What this changes**

- `max` is accepted in the `Content-Appearance: ` header and in `--content-appearance`.
- The README documents which editor width each value corresponds to.
- `UpdatePage` writes `content-appearance-draft` alongside `content-appearance-published`.

**About the draft property**

The previous code deliberately skipped the draft key, with a comment referencing [CONFCLOUD-65447](https://jira.atlassian.com/browse/CONFCLOUD-65447) and "sporadic published widths". This deserves a second look.

The reason: writing published alone leaves the two keys disagreeing — draft still says whatever the editor last wrote, published says what mark wrote. The editor takes the draft value, so the width reverts as soon as anyone opens the page. The Confluence editor itself writes both keys with the same value, which is what this now matches. If you'd rather keep the old behavior,  I'll rework it.

**Compatibility**

`full-width`, `fixed` and `default` behave exactly as before, including the implicit `full-width` default when neither the header nor the flag is set.

**Testing**

The fake Confluence server discarded the content properties that ride along on a page update; it now records them, so `TestUpdatePageWritesBothAppearanceProperties` can assert both keys. Existing per-value tests in `util/cli_test.go` and `metadata/metadata_test.go` are extended for `max`.

`go test ./...` passes locally except the `d2` and `mermaid` suites, which need Chrome in `$PATH` and fail the same way on master here. `golangci-lint run ./...` and `markdownlint-cli2` are clean.

The value mapping was verified empirically against a live Confluence Cloud site: a page set to Wide reads back `full-width`, Narrow reads `default`, Max reads `max`.