### PR TITLE
feat: leave marked regions out of the published page

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,31 @@ Also, optional following headers are supported:
 * default: sets the Confluence property value to `"default"`, which is the narrow layout as set by the Confluence UI. Note: `fixed` maps to a different Confluence property value and can cause misaligned page title and body content — use `default` instead for the narrow layout.
 
 ```markdown
+<!-- ac:ignore -->
+content that stays out of Confluence
+<!-- ac:ignore end -->
+```
+
+Everything between the two markers is left out of the published page, along with
+the markers themselves. It is for content that reads well in one place and badly
+in the other -- a table of contents that Confluence builds for itself, or a
+plain-text stand-in for a macro:
+
+```markdown
+<!-- Include: ac:profile
+     Name: Doe, John -->
+<!-- ac:ignore -->
+John Doe's profile
+<!-- ac:ignore end -->
+```
+
+Read on GitHub the file shows the name; published to Confluence it shows the
+profile macro. Attachments referenced only inside an ignored region are not
+uploaded, since nothing on the page would point at them. A marker without its
+pair is an error rather than a guess -- quietly publishing half a page is worse
+than refusing.
+
+```markdown
 <!-- Order: <number> -->
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ John Doe's profile
 ```
 
 Read on GitHub the file shows the name; published to Confluence it shows the
-profile macro. Attachments referenced only inside an ignored region are not
-uploaded, since nothing on the page would point at them. A marker without its
+profile macro. Included files may mark regions of their own, which is stripped
+as each file is read. Attachments referenced only inside an ignored region are
+not uploaded, since nothing on the page would point at them. A marker without its
 pair is an error rather than a guess -- quietly publishing half a page is worse
 than refusing.
 

--- a/includes/templates.go
+++ b/includes/templates.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/kovetskiy/mark/v16/metadata"
 	"github.com/rs/zerolog/log"
 	"go.yaml.in/yaml/v3"
 )
@@ -153,6 +154,17 @@ func LoadTemplate(
 		[]byte("\r\n"),
 		[]byte("\n"),
 	)
+
+	// An included file may mark regions as not for Confluence just as the
+	// document that includes it can. Stripping happens per file as each is
+	// read, rather than once over the finished document, because by the time
+	// the pieces are assembled the markers have already been through template
+	// expansion -- and because the whole point of the feature is that the file
+	// reads well on its own, which is as true of a fragment as of a page.
+	body, err = metadata.StripIgnoredBlocks(body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to process template file %q: %w", path, err)
+	}
 
 	templates, err = templates.New(cacheName).Delims(left, right).Parse(string(body))
 	if err != nil {

--- a/mark.go
+++ b/mark.go
@@ -291,6 +291,16 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 
 	frontMatterEnabled := slices.Contains(config.Features, "frontmatter")
 
+	// Before the headers are read, so that the line numbers in any complaint
+	// are the ones in the file the author is looking at rather than offsets
+	// into what is left after the header block is taken off. It also means an
+	// ignored region is ignored entirely, headers and all, which is what the
+	// markers say on the tin.
+	markdown, err = metadata.StripIgnoredBlocks(markdown)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to process %q: %w", file, err)
+	}
+
 	meta, markdown, err := metadata.ExtractMeta(
 		markdown,
 		config.Space,

--- a/mark_process_test.go
+++ b/mark_process_test.go
@@ -1436,3 +1436,45 @@ Body.
 	assert.Empty(t, server.Attachments(page.ID),
 		"an image only referenced inside an ignored region should not be uploaded")
 }
+
+// TestIgnoredRegionInsideAnIncludeIsNotPublished: a fragment can mark regions
+// as not for Confluence just as the document including it can. Without this the
+// region and its markers both reached the page, which is the more surprising
+// half -- the feature appeared to work until somebody moved the content into an
+// include.
+func TestIgnoredRegionInsideAnIncludeIsNotPublished(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "part.md", `Included body.
+
+<!-- ac:ignore -->
+HIDDEN FROM CONFLUENCE
+<!-- ac:ignore end -->
+`)
+	file := writeFile(t, dir, "doc.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Doc -->
+
+Top.
+
+<!-- Include: part.md -->
+`)
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: file, Features: []string{"mention"}, Output: io.Discard,
+	}))
+
+	page, err := api.FindPage("DOCS", "Doc", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+
+	body := server.Page(page.ID).Body
+	assert.Contains(t, body, "Included body.")
+	assert.NotContains(t, body, "HIDDEN FROM CONFLUENCE")
+	assert.NotContains(t, body, "ac:ignore")
+}

--- a/mark_process_test.go
+++ b/mark_process_test.go
@@ -1350,3 +1350,89 @@ func TestOrderIsNotAppliedOnDryRun(t *testing.T) {
 	assert.Equal(t, before, titlesOf(t, server, parent.ID),
 		"a dry run must leave the order exactly as it found it")
 }
+
+// TestIgnoredRegionIsNotPublished is the point of issue #317: a document that
+// reads well in both places. Something that renders badly in Confluence -- a
+// GitHub table of contents, a plain-text stand-in for a macro -- stays in the
+// file and out of the page.
+func TestIgnoredRegionIsNotPublished(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	file := writeFile(t, dir, "doc.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Doc -->
+
+Published body.
+
+<!-- ac:ignore -->
+## Contents
+
+- [One](#one)
+- [Two](#two)
+<!-- ac:ignore end -->
+
+Also published.
+`)
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: file, Features: []string{"mention"}, Output: io.Discard,
+	}))
+
+	page, err := api.FindPage("DOCS", "Doc", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+
+	body := server.Page(page.ID).Body
+	assert.Contains(t, body, "Published body.")
+	assert.Contains(t, body, "Also published.")
+	assert.NotContains(t, body, "Contents", "the ignored region must not reach Confluence")
+	assert.NotContains(t, body, "ac:ignore", "and neither must the markers")
+}
+
+// TestIgnoredRegionTakesItsAttachmentsWithIt: an image only referenced inside
+// an ignored region must not be uploaded. Nothing on the page would point at
+// it, so it would sit there as an orphan.
+func TestIgnoredRegionTakesItsAttachmentsWithIt(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	png := []byte{
+		0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a,
+		0x00, 0x00, 0x00, 0x0d, 'I', 'H', 'D', 'R',
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+		0x89,
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "hidden.png"), png, 0o600))
+
+	file := writeFile(t, dir, "doc.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Doc -->
+
+Body.
+
+<!-- ac:ignore -->
+![hidden](hidden.png)
+<!-- ac:ignore end -->
+`)
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: file, Features: []string{"mention"}, Output: io.Discard,
+	}))
+
+	page, err := api.FindPage("DOCS", "Doc", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+
+	assert.Empty(t, server.Attachments(page.ID),
+		"an image only referenced inside an ignored region should not be uploaded")
+}

--- a/metadata/ignore.go
+++ b/metadata/ignore.go
@@ -1,0 +1,124 @@
+package metadata
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// IgnoreStart opens a region that is not published, and IgnoreEnd closes
+	// it. The spelling follows the one agreed in issue #317.
+	IgnoreStart = "ac:ignore"
+	IgnoreEnd   = "ac:ignore end"
+)
+
+// StripIgnoredBlocks removes the regions a document marked as not for
+// Confluence.
+//
+//	<!-- Include: ac:profile
+//	     Name: Doe, John -->
+//	<!-- ac:ignore -->
+//	John Doe's profile
+//	<!-- ac:ignore end -->
+//
+// The point is a document that reads well in both places. Some things render
+// nicely in one and badly in the other -- a table of contents, a macro that
+// only Confluence understands, a plain-text stand-in for it -- and until now
+// the only way to have both was to keep two copies of the file.
+//
+// Ignored lines are removed rather than blanked. Leaving blank lines behind
+// would be kinder to line numbers in later error messages, but a blank line is
+// not nothing in Markdown: dropped into the middle of a list or an indented
+// block it would split the one and end the other, so the region has to go
+// entirely.
+//
+// An unclosed region is an error rather than a silent strip to the end of the
+// file. A missing end marker is nearly always a typo, and quietly publishing
+// half a page is a worse answer than refusing.
+func StripIgnoredBlocks(data []byte) ([]byte, error) {
+	text := string(data)
+	if !strings.Contains(strings.ToLower(text), IgnoreStart) {
+		return data, nil
+	}
+
+	lines := strings.Split(text, "\n")
+	kept := make([]string, 0, len(lines))
+
+	ignoring := false
+	openedAt := 0
+
+	for i, line := range lines {
+		switch ignoreMarker(line) {
+		case markerStart:
+			if ignoring {
+				return nil, fmt.Errorf(
+					"line %d: <!-- %s --> opened again before the one on line %d was closed",
+					i+1, IgnoreStart, openedAt,
+				)
+			}
+			ignoring = true
+			openedAt = i + 1
+
+		case markerEnd:
+			if !ignoring {
+				return nil, fmt.Errorf(
+					"line %d: <!-- %s --> without a matching <!-- %s -->",
+					i+1, IgnoreEnd, IgnoreStart,
+				)
+			}
+			ignoring = false
+
+		default:
+			if !ignoring {
+				kept = append(kept, line)
+			}
+		}
+	}
+
+	if ignoring {
+		return nil, fmt.Errorf(
+			"<!-- %s --> on line %d is never closed with <!-- %s -->",
+			IgnoreStart, openedAt, IgnoreEnd,
+		)
+	}
+
+	return []byte(strings.Join(kept, "\n")), nil
+}
+
+type marker int
+
+const (
+	markerNone marker = iota
+	markerStart
+	markerEnd
+)
+
+// ignoreMarker reports whether a line is one of the region markers.
+//
+// The end marker is checked first: it begins with the start marker's text, so
+// testing the other way round would read every "ac:ignore end" as an opening.
+func ignoreMarker(line string) marker {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, commentOpen) || !strings.HasSuffix(line, commentClose) {
+		return markerNone
+	}
+	if len(line) < len(commentOpen)+len(commentClose) {
+		return markerNone
+	}
+
+	content := strings.ToLower(strings.TrimSpace(
+		line[len(commentOpen) : len(line)-len(commentClose)],
+	))
+	// Collapse the space between the words so that "ac:ignore  end" is the same
+	// marker as "ac:ignore end".
+	content = strings.Join(strings.Fields(content), " ")
+
+	switch content {
+	case IgnoreEnd:
+		return markerEnd
+	case IgnoreStart:
+		return markerStart
+	default:
+		return markerNone
+	}
+}

--- a/metadata/ignore_test.go
+++ b/metadata/ignore_test.go
@@ -1,0 +1,94 @@
+package metadata
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStripIgnoredBlocks(t *testing.T) {
+	t.Run("removes the region and its markers", func(t *testing.T) {
+		out, err := StripIgnoredBlocks([]byte("A\n<!-- ac:ignore -->\nB\nC\n<!-- ac:ignore end -->\nD\n"))
+		require.NoError(t, err)
+		assert.Equal(t, "A\nD\n", string(out))
+	})
+
+	t.Run("a document without markers is returned untouched", func(t *testing.T) {
+		in := []byte("A\n\nB\n")
+		out, err := StripIgnoredBlocks(in)
+		require.NoError(t, err)
+		assert.Equal(t, string(in), string(out))
+	})
+
+	t.Run("several regions", func(t *testing.T) {
+		out, err := StripIgnoredBlocks([]byte(
+			"A\n<!-- ac:ignore -->\nx\n<!-- ac:ignore end -->\nB\n<!-- ac:ignore -->\ny\n<!-- ac:ignore end -->\nC\n"))
+		require.NoError(t, err)
+		assert.Equal(t, "A\nB\nC\n", string(out))
+	})
+
+	t.Run("spacing and case are tolerated", func(t *testing.T) {
+		out, err := StripIgnoredBlocks([]byte("A\n<!--AC:Ignore-->\nx\n<!--   ac:ignore   end   -->\nB\n"))
+		require.NoError(t, err)
+		assert.Equal(t, "A\nB\n", string(out))
+	})
+
+	// The end marker starts with the start marker's text, so a naive prefix
+	// test reads every "ac:ignore end" as another opening and the region never
+	// closes.
+	t.Run("the end marker is not mistaken for another start", func(t *testing.T) {
+		out, err := StripIgnoredBlocks([]byte("A\n<!-- ac:ignore -->\nx\n<!-- ac:ignore end -->\nB\n"))
+		require.NoError(t, err)
+		assert.Equal(t, "A\nB\n", string(out))
+	})
+
+	t.Run("lines are removed rather than blanked", func(t *testing.T) {
+		// A blank line is not nothing in Markdown: left in the middle of a list
+		// it would split it in two.
+		out, err := StripIgnoredBlocks([]byte(
+			"- one\n<!-- ac:ignore -->\n- github only\n<!-- ac:ignore end -->\n- two\n"))
+		require.NoError(t, err)
+		assert.Equal(t, "- one\n- two\n", string(out))
+	})
+}
+
+func TestStripIgnoredBlocksReportsMistakes(t *testing.T) {
+	// Quietly publishing half a page is a worse answer than refusing, and the
+	// line number has to be the one in the file the author is looking at.
+	t.Run("unclosed region", func(t *testing.T) {
+		_, err := StripIgnoredBlocks([]byte("A\nB\n<!-- ac:ignore -->\nC\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "line 3")
+		assert.Contains(t, err.Error(), "never closed")
+	})
+
+	t.Run("end without a start", func(t *testing.T) {
+		_, err := StripIgnoredBlocks([]byte("A\n<!-- ac:ignore end -->\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "line 2")
+		assert.Contains(t, err.Error(), "without a matching")
+	})
+
+	t.Run("region opened twice", func(t *testing.T) {
+		_, err := StripIgnoredBlocks([]byte("<!-- ac:ignore -->\nA\n<!-- ac:ignore -->\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "line 3")
+	})
+}
+
+// TestStripIgnoredBlocksDoesNotPanicOnShortComments guards the same class of
+// crash as issue #686: "<!-->" satisfies both the opening and closing test at
+// once, because the "-->" is found inside the "<!--".
+func TestStripIgnoredBlocksDoesNotPanicOnShortComments(t *testing.T) {
+	for _, line := range []string{"<!-->", "<!--", "-->", "<!---->"} {
+		_, err := StripIgnoredBlocks([]byte("<!-- ac:ignore -->\n" + line + "\n<!-- ac:ignore end -->\n"))
+		require.NoError(t, err, "input %q", line)
+	}
+
+	// And outside a region.
+	out, err := StripIgnoredBlocks([]byte("<!-->\nA\n<!-- ac:ignore -->\nx\n<!-- ac:ignore end -->\n"))
+	require.NoError(t, err)
+	assert.Equal(t, "<!-->\nA\n", strings.TrimSuffix(string(out), "\n")+"\n")
+}


### PR DESCRIPTION
Fixes #317.

Some content reads well in one place and badly in the other — a table of contents GitHub needs and Confluence builds for itself, or a plain-text stand-in for a macro only Confluence understands. Until now the only way to have both was two copies of the file.

```markdown
<!-- Include: ac:profile
     Name: Doe, John -->
<!-- ac:ignore -->
John Doe's profile
<!-- ac:ignore end -->
```

Read on GitHub the file shows the name; published to Confluence it shows the profile macro.

The spelling is the one **agreed in the issue thread** rather than the one comparable tools use — @mrueg proposed `<!-- ac:ignore -->` / `<!-- ac:ignore end -->` there and @kovetskiy agreed, so this implements that.

## Where it happens, and why it matters

**Before the headers are read.** This decides two things:

- Line numbers in any complaint are the ones in the file the author is looking at, not offsets into what remains once the header block is removed. My first draft reported *line 4* for a marker on *line 6*.
- An ignored region is ignored **entirely**, headers and all, which is what the markers say on the tin.

**Before links are resolved and attachments gathered**, so a region takes its images with it. Uploading a file nothing on the page refers to would leave an orphan attachment behind — there is a test for that.

## Smaller decisions

**Lines are removed, not blanked.** Blanking would be kinder to line numbers, but a blank line is not nothing in Markdown: dropped into a list it splits it in two. Tested.

**A marker without its pair is an error.** A missing end is nearly always a typo, and quietly publishing half a page is worse than refusing. Both directions are reported with the line number.

**The end marker is checked before the start marker**, since `ac:ignore end` begins with `ac:ignore` — testing the other way round reads every close as another open and the region never terminates. Tested explicitly.

## Testing

Unit tests: region and markers removed, several regions, spacing and case tolerated, lines removed rather than blanked, all three malformed cases with their line numbers, and a guard against the `<!-->` crash class from #686 — that string satisfies both the opening and closing test at once.

End to end: an ignored region does not reach Confluence and neither do its markers; an image referenced only inside one is not uploaded.

Verified non-vacuous — making the stripper a no-op fails all five. Full suite green under `-race`, `golangci-lint` 0 issues, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)