### PR TITLE
feat: order child pages with an Order header

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,24 @@ Also, optional following headers are supported:
 * default: sets the Confluence property value to `"default"`, which is the narrow layout as set by the Confluence UI. Note: `fixed` maps to a different Confluence property value and can cause misaligned page title and body content — use `default` instead for the narrow layout.
 
 ```markdown
+<!-- Order: <number> -->
+```
+
+Positions the page among its siblings, smaller numbers first. Pages that do not
+declare an order are left exactly where Confluence has them, so annotating one
+page does not disturb the rest.
+
+Only pages published in the same run are arranged, and only relative to each
+other -- a run narrowed with `--files` knows nothing about the other children of
+those parents and will not rearrange them. Nothing is moved that is already in
+the right relative order, so a run that changes nothing performs no moves at
+all.
+
+Note that giving Confluence explicit positions takes that branch of the tree out
+of its default alphabetical ordering, which is inherent to asking for a
+particular order.
+
+```markdown
 <!-- Sidebar: <h2>Test</h2> -->
 ```
 

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -1479,12 +1479,74 @@ func (api *API) CreatePageWithFolderParent(
 }
 
 // MoveContentAppend relocates any content (page, folder, etc.) under targetID using the v1 move API.
+// GetChildPages returns a page's children in the order Confluence shows them.
+//
+// The order of this response is the order of the tree in the UI, which is what
+// makes it usable for working out which pages are already where they should be.
+// Position is not requested explicitly: it exists as an extension field but is
+// absent whenever a branch has never been ordered by hand, and the sequence is
+// the part that matters here.
+func (api *API) GetChildPages(parentID string) ([]PageInfo, error) {
+	const pageSize = 100
+
+	var all []PageInfo
+	start := 0
+
+	for {
+		result := struct {
+			Results []PageInfo `json:"results"`
+		}{}
+
+		request, err := api.rest.Res(
+			"content/"+parentID+"/child/page", &result,
+		).Get(map[string]string{
+			"limit": fmt.Sprintf("%d", pageSize),
+			"start": fmt.Sprintf("%d", start),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("unable to list children of %s: %w", parentID, err)
+		}
+
+		if request.Raw.StatusCode != http.StatusOK {
+			return nil, newErrorStatusNotOK(request)
+		}
+
+		all = append(all, result.Results...)
+		if len(result.Results) < pageSize {
+			break
+		}
+		start += len(result.Results)
+	}
+
+	return all, nil
+}
+
+// MoveContentAfter places a page immediately after one of its siblings.
+//
+// Unlike the append form, the target here is a sibling rather than the new
+// parent. Atlassian warn against using it when the target is a top-level page,
+// where it can move content to the root of the space; callers are expected not
+// to.
+func (api *API) MoveContentAfter(contentID, siblingID string) error {
+	return api.moveContent(contentID, "after", siblingID)
+}
+
+// MoveContentBefore places a page immediately before one of its siblings. The
+// same caution about top-level targets applies as for MoveContentAfter.
+func (api *API) MoveContentBefore(contentID, siblingID string) error {
+	return api.moveContent(contentID, "before", siblingID)
+}
+
 func (api *API) MoveContentAppend(contentID, targetID string) error {
-	path := fmt.Sprintf("content/%s/move/append/%s", contentID, targetID)
+	return api.moveContent(contentID, "append", targetID)
+}
+
+func (api *API) moveContent(contentID, position, targetID string) error {
+	path := fmt.Sprintf("content/%s/move/%s/%s", contentID, position, targetID)
 	var result map[string]any
 	request, err := api.rest.Res(path, &result).Put(map[string]interface{}{})
 	if err != nil {
-		return fmt.Errorf("failed to move content %s under %s: %w", contentID, targetID, err)
+		return fmt.Errorf("failed to move content %s %s %s: %w", contentID, position, targetID, err)
 	}
 
 	switch request.Raw.StatusCode {

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -97,6 +97,7 @@ type Server struct {
 	spaces      map[string]*Space
 	attachments []*Attachment
 	properties  []*SpaceProperty
+	childOrder  map[string][]string
 	folders     []*Folder
 	comments    map[string][]InlineComment
 	users       []User
@@ -195,6 +196,7 @@ func (s *Server) AddPage(spaceKey, title, pageType, parentID string) *Page {
 		Version:  1,
 	}
 	s.pages[p.ID] = p
+	s.placeChild(p.ParentID, p.ID, "")
 	return p
 }
 
@@ -474,10 +476,14 @@ func (s *Server) handleV1(w http.ResponseWriter, r *http.Request, path string) {
 		case strings.HasPrefix(sub, "child/attachment/"):
 			// .../child/attachment/{attachID}/data -- attachment update
 			s.updateAttachment(w, r, id)
+		case sub == "child/page":
+			s.childPages(w, r, id)
 		case sub == "child/comment":
 			s.childComment(w, r, id)
-		case strings.HasPrefix(sub, "move/append/"):
-			s.moveContent(w, r, id, strings.TrimPrefix(sub, "move/append/"))
+		case strings.HasPrefix(sub, "move/"):
+			rest := strings.TrimPrefix(sub, "move/")
+			position, target, _ := strings.Cut(rest, "/")
+			s.moveContent(w, r, id, position, target)
 		case sub == "label":
 			s.label(w, r, id)
 		case sub == "property":
@@ -597,7 +603,7 @@ func (s *Server) SetSpaceProperty(ownerID, key string, value []byte) *SpacePrope
 // by key rather than by property id.
 // moveContent reparents a page, which is how mark puts an existing page inside
 // a folder.
-func (s *Server) moveContent(w http.ResponseWriter, r *http.Request, contentID, targetID string) {
+func (s *Server) moveContent(w http.ResponseWriter, r *http.Request, contentID, position, targetID string) {
 	if r.Method != http.MethodPut {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -614,7 +620,29 @@ func (s *Server) moveContent(w http.ResponseWriter, r *http.Request, contentID, 
 
 	// The target may be a folder or another page; the fake only has to record
 	// that the move happened.
-	p.ParentID = targetID
+	switch position {
+	case "append":
+		p.ParentID = targetID
+		s.placeChild(targetID, p.ID, "")
+	case "before", "after":
+		sibling, ok := s.pages[targetID]
+		if !ok {
+			writeJSON(w, http.StatusNotFound, map[string]any{"message": "no such sibling"})
+			return
+		}
+		// The target is a sibling here, not the new parent, so the page joins
+		// whatever parent the sibling has.
+		p.ParentID = sibling.ParentID
+		if position == "after" {
+			s.placeChild(sibling.ParentID, p.ID, targetID)
+		} else {
+			s.placeBefore(sibling.ParentID, p.ID, targetID)
+		}
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]any{"message": "unknown position " + position})
+		return
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{"id": p.ID})
 }
 
@@ -888,6 +916,7 @@ func (s *Server) createContent(w http.ResponseWriter, r *http.Request) {
 		Body:     payload.Body.Storage.Value,
 	}
 	s.pages[p.ID] = p
+	s.placeChild(p.ParentID, p.ID, "")
 	writeJSON(w, http.StatusOK, s.pageJSON(p))
 }
 
@@ -1069,6 +1098,98 @@ func parseMultipartAttachment(r *http.Request) (filename, comment string) {
 		}
 	}
 	return filename, comment
+}
+
+// childPages lists a page's children in the order the tree shows them, which
+// for the fake is simply the order they were created or last moved into.
+func (s *Server) childPages(w http.ResponseWriter, r *http.Request, parentID string) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	results := []map[string]any{}
+	for _, id := range s.childOrder[parentID] {
+		if p, ok := s.pages[id]; ok && p.ParentID == parentID {
+			results = append(results, s.pageJSON(p))
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}
+
+// ChildOrder returns the ids of a page's children, in order.
+func (s *Server) ChildOrder(parentID string) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := []string{}
+	for _, id := range s.childOrder[parentID] {
+		if p, ok := s.pages[id]; ok && p.ParentID == parentID {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// placeBefore inserts a child directly before a sibling. Callers must hold the
+// lock.
+func (s *Server) placeBefore(parentID, childID, before string) {
+	s.placeChild(parentID, childID, "")
+	ids := s.childOrder[parentID]
+	// Lift it back out and reinsert ahead of the sibling.
+	for i, id := range ids {
+		if id == childID {
+			ids = append(ids[:i:i], ids[i+1:]...)
+			break
+		}
+	}
+	for i, id := range ids {
+		if id == before {
+			rest := append([]string{childID}, ids[i:]...)
+			s.childOrder[parentID] = append(ids[:i:i], rest...)
+			return
+		}
+	}
+	s.childOrder[parentID] = append(ids, childID)
+}
+
+// placeChild records a child's position under a parent. Callers must hold the
+// lock. Appends when after is empty, otherwise inserts directly after it.
+func (s *Server) placeChild(parentID, childID, after string) {
+	if s.childOrder == nil {
+		s.childOrder = map[string][]string{}
+	}
+
+	// Remove it from wherever it currently sits, including another parent.
+	for parent, ids := range s.childOrder {
+		for i, id := range ids {
+			if id == childID {
+				s.childOrder[parent] = append(ids[:i:i], ids[i+1:]...)
+				break
+			}
+		}
+	}
+
+	if parentID == "" {
+		return
+	}
+
+	if after == "" {
+		s.childOrder[parentID] = append(s.childOrder[parentID], childID)
+		return
+	}
+
+	for i, id := range s.childOrder[parentID] {
+		if id == after {
+			rest := append([]string{childID}, s.childOrder[parentID][i+1:]...)
+			s.childOrder[parentID] = append(s.childOrder[parentID][:i+1:i+1], rest...)
+			return
+		}
+	}
+
+	s.childOrder[parentID] = append(s.childOrder[parentID], childID)
 }
 
 func (s *Server) childComment(w http.ResponseWriter, r *http.Request, pageID string) {
@@ -1309,6 +1430,7 @@ func (s *Server) createPageV2(w http.ResponseWriter, r *http.Request) {
 		Body:     payload.Body.Storage.Value,
 	}
 	s.pages[p.ID] = p
+	s.placeChild(p.ParentID, p.ID, "")
 	// The version has to come back. Without it the caller computes the version
 	// it is superseding from zero, and its first update is rejected as stale.
 	writeJSON(w, http.StatusOK, map[string]any{

--- a/mark.go
+++ b/mark.go
@@ -164,11 +164,19 @@ func Run(config Config) error {
 		tracker.SetRunFiles(config.Files, files)
 	}
 
+	// Pages that asked for a position among their siblings, collected as they
+	// publish and applied once at the end -- the order of one page only means
+	// anything alongside the others.
+	var ordered []page.Ordered
+
 	var hasErrors bool
 	for _, file := range files {
 		log.Info().Msgf("processing %s", file)
 
-		target, err := processFile(file, api, config, std, tracker, folders)
+		target, placement, err := processFile(file, api, config, std, tracker, folders)
+		if placement != nil {
+			ordered = append(ordered, *placement)
+		}
 		if err != nil {
 			if config.ContinueOnError {
 				log.Error().Err(err).Msgf("processing %s", file)
@@ -191,6 +199,15 @@ func Run(config Config) error {
 	// away the mapping for every page that had published perfectly well --
 	// worst under --continue-on-error, which exists precisely to keep going.
 	// What was recorded actually happened, and is worth keeping either way.
+	if !hasErrors && len(ordered) > 0 {
+		// Not attempted when a file failed: the pages that did not publish are
+		// missing from the sequence, and ordering the rest against each other
+		// would arrange them as though the absent ones were gone for good.
+		if err := page.OrderChildren(api, config.DryRun, ordered); err != nil {
+			return fmt.Errorf("unable to order pages: %w", err)
+		}
+	}
+
 	var saveErr error
 	if tracker != nil {
 		reportOrphans(tracker, hasErrors)
@@ -254,13 +271,14 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 		return nil, fmt.Errorf("unable to retrieve standard library: %w", err)
 	}
 
-	return processFile(file, api, config, std, nil, nil)
+	target, _, err := processFile(file, api, config, std, nil, nil)
+	return target, err
 }
 
-func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, folders page.FolderTracker) (*confluence.PageInfo, error) {
+func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, folders page.FolderTracker) (*confluence.PageInfo, *page.Ordered, error) {
 	markdown, err := os.ReadFile(file)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read file %q: %w", file, err)
+		return nil, nil, fmt.Errorf("unable to read file %q: %w", file, err)
 	}
 
 	markdown = bytes.ReplaceAll(markdown, []byte("\r\n"), []byte("\n"))
@@ -285,7 +303,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		frontMatterEnabled,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("unable to extract metadata from file %q: %w", file, err)
+		return nil, nil, fmt.Errorf("unable to extract metadata from file %q: %w", file, err)
 	}
 
 	if config.PageID != "" && meta != nil {
@@ -297,7 +315,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	}
 
 	if config.PageID == "" && meta == nil {
-		return nil, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"specified file doesn't contain metadata and URL is not specified " +
 				"via command line or doesn't contain pageId GET-parameter",
 		)
@@ -305,12 +323,12 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 
 	if meta != nil {
 		if meta.Space == "" {
-			return nil, fmt.Errorf(
+			return nil, nil, fmt.Errorf(
 				"space is not set ('Space' header is not set and '--space' option is not set)",
 			)
 		}
 		if meta.Title == "" {
-			return nil, fmt.Errorf(
+			return nil, nil, fmt.Errorf(
 				"page title is not set: use the 'Title' header, " +
 					"or the --title-from-h1 / --title-from-filename flags",
 			)
@@ -330,7 +348,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		frontMatterEnabled,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("unable to resolve relative links: %w", err)
+		return nil, nil, fmt.Errorf("unable to resolve relative links: %w", err)
 	}
 
 	markdown = page.SubstituteLinks(markdown, links)
@@ -338,7 +356,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	if config.DryRun {
 		if meta != nil {
 			if _, pg, err := page.ResolvePage(true, api, meta, folders); err != nil {
-				return nil, fmt.Errorf("unable to resolve page location: %w", err)
+				return nil, nil, fmt.Errorf("unable to resolve page location: %w", err)
 			} else if pg == nil {
 				// The title found nothing, which is where a real run consults
 				// the manifest. Saying so is the whole point of a dry run:
@@ -348,7 +366,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 			}
 		} else if config.PageID != "" {
 			if _, err := api.GetPageByID(config.PageID); err != nil {
-				return nil, fmt.Errorf("unable to resolve page by ID: %w", err)
+				return nil, nil, fmt.Errorf("unable to resolve page by ID: %w", err)
 			}
 		}
 	}
@@ -360,7 +378,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 
 		imageAlign, err := getImageAlign(config.ImageAlign, meta)
 		if err != nil {
-			return nil, fmt.Errorf("unable to determine image-align: %w", err)
+			return nil, nil, fmt.Errorf("unable to determine image-align: %w", err)
 		}
 
 		cfg := types.MarkConfig{
@@ -374,12 +392,12 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		}
 		html, _, err := markmd.CompileMarkdown(markdown, std, file, cfg)
 		if err != nil {
-			return nil, fmt.Errorf("unable to compile markdown: %w", err)
+			return nil, nil, fmt.Errorf("unable to compile markdown: %w", err)
 		}
 		if _, err := fmt.Fprintln(config.output(), html); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	var target *confluence.PageInfo
@@ -394,12 +412,12 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		// Do this before resolution, so ancestry is walked against titles that
 		// exist rather than creating an empty page under the old one.
 		if err := refreshStaleParents(tracker, api, meta); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		parent, pg, err := page.ResolvePage(false, api, meta, folders)
 		if err != nil {
-			return nil, fmt.Errorf("error resolving page %q: %w", meta.Title, err)
+			return nil, nil, fmt.Errorf("error resolving page %q: %w", meta.Title, err)
 		}
 
 		// The title lookup found nothing, which is how both "this page is new"
@@ -408,7 +426,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		if pg == nil {
 			pg, err = resolveTrackedPage(tracker, api, meta, file)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if pg == nil {
 				// Not published under this path before. It may have been
@@ -416,7 +434,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 				// an old document.
 				pg, err = resolveRenamedFile(tracker, api, meta, file, sourceHash)
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 			}
 			if pg != nil && pg.Title != meta.Title {
@@ -432,7 +450,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 				pg, err = api.CreatePage(meta.Space, meta.Type, parent, meta.Title, ``)
 			}
 			if err != nil {
-				return nil, fmt.Errorf("can't create %s %q: %w", meta.Type, meta.Title, err)
+				return nil, nil, fmt.Errorf("can't create %s %q: %w", meta.Type, meta.Title, err)
 			}
 			// A delay between the create and update call helps mitigate a 409
 			// conflict that can occur when attempting to update a page just
@@ -441,7 +459,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 			pageCreated = true
 		} else if parent != nil && parent.Type == "folder-parent" {
 			if err := page.EnsurePageUnderFolderParent(api, pg, parent.ID); err != nil {
-				return nil, fmt.Errorf("error relocating page %q: %w", meta.Title, err)
+				return nil, nil, fmt.Errorf("error relocating page %q: %w", meta.Title, err)
 			}
 		} else if parent != nil && !page.UnderDeclaredParents(pg, meta.Parents) {
 			// A page resolved through the manifest rather than by title never
@@ -449,7 +467,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 			// lookup that just missed. So an edit changing the title and the
 			// parent together would retitle the page and leave it where it was.
 			if err := page.EnsurePageUnderParent(api, pg, parent.ID); err != nil {
-				return nil, fmt.Errorf("error relocating page %q: %w", meta.Title, err)
+				return nil, nil, fmt.Errorf("error relocating page %q: %w", meta.Title, err)
 			}
 		}
 
@@ -465,10 +483,10 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	} else {
 		pg, err := api.GetPageByID(config.PageID)
 		if err != nil {
-			return nil, fmt.Errorf("unable to retrieve page by id: %w", err)
+			return nil, nil, fmt.Errorf("unable to retrieve page by id: %w", err)
 		}
 		if pg == nil {
-			return nil, fmt.Errorf("page with id %q not found", config.PageID)
+			return nil, nil, fmt.Errorf("page with id %q not found", config.PageID)
 		}
 		target = pg
 	}
@@ -493,7 +511,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		declaredAttachments,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("unable to locate attachments: %w", err)
+		return nil, nil, fmt.Errorf("unable to locate attachments: %w", err)
 	}
 
 	// The page's remote attachment list is fetched once and threaded through
@@ -502,14 +520,14 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	// pass previously issued its own paginated fetch of the same list.
 	remoteAttachments, err := api.GetAttachments(target.ID)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get attachments for page %s: %w", target.ID, err)
+		return nil, nil, fmt.Errorf("unable to get attachments for page %s: %w", target.ID, err)
 	}
 
 	attaches, remoteAttachments, err := attachment.ResolveAttachmentsWithRemotes(
 		api, target, localAttachments, remoteAttachments,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create/update attachments: %w", err)
+		return nil, nil, fmt.Errorf("unable to create/update attachments: %w", err)
 	}
 
 	markdown = attachment.CompileAttachmentLinks(markdown, attaches)
@@ -520,7 +538,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 
 	imageAlign, err := getImageAlign(config.ImageAlign, meta)
 	if err != nil {
-		return nil, fmt.Errorf("unable to determine image-align: %w", err)
+		return nil, nil, fmt.Errorf("unable to determine image-align: %w", err)
 	}
 
 	cfg := types.MarkConfig{
@@ -535,13 +553,13 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 
 	html, inlineAttachments, err := markmd.CompileMarkdown(markdown, std, file, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("unable to compile markdown: %w", err)
+		return nil, nil, fmt.Errorf("unable to compile markdown: %w", err)
 	}
 
 	if _, _, err = attachment.ResolveAttachmentsWithRemotes(
 		api, target, inlineAttachments, remoteAttachments,
 	); err != nil {
-		return nil, fmt.Errorf("unable to create/update attachments: %w", err)
+		return nil, nil, fmt.Errorf("unable to create/update attachments: %w", err)
 	}
 
 	var layout, sidebar string
@@ -572,7 +590,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 			},
 		)
 		if err != nil {
-			return nil, fmt.Errorf("unable to execute layout template: %w", err)
+			return nil, nil, fmt.Errorf("unable to execute layout template: %w", err)
 		}
 		html = buffer.String()
 	}
@@ -607,24 +625,24 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	if shouldUpdatePage && config.PreserveComments && !pageCreated {
 		pg, err := api.GetPageByIDExpanded(target.ID, "ancestors,version,body.storage")
 		if err != nil {
-			return nil, fmt.Errorf("unable to retrieve page body for comments: %w", err)
+			return nil, nil, fmt.Errorf("unable to retrieve page body for comments: %w", err)
 		}
 		target = pg
 
 		comments, err := api.GetInlineComments(target.ID)
 		if err != nil {
-			return nil, fmt.Errorf("unable to retrieve inline comments: %w", err)
+			return nil, nil, fmt.Errorf("unable to retrieve inline comments: %w", err)
 		}
 
 		html, err = mergeComments(html, target.Body.Storage.Value, comments)
 		if err != nil {
-			return nil, fmt.Errorf("unable to merge inline comments: %w", err)
+			return nil, nil, fmt.Errorf("unable to merge inline comments: %w", err)
 		}
 	}
 
 	if tracker != nil && meta != nil {
 		if err := tracker.Record(meta.Space, file, target.ID, meta.Title, sourceHash); err != nil {
-			return nil, fmt.Errorf("unable to record page mapping for %q: %w", file, err)
+			return nil, nil, fmt.Errorf("unable to record page mapping for %q: %w", file, err)
 		}
 	}
 
@@ -638,13 +656,25 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 			emoji,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("unable to update page: %w", err)
+			return nil, nil, fmt.Errorf("unable to update page: %w", err)
 		}
 	}
 
 	if meta != nil {
 		if err := updateLabels(api, target, labels); err != nil {
-			return nil, err
+			return nil, nil, err
+		}
+	}
+
+	// Where this page asked to sit among its siblings. Applied once the whole
+	// run is known, since a position only means something next to the others.
+	var placement *page.Ordered
+	if meta != nil && meta.Order != nil {
+		placement = &page.Ordered{
+			PageID:   target.ID,
+			ParentID: page.ImmediateParentID(target),
+			Title:    target.Title,
+			Order:    *meta.Order,
 		}
 	}
 
@@ -655,11 +685,11 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 			config.Username,
 		)
 		if err := api.RestrictPageUpdates(target, config.Username); err != nil {
-			return nil, fmt.Errorf("unable to restrict page updates: %w", err)
+			return nil, nil, fmt.Errorf("unable to restrict page updates: %w", err)
 		}
 	}
 
-	return target, nil
+	return target, placement, nil
 }
 
 // pruneOrphans forgets the entries reportOrphans just named.

--- a/mark_process_test.go
+++ b/mark_process_test.go
@@ -1187,3 +1187,166 @@ func TestHomepageItselfIsStillPublishable(t *testing.T) {
 	assert.Contains(t, after.Body, "Welcome!")
 	assert.Empty(t, after.ParentID, "the homepage must stay at the root")
 }
+
+// orderedDoc is a document asking for a position among its siblings.
+func orderedDoc(title string, order int) string {
+	return fmt.Sprintf(`<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: %s -->
+<!-- Order: %d -->
+
+Body.
+`, title, order)
+}
+
+// orderSpace builds a space and returns the parent the documents hang from.
+func orderSpace(t *testing.T) (*confluencetest.Server, *confluencetest.Page) {
+	t.Helper()
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	return server, server.AddPage("DOCS", "Parent", "page", home.ID)
+}
+
+func titlesOf(t *testing.T, server *confluencetest.Server, parentID string) []string {
+	t.Helper()
+	var titles []string
+	for _, id := range server.ChildOrder(parentID) {
+		titles = append(titles, server.Page(id).Title)
+	}
+	return titles
+}
+
+// TestOrderHeaderArrangesSiblings is the feature: documents are published in
+// whatever order the glob produced them, and end up in the order they asked
+// for.
+func TestOrderHeaderArrangesSiblings(t *testing.T) {
+	server, parent := orderSpace(t)
+	dir := t.TempDir()
+
+	// Written so the filenames sort opposite to the requested order, which is
+	// what shows the ordering is doing the work.
+	writeFile(t, dir, "a.md", orderedDoc("Third", 30))
+	writeFile(t, dir, "b.md", orderedDoc("First", 10))
+	writeFile(t, dir, "c.md", orderedDoc("Second", 20))
+
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"}, Output: io.Discard,
+	}))
+
+	assert.Equal(t, []string{"First", "Second", "Third"}, titlesOf(t, server, parent.ID))
+}
+
+// TestOrderIsIdempotent is what decides whether this can run in CI. Ordering
+// happens on every publish, so a run that changes nothing must move nothing --
+// otherwise every run fills page histories with churn.
+func TestOrderIsIdempotent(t *testing.T) {
+	server, parent := orderSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "a.md", orderedDoc("Third", 30))
+	writeFile(t, dir, "b.md", orderedDoc("First", 10))
+	writeFile(t, dir, "c.md", orderedDoc("Second", 20))
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"}, Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+	require.Equal(t, []string{"First", "Second", "Third"}, titlesOf(t, server, parent.ID))
+
+	server.ResetRequests()
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, 0, countMoves(server), "a second run must not move anything")
+	assert.Equal(t, []string{"First", "Second", "Third"}, titlesOf(t, server, parent.ID))
+}
+
+func countMoves(server *confluencetest.Server) int {
+	n := 0
+	for _, r := range server.Requests() {
+		if strings.Contains(r.Path, "/move/") {
+			n++
+		}
+	}
+	return n
+}
+
+// TestOrderMovesOnlyWhatMustMove: one page changing position must not
+// reshuffle the rest.
+func TestOrderMovesOnlyWhatMustMove(t *testing.T) {
+	server, parent := orderSpace(t)
+	dir := t.TempDir()
+
+	for i, title := range []string{"One", "Two", "Three", "Four"} {
+		writeFile(t, dir, fmt.Sprintf("%d.md", i), orderedDoc(title, (i+1)*10))
+	}
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"}, Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+	require.Equal(t, []string{"One", "Two", "Three", "Four"}, titlesOf(t, server, parent.ID))
+
+	// "Four" is asked to lead. Everything else keeps its relative order, so
+	// only one page needs to move.
+	writeFile(t, dir, "3.md", orderedDoc("Four", 5))
+	server.ResetRequests()
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, []string{"Four", "One", "Two", "Three"}, titlesOf(t, server, parent.ID))
+	assert.Equal(t, 1, countMoves(server), "only the page that changed position should move")
+}
+
+// TestOrderLeavesUnorderedPagesAlone: a document that says nothing about order
+// must not be dragged about by the ones that do.
+func TestOrderLeavesUnorderedPagesAlone(t *testing.T) {
+	server, parent := orderSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "plain.md", markdownWithTitle("Plain"))
+	writeFile(t, dir, "a.md", orderedDoc("Second", 20))
+	writeFile(t, dir, "b.md", orderedDoc("First", 10))
+
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"}, Output: io.Discard,
+	}))
+
+	order := titlesOf(t, server, parent.ID)
+	assert.Contains(t, order, "Plain")
+	first, second := indexOf(order, "First"), indexOf(order, "Second")
+	assert.Less(t, first, second, "the ordered pages should be in the order they asked for")
+}
+
+func indexOf(values []string, want string) int {
+	for i, v := range values {
+		if v == want {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestOrderIsNotAppliedOnDryRun: a dry run reports and rearranges nothing.
+func TestOrderIsNotAppliedOnDryRun(t *testing.T) {
+	server, parent := orderSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "a.md", orderedDoc("Third", 30))
+	writeFile(t, dir, "b.md", orderedDoc("First", 10))
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"}, Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	// Flip the requested order, then dry run.
+	writeFile(t, dir, "a.md", orderedDoc("Third", 5))
+	before := titlesOf(t, server, parent.ID)
+	config.DryRun = true
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, before, titlesOf(t, server, parent.ID),
+		"a dry run must leave the order exactly as it found it")
+}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -27,6 +28,7 @@ const (
 	HeaderEmoji       = `Emoji`
 	HeaderAttachment  = `Attachment`
 	HeaderLabel       = `Label`
+	HeaderOrder       = `Order`
 	HeaderInclude     = `Include`
 	HeaderSidebar     = `Sidebar`
 	ContentAppearance = `Content-Appearance`
@@ -45,7 +47,13 @@ type Meta struct {
 	Attachments       []string
 	Labels            []string
 	ContentAppearance string
-	ImageAlign        string
+
+	// Order positions this page among its siblings, smaller first. Nil means
+	// the document said nothing about order, which is not the same as zero:
+	// mark leaves such pages exactly where Confluence has them rather than
+	// sorting them to the front.
+	Order      *int
+	ImageAlign string
 }
 
 const (
@@ -231,6 +239,15 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 
 				case HeaderEmoji:
 					meta.Emoji = strings.TrimSpace(value)
+
+				case HeaderOrder:
+					order, err := strconv.Atoi(strings.TrimSpace(value))
+					if err != nil {
+						return nil, nil, fmt.Errorf(
+							"%s header must be a whole number, got %q", HeaderOrder, value,
+						)
+					}
+					meta.Order = &order
 
 				case HeaderAttachment:
 					meta.Attachments = append(meta.Attachments, value)

--- a/page/order.go
+++ b/page/order.go
@@ -1,0 +1,205 @@
+package page
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/rs/zerolog/log"
+)
+
+// Ordered is a page a document asked to be placed at a particular position
+// among its siblings.
+type Ordered struct {
+	PageID   string
+	ParentID string
+	Title    string
+	Order    int
+}
+
+// OrderChildren arranges pages under each parent into the order their documents
+// asked for.
+//
+// Only pages named here are touched, and only relative to each other. A run
+// covering part of a repository has no idea what else lives under those
+// parents, and dragging strangers about because they happen to share a parent
+// would be well beyond what was asked for.
+//
+// Nothing is moved that is already in the right relative order. That is not an
+// optimisation but the point: ordering runs on every publish, and a version
+// that reissued every move each time would fill page histories with churn and
+// make the feature unusable in CI. A run that changes nothing performs no
+// writes at all.
+func OrderChildren(api *confluence.API, dryRun bool, pages []Ordered) error {
+	byParent := map[string][]Ordered{}
+	for _, p := range pages {
+		if p.ParentID == "" {
+			// Nothing to be ordered relative to. Confluence's before/after also
+			// misbehave against top-level targets, so this is left alone.
+			continue
+		}
+		byParent[p.ParentID] = append(byParent[p.ParentID], p)
+	}
+
+	parents := make([]string, 0, len(byParent))
+	for parent := range byParent {
+		parents = append(parents, parent)
+	}
+	sort.Strings(parents)
+
+	for _, parent := range parents {
+		if err := orderUnder(api, dryRun, parent, byParent[parent]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func orderUnder(api *confluence.API, dryRun bool, parentID string, wanted []Ordered) error {
+	if len(wanted) < 2 {
+		// A single page has nothing to be ordered against, and moving it would
+		// only disturb whatever it currently sits beside.
+		return nil
+	}
+
+	// Title breaks ties so that two documents claiming the same position come
+	// out the same way on every run rather than following map iteration.
+	sort.SliceStable(wanted, func(i, j int) bool {
+		if wanted[i].Order != wanted[j].Order {
+			return wanted[i].Order < wanted[j].Order
+		}
+		return wanted[i].Title < wanted[j].Title
+	})
+
+	children, err := api.GetChildPages(parentID)
+	if err != nil {
+		return err
+	}
+
+	// Where each page sits now, among this parent's children as Confluence
+	// lists them -- which is the order the tree is shown in.
+	position := make(map[string]int, len(children))
+	for i, child := range children {
+		position[child.ID] = i
+	}
+
+	current := make([]int, 0, len(wanted))
+	for _, p := range wanted {
+		at, ok := position[p.PageID]
+		if !ok {
+			// Published under a different parent than the one it is listed
+			// under, or created moments ago and not yet visible. Either way
+			// there is nothing to compare it against.
+			log.Debug().Msgf("page %q is not listed under %s; leaving its position alone", p.Title, parentID)
+			return nil
+		}
+		current = append(current, at)
+	}
+
+	// Pages already in the right order relative to each other are the ones
+	// worth keeping still; everything else moves. Taking the longest such run
+	// is what makes the number of moves minimal.
+	keep := longestIncreasingSubsequence(current)
+	settled := make(map[int]bool, len(keep))
+	for _, i := range keep {
+		settled[i] = true
+	}
+
+	if len(keep) == len(wanted) {
+		return nil
+	}
+
+	// Left to right, so that by the time a page is placed after its
+	// predecessor, that predecessor is already where it finally belongs.
+	for i := range wanted {
+		if settled[i] {
+			continue
+		}
+
+		// The first page has nothing to sit after, so it is placed ahead of the
+		// one that follows it instead. Without this a page asked to lead never
+		// moved at all.
+		before := i == 0
+		var neighbour Ordered
+		if before {
+			neighbour = wanted[1]
+		} else {
+			neighbour = wanted[i-1]
+		}
+
+		where := "after"
+		if before {
+			where = "before"
+		}
+
+		if dryRun {
+			log.Info().Msgf("page %q would be moved %s %q", wanted[i].Title, where, neighbour.Title)
+			continue
+		}
+
+		log.Info().Msgf("moving page %q %s %q", wanted[i].Title, where, neighbour.Title)
+
+		var err error
+		if before {
+			err = api.MoveContentBefore(wanted[i].PageID, neighbour.PageID)
+		} else {
+			err = api.MoveContentAfter(wanted[i].PageID, neighbour.PageID)
+		}
+		if err != nil {
+			return fmt.Errorf("unable to order page %q: %w", wanted[i].Title, err)
+		}
+	}
+
+	return nil
+}
+
+// longestIncreasingSubsequence returns the indices of a longest run of values
+// that is already in ascending order.
+//
+// Those are the pages that need not move: every page outside the run has to be
+// repositioned no matter what, and no larger set can be left in place, so this
+// is the smallest number of moves that produces the requested order.
+func longestIncreasingSubsequence(values []int) []int {
+	if len(values) == 0 {
+		return nil
+	}
+
+	// tails[k] is the index of the smallest value that ends an increasing run
+	// of length k+1; prev threads each element back to its predecessor.
+	tails := []int{}
+	prev := make([]int, len(values))
+	for i := range prev {
+		prev[i] = -1
+	}
+
+	for i, v := range values {
+		lo, hi := 0, len(tails)
+		for lo < hi {
+			mid := (lo + hi) / 2
+			if values[tails[mid]] < v {
+				lo = mid + 1
+			} else {
+				hi = mid
+			}
+		}
+
+		if lo > 0 {
+			prev[i] = tails[lo-1]
+		}
+		if lo == len(tails) {
+			tails = append(tails, i)
+		} else {
+			tails[lo] = i
+		}
+	}
+
+	result := make([]int, len(tails))
+	k := tails[len(tails)-1]
+	for i := len(tails) - 1; i >= 0; i-- {
+		result[i] = k
+		k = prev[k]
+	}
+
+	return result
+}

--- a/page/order_test.go
+++ b/page/order_test.go
@@ -1,0 +1,62 @@
+package page
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestLongestIncreasingSubsequence pins the property the move count depends on:
+// the pages left in place are the largest set already in the right order, so
+// everything else has to move regardless and nothing else can be spared.
+func TestLongestIncreasingSubsequence(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []int
+		want []int
+	}{
+		{"already ordered", []int{0, 1, 2, 3}, []int{0, 1, 2, 3}},
+		{"exactly reversed", []int{3, 2, 1, 0}, []int{3}},
+		{"one out of place", []int{0, 3, 1, 2}, []int{0, 2, 3}},
+		{"single", []int{7}, []int{0}},
+		{"empty", nil, nil},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := longestIncreasingSubsequence(c.in)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestLongestIncreasingSubsequenceIsMaximal checks the result really is the
+// longest such run, by brute force over every subsequence of a small input.
+// A merely-increasing answer would still pass the cases above.
+func TestLongestIncreasingSubsequenceIsMaximal(t *testing.T) {
+	in := []int{5, 1, 6, 2, 7, 3, 8, 0}
+
+	best := 0
+	for mask := 1; mask < 1<<len(in); mask++ {
+		last, n, ok := -1, 0, true
+		for i := range in {
+			if mask&(1<<i) == 0 {
+				continue
+			}
+			if in[i] <= last {
+				ok = false
+				break
+			}
+			last = in[i]
+			n++
+		}
+		if ok && n > best {
+			best = n
+		}
+	}
+
+	if got := len(longestIncreasingSubsequence(in)); got != best {
+		t.Errorf("kept %d in place, but %d could have been", got, best)
+	}
+}


### PR DESCRIPTION
Fixes #359.

Confluence sorts a page's children alphabetically until somebody arranges them by hand, and mark had no way to express an arrangement at all.

```markdown
<!-- Order: 20 -->
```

Smaller numbers first. A document that says nothing about order is left exactly where Confluence has it, so annotating one page does not disturb the rest.

## Why not filesystem order

Comparable tools derive order from filenames. **I deliberately did not**, for a reason specific to mark: `--track-pages` exists precisely so that renaming a file does not disturb its page. Deriving order from filenames would undo that — a rename would silently rearrange the tree. A header also opts in by existing, so no flag is needed.

## Scope

Only pages published in the same run are arranged, and only relative to each other. A run narrowed by `--files` knows nothing about the other children of those parents, and rearranging strangers because they share a parent is well beyond what was asked for. Pages with no resolvable parent are skipped, which also avoids Confluence's documented misbehaviour when `before`/`after` target a top-level page.

## Minimal moves, which is the part that matters

Ordering runs on **every** publish. A version that reissued every move each time would fill page histories with churn and be unusable in CI.

The pages left in place are the longest run already in ascending position — the largest set that can be spared — so the number of moves is minimal. Concretely, in a four-page tree where one page is asked to lead, exactly **one** move is issued, and a run that changes nothing issues **none**.

Both are tests rather than claims: replacing the calculation with "move everything" fails `TestOrderIsIdempotent` and `TestOrderMovesOnlyWhatMustMove`.

## What was added

- `Order` header in `metadata`
- `GetChildPages` — the response order of `content/{id}/child/page` is the order the tree is shown in
- `MoveContentBefore` / `MoveContentAfter` — mark already used the `append` form of that endpoint to relocate pages
- ordering applied once per run, after publishing, alongside the manifest save
- the fake gains child listing, child order, and the `before`/`after` move forms

## A bug worth mentioning

The first draft never moved a page asked to **lead**. The loop placed each page after its predecessor, and the first page has none — so it was skipped entirely. Two tests caught it. It now places the leading page ahead of the one that follows.

## Caveat for the docs

Giving Confluence explicit positions takes that branch out of its default alphabetical ordering. That is inherent to asking for a particular order, and the README says so.

## Testing

Five end-to-end tests: the order is applied against a deliberately contrary filename order; a second identical run moves nothing; a single position change moves exactly one page; unordered pages are left alone; a dry run rearranges nothing. Plus unit tests for the move calculation, including a brute-force check that the set left in place really is maximal.

Full suite green under `-race`, `golangci-lint` 0 issues, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)