### PR TITLE
fix(manifest): scope rename matching to the pattern that published the entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1207,7 +1207,7 @@ recovers a rename after the fact rather than being told about it.
 | a file renamed *and* rewritten in one commit | the fingerprint is exact, so any content change breaks the match. Reads as a deletion plus a new page -- Git's limit too, without an `-M50%` to loosen it |
 | an ambiguous rename | two unpublished documents sharing content, or a target page another file already claimed this run. A duplicate is a nuisance; a wrong rebind overwrites someone's page |
 | anything in the first run | nothing is recorded until a file publishes with the flag set, so the first run only adopts |
-| a rename across two `--files` patterns | matching and reporting are both scoped to the pattern that recorded the entry, so the file is a deletion in one and a new page in the other |
+| a rename across two `--files` patterns | matching and reporting are both scoped to the pattern that recorded the entry, so the file is a deletion in one and a new page in the other. That scoping is what lets several Mark invocations publish different folders into one space without reaching into each other's pages |
 | whether a deletion was intended | it reports; it never deletes |
 | a `Parent:` header change | still fails the run with an ancestry error rather than moving the page |
 | a moved space homepage (Server/DC) | the mapping is anchored to it, so tracking starts over |

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -581,15 +581,26 @@ func (s *Store) Record(spaceKey, path, pageID, title, hash string) error {
 // path, for a document whose own path is not recorded.
 //
 // A rename changes the key, so the entry cannot be found by where it was; the
-// only thing connecting the two is what the document contains. Candidates are
-// restricted to recorded paths this run is not publishing -- a path that is
-// still in the run belongs to a file that still exists, and matching against it
-// would rebind two documents onto one page.
+// only thing connecting the two is what the document contains.
 //
-// Deliberately unforgiving. A match must be unique, and the page must not
-// already be claimed by another document this run. Anything else returns
-// nothing and a new page is created: a duplicate is a nuisance, where rebinding
-// onto the wrong page overwrites a document nobody asked to change.
+// Candidates are restricted to what this run's own --files pattern published,
+// and to paths it is not publishing now. Both restrictions matter, and the
+// second alone is not enough: several mark invocations commonly publish
+// different folders into one space, and every path belonging to another
+// invocation is missing from this one. Without the pattern check they all look
+// like deleted files this document might be a rename of, so a new file that
+// happens to share content with another invocation's document takes over its
+// page -- retitling it and dropping its entry, which leaves that document with
+// no page at all and publishing a duplicate on its next run.
+//
+// The cost is that a file moved from one pattern to another reads as a deletion
+// in the first and a new page in the second. That is already how deletion
+// reporting behaves, and it is the safe direction: a duplicate is a nuisance,
+// where rebinding onto the wrong page overwrites a document nobody asked to
+// change.
+//
+// Deliberately unforgiving beyond that. A match must be unique, and the page
+// must not already be claimed by another document this run.
 func (s *Store) ResolveRenamed(spaceKey, hash string) (string, Entry, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -610,7 +621,8 @@ func (s *Store) ResolveRenamed(spaceKey, hash string) (string, Entry, bool, erro
 	)
 	for i := range state.shards {
 		for path, entry := range state.shards[i].pages {
-			if entry.Hash != hash || s.runFiles[path] || state.claimed[entry.PageID] {
+			if entry.Hash != hash || entry.Glob != s.runGlob ||
+				s.runFiles[path] || state.claimed[entry.PageID] {
 				continue
 			}
 			foundPath, foundEntry = path, entry

--- a/mark_process_test.go
+++ b/mark_process_test.go
@@ -1043,3 +1043,90 @@ func TestTrackedPageDeeperThanDeclaredIsLeftAlone(t *testing.T) {
 	assert.Equal(t, extra.ID, server.Page(published.ID).ParentID,
 		"a tracked page nested deeper than declared must stay where it is")
 }
+
+// multiGlobConfig is one of several mark invocations publishing different
+// folders into a single space, which is a common way to run it.
+func multiGlobConfig(server *confluencetest.Server, glob string) Config {
+	return Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: glob, Features: []string{"mention"},
+		TrackPages: true, TitleFromFilename: true, Output: io.Discard,
+	}
+}
+
+// TestRenameDoesNotReachAcrossGlobs is the failure that scoping rename
+// candidates prevents. Every path belonging to another invocation is missing
+// from this one, so without the check they all look like deleted files this
+// document might be a rename of -- and a new file sharing content with another
+// invocation's document takes over its page, retitling it and dropping its
+// entry, which leaves that document with no page and a duplicate on its next
+// run.
+func TestRenameDoesNotReachAcrossGlobs(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "a"), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "b"), 0o750))
+	globA := filepath.Join(dir, "a", "*.md")
+	globB := filepath.Join(dir, "b", "*.md")
+
+	// Identical content, which is all it takes: shared boilerplate or a copied
+	// stub is enough.
+	body := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n\nShared body text.\n"
+
+	writeFile(t, dir, "a/one.md", body)
+	require.NoError(t, Run(multiGlobConfig(server, globA)))
+
+	pageA, err := api.FindPage("DOCS", "One", "page")
+	require.NoError(t, err)
+	require.NotNil(t, pageA)
+
+	// A second invocation adds a brand-new file that happens to match.
+	writeFile(t, dir, "b/two.md", body)
+	require.NoError(t, Run(multiGlobConfig(server, globB)))
+
+	assert.Equal(t, "One", server.Page(pageA.ID).Title,
+		"the other invocation's page must be left alone")
+	assert.Equal(t, 1, countPagesTitled(t, server, "Two"),
+		"the new file should have got its own page")
+
+	// And the first invocation still owns its document: re-running it must not
+	// republish, which is what would happen if its entry had been taken.
+	require.NoError(t, Run(multiGlobConfig(server, globA)))
+	assert.Equal(t, "One", server.Page(pageA.ID).Title)
+	assert.Equal(t, 1, countPagesTitled(t, server, "One"),
+		"no duplicate should have appeared for the first invocation")
+}
+
+// TestRenameStillWorksWithinOneGlob is the control: scoping must not cost the
+// feature its point.
+func TestRenameStillWorksWithinOneGlob(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "a"), 0o750))
+	glob := filepath.Join(dir, "a", "*.md")
+	body := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n\nBody.\n"
+
+	writeFile(t, dir, "a/old-name.md", body)
+	require.NoError(t, Run(multiGlobConfig(server, glob)))
+
+	published, err := api.FindPage("DOCS", "Old Name", "page")
+	require.NoError(t, err)
+	require.NotNil(t, published)
+
+	require.NoError(t, os.Rename(
+		filepath.Join(dir, "a", "old-name.md"), filepath.Join(dir, "a", "new-name.md")))
+	require.NoError(t, Run(multiGlobConfig(server, glob)))
+
+	assert.Equal(t, "New Name", server.Page(published.ID).Title,
+		"a rename within one pattern must still be followed")
+}


### PR DESCRIPTION
Running several `mark` invocations over different folders of the same space -- a common setup -- could make one invocation take over another's page.

## What happens

Rename matching excluded paths **this run** is publishing, so that a file which still exists is never mistaken for a deleted one. But every path belonging to *another* invocation is also missing from this run, and those were not excluded. They all looked like deleted files the current document might be a rename of.

So a brand-new file that happens to share content with another invocation's document is treated as that document's new name: the page is retitled and the other invocation's manifest entry is dropped. That document now has no page, and publishes a duplicate on its next run.

Identical content is all it takes. Shared boilerplate, a stub page, or a copied template supplies it readily enough.

```text
invocation A  --files "docs/a/*.md"   publishes a/one.md  -> page "One"
invocation B  --files "docs/b/*.md"   adds b/two.md, same body
                                       -> page "One" is retitled "Two"
                                       -> A's entry is dropped
next A run                             -> republishes, duplicate
```

## The fix

Restrict rename candidates to entries published by the same `--files` pattern, exactly as deletion reporting already is. **One of the two restrictions was applied and the other was not** — that asymmetry is the whole of the bug.

The cost: a file moved from one pattern to another reads as a deletion in the first and a new page in the second. That is already how deletion reporting behaves, and it is the safe direction — a duplicate is a nuisance, where rebinding onto the wrong page overwrites a document nobody asked to change.

## Testing

- `TestRenameDoesNotReachAcrossGlobs` reproduces the takeover end to end across two invocations, and checks the first invocation still owns its document afterwards
- `TestRenameStillWorksWithinOneGlob` is the control: scoping must not cost the feature its point

Verified non-vacuous — removing the pattern check fails the first test with *the other invocation's page must be left alone*. Full suite green under `-race`, `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)