### PR TITLE
fix: adopt a page sitting at the space root instead of refusing it

### DIFF
--- a/mark_process_test.go
+++ b/mark_process_test.go
@@ -1130,3 +1130,60 @@ func TestRenameStillWorksWithinOneGlob(t *testing.T) {
 	assert.Equal(t, "New Name", server.Page(published.ID).Title,
 		"a rename within one pattern must still be followed")
 }
+
+// TestRootLevelPageIsAdoptedRatherThanRefused is issue #88's neighbourhood.
+// Publishing to the space homepage works, and always has since the homepage is
+// recognised. A page sitting beside it at the root did not: mark placed a
+// document with no declared parents under the space root page, saw the existing
+// page was not there, and refused.
+//
+// That left such a page unpublishable by any means, because declaring the
+// parent it ought to have is exactly what produces the state being refused.
+func TestRootLevelPageIsAdoptedRatherThanRefused(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+
+	// Somebody created this at the space root, outside mark.
+	orphan := server.AddPage("DOCS", "Standalone", "page", "")
+
+	dir := t.TempDir()
+	file := writeFile(t, dir, "doc.md", "<!-- Space: DOCS -->\n<!-- Title: Standalone -->\n\nAdopted body.\n")
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: file, Features: []string{"mention"}, Output: io.Discard,
+	}), "a page at the space root must be publishable")
+
+	after := server.Page(orphan.ID)
+	require.NotNil(t, after)
+	assert.Contains(t, after.Body, "Adopted body.",
+		"the existing page should have been updated, not passed over")
+	assert.Equal(t, home.ID, after.ParentID,
+		"and moved under the root page, which is where a document with no declared parents belongs")
+
+	assert.Equal(t, 1, countPagesTitled(t, server, "Standalone"),
+		"no second page should have appeared")
+	_ = api
+}
+
+// TestHomepageItselfIsStillPublishable guards the case that already worked:
+// the homepage has no ancestors either, and must not be mistaken for a page
+// that needs moving under itself.
+func TestHomepageItselfIsStillPublishable(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Team Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+
+	dir := t.TempDir()
+	file := writeFile(t, dir, "home.md", "<!-- Space: DOCS -->\n<!-- Title: Team Home -->\n\nWelcome!\n")
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: file, Features: []string{"mention"}, Output: io.Discard,
+	}))
+
+	after := server.Page(home.ID)
+	require.NotNil(t, after)
+	assert.Contains(t, after.Body, "Welcome!")
+	assert.Empty(t, after.ParentID, "the homepage must stay at the root")
+}

--- a/page/ancestry.go
+++ b/page/ancestry.go
@@ -482,7 +482,19 @@ func ValidateAncestry(
 			log.Debug().Msgf("page is homepage for space %q", space)
 			isHomepage = true
 		} else {
-			return nil, fmt.Errorf(`page %q has no parents`, page.Title)
+			// The page sits at the root of its space and is not the homepage,
+			// while a document that declares no parents is placed under the
+			// space root page. So the two disagree about where it belongs --
+			// which is a misplacement like any other, and is reported as one so
+			// the caller can move it rather than refuse.
+			//
+			// It used to be a flat refusal, which left the page unpublishable
+			// by mark at all: nothing mark could be told would move it, because
+			// declaring the parent it ought to have is precisely what produces
+			// this state.
+			return page, fmt.Errorf(
+				"%w: %q sits at the root of the space", ErrAncestryMismatch, page.Title,
+			)
 		}
 	}
 

--- a/page/ancestry_server_test.go
+++ b/page/ancestry_server_test.go
@@ -166,15 +166,24 @@ func TestValidateAncestryHomepageWithoutAncestors(t *testing.T) {
 	assert.Equal(t, "Home", found.Title)
 }
 
-// TestValidateAncestryOrphanIsRejected is the same shape as the homepage case
-// but for a page that is not the homepage, which must be an error.
-func TestValidateAncestryOrphanIsRejected(t *testing.T) {
+// TestValidateAncestryRootLevelPageIsMisplaced is the same shape as the
+// homepage case but for a page that is not the homepage. A document declaring
+// no parents is placed under the space root page, so a page sitting at the root
+// instead disagrees with that -- a misplacement, reported as one so the caller
+// can move it.
+//
+// It used to be a flat refusal, which made such a page unpublishable by mark at
+// all: declaring the parent it ought to have is exactly what produces this
+// state, so no header could get past it.
+func TestValidateAncestryRootLevelPageIsMisplaced(t *testing.T) {
 	api, server := newAPI(t)
 	home := server.AddPage("DOCS", "Home", "page", "")
 	server.SetHomepage("DOCS", home.ID)
-	server.AddPage("DOCS", "Orphan", "page", "")
+	orphan := server.AddPage("DOCS", "Orphan", "page", "")
 
-	_, err := page.ValidateAncestry(api, "DOCS", []string{"Orphan"})
+	found, err := page.ValidateAncestry(api, "DOCS", []string{"Orphan"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "has no parents")
+	assert.ErrorIs(t, err, page.ErrAncestryMismatch)
+	require.NotNil(t, found, "the page comes back with the error, so it can be moved")
+	assert.Equal(t, orphan.ID, found.ID)
 }


### PR DESCRIPTION
Investigating #88 turned up something adjacent to it that is still broken.

## What I found

| scenario | before |
| --- | --- |
| publish to the space **homepage** (#88 as reported) | **works** — the homepage is recognised explicitly |
| brand-new page with no `Parent` header | **works** — created under the space root page |
| existing page **at the space root**, beside the homepage | **fails**: `page "Standalone" has no parents` |

So #88's own scenario has worked for some time. The neighbouring one did not.

## Why refusing was the wrong answer

`EnsureAncestry` falls back to `FindRootPage` when no parents resolve, so a document declaring no parents is placed **under the space root page**. A page already sitting *at* the root therefore disagrees with where mark would put it.

That is a misplacement, and #430's work already moves misplaced pages. This one refused instead — and the refusal was inescapable: **declaring the parent it ought to have is exactly what produces the state being refused**, so no header could get past it. The only way out was to move the page by hand in Confluence first.

## The change

`ValidateAncestry` reports it with `ErrAncestryMismatch` rather than a flat error, so the existing relocation path adopts the page and moves it under the root page. The homepage keeps its own branch: it has no ancestors either, and must not be moved under itself.

## Testing

- an existing root-level page is updated and moved under the root page, with no second page created
- the homepage is still publishable and stays at the root
- `ValidateAncestry` returns the page alongside the error so the caller can move it

Verified non-vacuous — restoring the flat refusal fails the first test with *a page at the space root must be publishable*. Full suite green under `-race`, `golangci-lint` 0 issues.

Related to #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)