### PR TITLE
fix: report a configuration file that cannot be read or parsed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kovetskiy/mark/v16
 go 1.26
 
 require (
+	github.com/BurntSushi/toml v1.5.0
 	github.com/FurqanSoftware/goldmark-katex v0.0.0-20260803101007-c52a8e1564b2
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/chromedp/cdproto v0.0.0-20260714215040-dc233986426f
@@ -24,7 +25,6 @@ require (
 )
 
 require (
-	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/PuerkitoBio/goquery v1.10.0 // indirect
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/util/flags.go
+++ b/util/flags.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
+	"os"
 	"strings"
+
+	"github.com/BurntSushi/toml"
 
 	altsrc "github.com/urfave/cli-altsrc/v3"
 	altsrctoml "github.com/urfave/cli-altsrc/v3/toml"
@@ -234,7 +238,52 @@ var Flags = []cli.Flag{
 }
 
 // CheckFlags validates combinations and values of global flags.
+// CheckConfigFile reports a configuration file that cannot be used.
+//
+// Settings are read from the file lazily, one flag at a time, and a file that
+// cannot be parsed simply yields nothing. A stray syntax error therefore
+// removes every setting at once and says nothing, and the first sign of trouble
+// is whichever required value went missing with it -- so "confluence password
+// should be specified" is what an unquoted list three lines further down looks
+// like, which is a long way from where the problem is.
+func CheckConfigFile(command *cli.Command) error {
+	path := command.String("config")
+	if path == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// Nothing at the default location is the ordinary case: most
+			// people pass flags. A path somebody named themselves is
+			// different, because there silence makes a typo indistinguishable
+			// from a setting they forgot.
+			//
+			// Compared against the default rather than asked of IsSet, which
+			// answers true for a flag carrying a default value and would
+			// therefore fail every run that has no configuration file at all.
+			if path != ConfigFilePath() {
+				return fmt.Errorf("configuration file %q does not exist", path)
+			}
+			return nil
+		}
+		return fmt.Errorf("unable to read configuration file %q: %w", path, err)
+	}
+
+	var parsed map[string]any
+	if err := toml.Unmarshal(data, &parsed); err != nil {
+		return fmt.Errorf("unable to parse configuration file %q: %w", path, err)
+	}
+
+	return nil
+}
+
 func CheckFlags(context context.Context, command *cli.Command) (context.Context, error) {
+	if err := CheckConfigFile(command); err != nil {
+		return context, err
+	}
+
 	if command.Bool("title-from-h1") && command.Bool("title-from-filename") {
 		return context, errors.New("flags --title-from-h1 and --title-from-filename are mutually exclusive. Please specify only one")
 	}

--- a/util/flags_test.go
+++ b/util/flags_test.go
@@ -1,0 +1,76 @@
+package util
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+// TestCheckConfigFile covers the reason issue #613 was so hard to diagnose.
+//
+// Settings are read from the file lazily, one flag at a time, so a file that
+// cannot be parsed yields nothing at all and says nothing about it. Every
+// setting disappears at once, and the first sign of trouble is whichever
+// required value went with them -- which is how an unquoted list produces
+// "confluence password should be specified".
+func TestCheckConfigFile(t *testing.T) {
+	write := func(t *testing.T, content string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "mark.toml")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+		return path
+	}
+
+	run := func(t *testing.T, args ...string) error {
+		t.Helper()
+		cmd := &cli.Command{
+			Flags:  Flags,
+			Action: func(context.Context, *cli.Command) error { return nil },
+		}
+		return CheckConfigFile(mustParse(t, cmd, args...))
+	}
+
+	t.Run("a file that cannot be parsed is reported", func(t *testing.T) {
+		path := write(t, "username = \"u\"\nfeatures = [frontmatter,mention]\n")
+		err := run(t, "mark", "--config", path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), path, "the message must name the file")
+		assert.Contains(t, err.Error(), "line 2", "and where in it to look")
+	})
+
+	t.Run("a valid file passes", func(t *testing.T) {
+		path := write(t, "username = \"u\"\npassword = \"p\"\nbase-url = \"http://example.invalid\"\n")
+		assert.NoError(t, run(t, "mark", "--config", path))
+	})
+
+	t.Run("a named file that is absent is reported", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "nope.toml")
+		err := run(t, "mark", "--config", missing)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not exist")
+	})
+
+	t.Run("nothing at the default location is fine", func(t *testing.T) {
+		// The overwhelmingly common case: no config file, everything passed as
+		// flags. Complaining here would break every such invocation.
+		assert.NoError(t, run(t, "mark"))
+	})
+}
+
+// mustParse runs a command far enough to populate its flags.
+func mustParse(t *testing.T, cmd *cli.Command, args ...string) *cli.Command {
+	t.Helper()
+	var parsed *cli.Command
+	cmd.Action = func(_ context.Context, c *cli.Command) error {
+		parsed = c
+		return nil
+	}
+	require.NoError(t, cmd.Run(context.Background(), args))
+	require.NotNil(t, parsed)
+	return parsed
+}


### PR DESCRIPTION
Fixes #613.

## Why that issue was so hard to pin down

Settings are read from the config file lazily, one flag at a time. A file that cannot be parsed simply yields nothing — so a single syntax error removes **every** setting at once, silently, and the first sign of trouble is whichever required value went missing along with them.

Reproduced on current `master`, using the exact case from the last comment on the issue:

```toml
username = "u"
password = "p"
base-url = "http://example.invalid"
features = [frontmatter,mention,mermaid]   # unquoted
```

```text
FATAL confluence password should be specified using -p flag or be stored in configuration file
```

The password is right there in the file. That message sends you to inspect the one field that was fine — and reading the issue, that is exactly what happened: several commenters work through key spellings, hyphens versus underscores, and file locations in turn, hunting for a fault that was three lines further down.

## After

```text
FATAL unable to parse configuration file "/home/u/.config/mark.toml": toml: line 4 (last key "features"): expected value but found "frontmatter" instead
```

A path given by name that does not exist is reported too, since silence there makes a typo indistinguishable from a setting somebody forgot.

## What I could not reproduce

The other complaints on the issue no longer occur on `master`: the default location is picked up, and `MARK_CONFIG` is honoured. Both were verified with a scratch `HOME`. The macOS-specific location several people ran into is `os.UserConfigDir()` returning `~/Library/Application Support` rather than `~/.config` — Go's documented behaviour, unchanged here, and now at least a mistyped `MARK_CONFIG` says so rather than falling back silently.

## One thing worth review attention

Whether the file is "the default" or "one you named" is decided by comparing the path against `ConfigFilePath()`, not by asking `cmd.IsSet("config")`. **`IsSet` answers true for a flag carrying a default value**, so the obvious version failed every run that has no configuration file at all — which is most of them. The test for that case caught it.

## Testing

Four cases in `util`: an unparseable file is reported with its path and line, a valid file passes, a named file that is absent is reported, and nothing at the default location stays quiet. Also exercised end to end against a built binary with a scratch `HOME`.

Full suite green under `-race`, `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)