### PR TITLE
fix(markdown): point same-page links at the anchors mark generates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1124,6 +1124,28 @@ You can also use `**` to get all files recursively.
 mark -f "**/docs/*.md"
 ```
 
+### Links to Headings on the Same Page
+
+Mark generates Confluence-compatible heading anchors, which keep their capitals
+and punctuation: `## My Heading` becomes `id="My-Heading"`. A link written the
+way every other Markdown tool expects -- `[jump](#my-heading)` -- would not name
+that anchor, and would quietly go nowhere.
+
+Mark now points such links at the anchor it actually generated, so both spellings
+work:
+
+```markdown
+## My Heading
+
+[slug style](#my-heading) and [exact style](#My-Heading) both resolve.
+```
+
+Matching is on the letters and digits only, because the two conventions disagree
+about which punctuation survives: a heading `API/v2 Guide` becomes
+`API/v2-Guide`, while a slug of it is `apiv2-guide`. If two headings differ only
+in punctuation that matching drops, the link is left exactly as written rather
+than guessed at.
+
 ### Linting markdown
 
 We recommend to lint your markdown files with [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) before publishing them to confluence to catch any conversion errors early.

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -323,6 +323,10 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 		util.Prioritized(c.Pipeline, 10),
 		util.Prioritized(ctransformer.NewLayoutTransformer(), 100),
 		util.Prioritized(ctransformer.NewGHAlertsTransformer(), 100),
+		// Last, so that it sees the headings includes and macros brought in as
+		// well as the ones written in the file, and so that heading ids have
+		// already been assigned.
+		util.Prioritized(ctransformer.NewAnchorTransformer(), 900),
 	))
 
 	// Add date widget support if requested

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -106,7 +106,7 @@ func TestCompileMarkdownDropH1(t *testing.T) {
 		}
 		var variant string
 		switch filename {
-		case "testdata/quotes.md", "testdata/header.md", "testdata/admonitions.md", "testdata/plantuml.md", "testdata/codeblock-comments.md", "testdata/frontmatter.md":
+		case "testdata/quotes.md", "testdata/header.md", "testdata/admonitions.md", "testdata/plantuml.md", "testdata/codeblock-comments.md", "testdata/frontmatter.md", "testdata/heading-anchor-links.md":
 			variant = "-droph1"
 		default:
 			variant = ""
@@ -160,7 +160,7 @@ func TestCompileMarkdownStripNewlines(t *testing.T) {
 		}
 		var variant string
 		switch filename {
-		case "testdata/quotes.md", "testdata/codes.md", "testdata/newlines.md", "testdata/macro-include.md", "testdata/admonitions.md", "testdata/mention.md", "testdata/codeblock-comments.md":
+		case "testdata/quotes.md", "testdata/codes.md", "testdata/newlines.md", "testdata/macro-include.md", "testdata/admonitions.md", "testdata/mention.md", "testdata/codeblock-comments.md", "testdata/heading-anchor-links.md":
 			variant = "-stripnewlines"
 		default:
 			variant = ""

--- a/testdata/heading-anchor-links-droph1.html
+++ b/testdata/heading-anchor-links-droph1.html
@@ -1,0 +1,15 @@
+<p>Headings become ids that keep their capitals and punctuation, while the links
+authors write use the lowercase-and-hyphens slug every other Markdown tool
+produces. Both ends have to end up naming the same thing.</p>
+<h2 id="My-Heading">My Heading</h2>
+<p><a href="#My-Heading">slug style</a> and <a href="#My-Heading">exact style</a>.</p>
+<h2 id="API/v2-Guide">API/v2 Guide</h2>
+<p>The conventions disagree about which characters survive at all, so matching is
+on the letters and digits: <a href="#API/v2-Guide">dropped punctuation</a>.</p>
+<h2 id="Release-Notes">Release Notes</h2>
+<h2 id="Release.Notes">Release.Notes</h2>
+<p>Two headings whose ids differ only in punctuation that matching drops are one
+key, so <a href="#release-notes">this</a> is left exactly as written rather than guessed
+at.</p>
+<p><a href="https://example.com/#fragment">not an anchor</a> is untouched, and so is
+<a href="#nothing-here">an unknown target</a>.</p>

--- a/testdata/heading-anchor-links-stripnewlines.html
+++ b/testdata/heading-anchor-links-stripnewlines.html
@@ -1,0 +1,10 @@
+<h1 id="Anchor-Links">Anchor Links</h1>
+<p>Headings become ids that keep their capitals and punctuation, while the links authors write use the lowercase-and-hyphens slug every other Markdown tool produces. Both ends have to end up naming the same thing.</p>
+<h2 id="My-Heading">My Heading</h2>
+<p><a href="#My-Heading">slug style</a> and <a href="#My-Heading">exact style</a>.</p>
+<h2 id="API/v2-Guide">API/v2 Guide</h2>
+<p>The conventions disagree about which characters survive at all, so matching is on the letters and digits: <a href="#API/v2-Guide">dropped punctuation</a>.</p>
+<h2 id="Release-Notes">Release Notes</h2>
+<h2 id="Release.Notes">Release.Notes</h2>
+<p>Two headings whose ids differ only in punctuation that matching drops are one key, so <a href="#release-notes">this</a> is left exactly as written rather than guessed at.</p>
+<p><a href="https://example.com/#fragment">not an anchor</a> is untouched, and so is <a href="#nothing-here">an unknown target</a>.</p>

--- a/testdata/heading-anchor-links.html
+++ b/testdata/heading-anchor-links.html
@@ -1,0 +1,16 @@
+<h1 id="Anchor-Links">Anchor Links</h1>
+<p>Headings become ids that keep their capitals and punctuation, while the links
+authors write use the lowercase-and-hyphens slug every other Markdown tool
+produces. Both ends have to end up naming the same thing.</p>
+<h2 id="My-Heading">My Heading</h2>
+<p><a href="#My-Heading">slug style</a> and <a href="#My-Heading">exact style</a>.</p>
+<h2 id="API/v2-Guide">API/v2 Guide</h2>
+<p>The conventions disagree about which characters survive at all, so matching is
+on the letters and digits: <a href="#API/v2-Guide">dropped punctuation</a>.</p>
+<h2 id="Release-Notes">Release Notes</h2>
+<h2 id="Release.Notes">Release.Notes</h2>
+<p>Two headings whose ids differ only in punctuation that matching drops are one
+key, so <a href="#release-notes">this</a> is left exactly as written rather than guessed
+at.</p>
+<p><a href="https://example.com/#fragment">not an anchor</a> is untouched, and so is
+<a href="#nothing-here">an unknown target</a>.</p>

--- a/testdata/heading-anchor-links.md
+++ b/testdata/heading-anchor-links.md
@@ -1,0 +1,25 @@
+# Anchor Links
+
+Headings become ids that keep their capitals and punctuation, while the links
+authors write use the lowercase-and-hyphens slug every other Markdown tool
+produces. Both ends have to end up naming the same thing.
+
+## My Heading
+
+[slug style](#my-heading) and [exact style](#My-Heading).
+
+## API/v2 Guide
+
+The conventions disagree about which characters survive at all, so matching is
+on the letters and digits: [dropped punctuation](#apiv2-guide).
+
+## Release Notes
+
+## Release.Notes
+
+Two headings whose ids differ only in punctuation that matching drops are one
+key, so [this](#release-notes) is left exactly as written rather than guessed
+at.
+
+[not an anchor](https://example.com/#fragment) is untouched, and so is
+[an unknown target](#nothing-here).

--- a/transformer/anchors.go
+++ b/transformer/anchors.go
@@ -1,0 +1,133 @@
+package transformer
+
+import (
+	"strings"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+// AnchorTransformer points same-page links at the heading ids mark actually
+// generates.
+//
+// The two ends of a link are produced by different conventions and never met.
+// A heading becomes an id that keeps its capitals and its punctuation --
+// "## My Heading" is "My-Heading" -- while an author writing the link uses the
+// lowercase-and-hyphens slug every other Markdown tool would have made, and
+// writes "#my-heading". Confluence then has a heading with one id and a link
+// pointing at another, so the link silently goes nowhere.
+//
+// Nothing announces this. The page renders, the link is clickable, and it does
+// nothing when clicked, which is the sort of fault nobody reports twice -- they
+// stop linking to headings instead.
+type AnchorTransformer struct{}
+
+// NewAnchorTransformer creates a new AnchorTransformer instance.
+func NewAnchorTransformer() *AnchorTransformer {
+	return &AnchorTransformer{}
+}
+
+// anchorKey reduces an id or a link target to what the two conventions agree
+// on: the letters and digits, in order, folded to lower case.
+//
+// Everything else is discarded rather than mapped, because the conventions do
+// not merely punctuate differently -- they disagree about which characters
+// survive at all. mark keeps "/" and "." in an id where a slug drops them, so
+// "API/v2 Guide" becomes "API/v2-Guide" one way and "apiv2-guide" the other.
+// Comparing only the alphanumerics is what makes those the same heading.
+func anchorKey(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// Transform implements the parser.ASTTransformer interface.
+func (t *AnchorTransformer) Transform(doc *ast.Document, reader text.Reader, pc parser.Context) {
+	headings := map[string]string{}
+	ambiguous := map[string]bool{}
+
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering || node.Kind() != ast.KindHeading {
+			return ast.WalkContinue, nil
+		}
+
+		id, ok := node.AttributeString("id")
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+
+		value := attributeString(id)
+		key := anchorKey(value)
+		if key == "" {
+			return ast.WalkContinue, nil
+		}
+
+		// Two headings that differ only in punctuation collapse to one key.
+		// Rewriting either would be a guess, so both are left alone -- an
+		// anchor that does not work is better than one that silently goes to
+		// the wrong section.
+		if existing, seen := headings[key]; seen && existing != value {
+			ambiguous[key] = true
+		}
+		headings[key] = value
+
+		return ast.WalkContinue, nil
+	})
+
+	if len(headings) == 0 {
+		return
+	}
+
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		link, ok := node.(*ast.Link)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+
+		target, found := strings.CutPrefix(string(link.Destination), "#")
+		if !found || target == "" {
+			return ast.WalkContinue, nil
+		}
+
+		// An id written out exactly -- including one the author set with
+		// {#custom-id} -- is already correct and must not be touched.
+		for _, id := range headings {
+			if id == target {
+				return ast.WalkContinue, nil
+			}
+		}
+
+		key := anchorKey(target)
+		if ambiguous[key] {
+			return ast.WalkContinue, nil
+		}
+
+		if id, ok := headings[key]; ok {
+			link.Destination = []byte("#" + id)
+		}
+
+		return ast.WalkContinue, nil
+	})
+}
+
+// attributeString renders a node attribute value, which goldmark hands back as
+// either bytes or a string depending on how it was set.
+func attributeString(value any) string {
+	switch v := value.(type) {
+	case []byte:
+		return string(v)
+	case string:
+		return v
+	default:
+		return ""
+	}
+}

--- a/transformer/anchors_test.go
+++ b/transformer/anchors_test.go
@@ -1,0 +1,39 @@
+package transformer
+
+import "testing"
+
+// TestAnchorKey pins what the two conventions are reduced to before they are
+// compared. mark keeps capitals and punctuation in an id; a Markdown author
+// writes the lowercase-and-hyphens slug every other tool produces. Only the
+// letters and digits are common to both.
+func TestAnchorKey(t *testing.T) {
+	same := [][2]string{
+		{"My-Heading", "my-heading"},
+		{"API/v2-Guide", "apiv2-guide"},    // a slug drops the slash, an id keeps it
+		{"Release.Notes", "release-notes"}, // and the dot
+		{"Heading_With_Underscores", "heading-with-underscores"},
+		{"Ünïcödé", "ünïcödé"}, // neither side keeps non-ASCII
+	}
+	for _, pair := range same {
+		if anchorKey(pair[0]) != anchorKey(pair[1]) {
+			t.Errorf("%q and %q should reduce alike, got %q and %q",
+				pair[0], pair[1], anchorKey(pair[0]), anchorKey(pair[1]))
+		}
+	}
+
+	differ := [][2]string{
+		{"Heading One", "Heading Two"},
+		{"Release-Notes", "Release-Notes-1"}, // goldmark's dedupe suffix is a digit
+	}
+	for _, pair := range differ {
+		if anchorKey(pair[0]) == anchorKey(pair[1]) {
+			t.Errorf("%q and %q should not reduce alike, both gave %q",
+				pair[0], pair[1], anchorKey(pair[0]))
+		}
+	}
+
+	// Nothing to match on is not a match against everything.
+	if anchorKey("---") != "" {
+		t.Errorf("punctuation alone should reduce to nothing, got %q", anchorKey("---"))
+	}
+}


### PR DESCRIPTION
Fixes #492. Fixes the live half of #47.

## The problem

The two ends of a heading link are produced by different conventions and never met:

```markdown
## My Heading

[jump](#my-heading)
```

```html
<h2 id="My-Heading">My Heading</h2>
<p><a href="#my-heading">jump</a></p>     ← names nothing
```

mark generates Confluence-compatible ids that keep capitals and punctuation (`parser/confluenceids.go`). An author writes the lowercase-and-hyphens slug every other Markdown tool produces. Nothing reconciled the two — there was no anchor handling anywhere in `transformer/` or `renderer/`.

Nothing announces it either. The page renders, the link is clickable, and it does nothing when clicked, which is the sort of fault nobody reports twice — they stop linking to headings instead.

#47's original complaint about `http://` being prepended is already fixed; this is what remained of it.

## The fix

Fragment links are resolved against the headings actually present and rewritten to the generated id. An id written out exactly is left untouched — **including one an author set with `{#custom-id}`**, so this composes with #770 rather than fighting it. I verified that explicitly (see below).

Matching compares **only letters and digits**, because the conventions do not merely punctuate differently — they disagree about which characters survive. `API/v2 Guide` is `API/v2-Guide` one way and `apiv2-guide` the other; nothing short of ignoring punctuation makes those the same heading.

Where two headings differ only in punctuation that matching drops, the link is **left exactly as written**. An anchor that does not work beats one that silently goes to the wrong section. Worth knowing: goldmark's dedupe suffix is a digit, so `Release-Notes` and `Release-Notes-1` stay distinguishable and are unaffected — I initially wrote a fixture assuming otherwise and it taught me the opposite.

The transformer runs last, so it sees headings that includes and macros brought in, not only those written in the file.

## Interaction with #770

Checked directly by applying #770's `parser.WithAttribute()` change on top of this:

```markdown
## My Heading {#custom-id}

[exact](#custom-id)     → href="#custom-id"    (untouched)

## Plain Heading

[slug](#plain-heading)  → href="#Plain-Heading" (rewritten)
```

They compose with no changes to either. #770 remains worth merging on its own.

## Testing

- golden fixture covering slug style, exact style, punctuation the conventions disagree about, the ambiguous case, an external URL with a fragment, and an unknown target — in all three variants (plain, `-droph1`, `-stripnewlines`)
- unit tests for the matching rule, including that goldmark's numeric dedupe suffix stays distinguishable

Verified non-vacuous — disabling the rewrite fails the golden tests. Full suite green under `-race`, `golangci-lint` 0 issues, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)