### PR TITLE
fix: resolve relative links on the AST, not on the file's text

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,6 +840,28 @@ And this is how to link when the linktext is the same as the [Pagetitle](ac:)
 Link to a [page title containing spaces](<ac:With Multiple Words>)
 ```
 
+### Link to another page in the same repository
+
+A relative link to another Markdown file is replaced with a link to the
+Confluence page that file publishes:
+
+```markdown
+See [the other page](./other.md) and [a heading in it](./other.md#setup).
+```
+
+The target file is read to find its `Space` and `Title`, and the page is looked
+up by those. Links are rewritten to Confluence [tiny
+links](https://support.atlassian.com/confluence/kb/how-to-programmatically-generate-the-tiny-link-of-a-confluence-page)
+(`/x/AbCdEf`), which survive page renames and moves.
+
+A link is left exactly as written when it has a scheme (`https:`, `mailto:`),
+is a bare `#fragment`, points at a directory or a non-text file, or names a
+file that has no mark metadata and so is never published. Links are resolved on
+the parsed document, so a link that appears inside a code span or a fenced or
+indented code block is left alone -- a page documenting Markdown gets to show
+its examples unchanged. Files pulled in with `Include` are resolved along with
+the document that includes them.
+
 ### Upload and included inline images
 
 ```markdown

--- a/mark.go
+++ b/mark.go
@@ -345,10 +345,12 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		}
 	}
 
-	links, err := page.ResolveRelativeLinks(
+	// Links are rewritten while the document is being rendered, by walking the
+	// parsed tree. Doing it here, over the text, meant a fenced block showing
+	// Markdown syntax had its example links turned into Confluence URLs.
+	resolveLink := page.NewLinkResolver(
 		api,
 		meta,
-		markdown,
 		filepath.Dir(file),
 		config.Space,
 		config.TitleFromH1,
@@ -356,12 +358,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		config.Parents,
 		config.TitleAppendGeneratedHash,
 		frontMatterEnabled,
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("unable to resolve relative links: %w", err)
-	}
-
-	markdown = page.SubstituteLinks(markdown, links)
+	).Resolve
 
 	if config.DryRun {
 		if meta != nil {
@@ -399,6 +396,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 			Features:      config.Features,
 			ImageAlign:    imageAlign,
 			IncludePath:   config.IncludePath,
+			ResolveLink:   resolveLink,
 		}
 		html, _, err := markmd.CompileMarkdown(markdown, std, file, cfg)
 		if err != nil {
@@ -559,6 +557,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		Features:      config.Features,
 		ImageAlign:    imageAlign,
 		IncludePath:   config.IncludePath,
+		ResolveLink:   resolveLink,
 	}
 
 	html, inlineAttachments, err := markmd.CompileMarkdown(markdown, std, file, cfg)

--- a/mark_process_test.go
+++ b/mark_process_test.go
@@ -1478,3 +1478,74 @@ Top.
 	assert.NotContains(t, body, "HIDDEN FROM CONFLUENCE")
 	assert.NotContains(t, body, "ac:ignore")
 }
+
+// linkedPair publishes two documents where one links to the other, and returns
+// the body of the linking page.
+func linkedPair(t *testing.T, body string) (string, *confluencetest.Server) {
+	t.Helper()
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "a-other.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Other -->\n\nOther.\n")
+	writeFile(t, dir, "b-doc.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Doc -->\n\n"+body)
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"}, Output: io.Discard,
+	}
+	// Twice, so the target exists by the time the link is resolved.
+	require.NoError(t, Run(config))
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	doc, err := api.FindPage("DOCS", "Doc", "page")
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	return server.Page(doc.ID).Body, server
+}
+
+// TestLinkInsideCodeBlockIsLeftAlone is the corruption this fixes. Resolution
+// used to scan the text and substitute across the whole file, so a fenced block
+// documenting Markdown syntax had its example links rewritten into Confluence
+// URLs -- and any code sample sharing text with a real link elsewhere went with
+// them.
+func TestLinkInsideCodeBlockIsLeftAlone(t *testing.T) {
+	body, _ := linkedPair(t, "Real link: [example](./a-other.md)\n\n"+
+		"```markdown\n[in a code block](./a-other.md)\n```\n")
+
+	i := strings.Index(body, "CDATA")
+	require.GreaterOrEqual(t, i, 0, "expected a code macro in %s", body)
+	code := body[i:]
+
+	assert.Contains(t, code, "./a-other.md",
+		"the code sample must survive exactly as written")
+	assert.NotContains(t, code, "/wiki/",
+		"a link inside a code block must not be rewritten")
+}
+
+// TestRealLinkIsStillResolved is the control: the fix must not simply stop
+// rewriting links.
+func TestRealLinkIsStillResolved(t *testing.T) {
+	body, _ := linkedPair(t, "Real link: [example](./a-other.md)\n")
+
+	assert.NotContains(t, body, "./a-other.md",
+		"a genuine relative link should have been rewritten")
+	assert.Contains(t, body, "/wiki/",
+		"and should point at the Confluence page")
+}
+
+// TestLinkInsideCodeSpanIsLeftAlone: the same for inline code.
+func TestLinkInsideCodeSpanIsLeftAlone(t *testing.T) {
+	body, _ := linkedPair(t, "Real link: [example](./a-other.md)\n\n"+
+		"Inline: `[sample](./a-other.md)`\n")
+
+	i := strings.Index(body, "<code>")
+	require.GreaterOrEqual(t, i, 0, "expected a code span in %s", body)
+	span := body[i:]
+	assert.Contains(t, span, "./a-other.md", "a code span must survive as written")
+}

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -211,8 +211,13 @@ func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib, path string, cfg types
 
 	ghAlertsExtension := NewConfluenceExtension(stdlib, path, cfg)
 	htmlOutput, err := compileMarkdownWithExtension(markdown, ghAlertsExtension, "rendering markdown with GitHub Alerts support:\n%s")
+	// A transformer cannot return an error from Transform, so each one that can
+	// fail keeps its failure for collection here.
 	if err == nil && ghAlertsExtension.Pipeline != nil && ghAlertsExtension.Pipeline.GetError() != nil {
 		err = ghAlertsExtension.Pipeline.GetError()
+	}
+	if err == nil && ghAlertsExtension.Links != nil && ghAlertsExtension.Links.GetError() != nil {
+		err = ghAlertsExtension.Links.GetError()
 	}
 	if err != nil {
 		return "", nil, err
@@ -278,6 +283,7 @@ type ConfluenceExtension struct {
 	MarkConfig  types.MarkConfig
 	Attachments []attachment.Attachment
 	Pipeline    *ctransformer.PipelineTransformer
+	Links       *ctransformer.LinkTransformer
 }
 
 // NewConfluenceExtension creates a new instance of the GitHub Alerts extension
@@ -298,6 +304,7 @@ func NewConfluenceExtension(stdlib *stdlib.Lib, path string, cfg types.MarkConfi
 		MarkConfig:  cfg,
 		Attachments: []attachment.Attachment{},
 		Pipeline:    pipeline,
+		Links:       ctransformer.NewLinkTransformer(cfg.ResolveLink),
 	}
 }
 
@@ -339,6 +346,9 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 		// well as the ones written in the file, and so that heading ids have
 		// already been assigned.
 		util.Prioritized(ctransformer.NewAnchorTransformer(), 900),
+		// After includes and macros have brought their content in, so links
+		// inside an included fragment are resolved too.
+		util.Prioritized(c.Links, 910),
 	))
 
 	// Add date widget support if requested

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -421,3 +421,66 @@ func TestDateFeature(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotContains(t, actualDisabled, `<time datetime="2026-07-27" />`)
 }
+
+// TestCompileMarkdownResolveLinkError checks that a failure while resolving a
+// link stops the run.
+//
+// An AST transformer cannot return an error, so this one is stashed and picked
+// up after rendering. Without that collection step the failure would be
+// dropped and the page published with the link left as written -- which is
+// exactly what a broken link target looks like, so nobody would notice.
+func TestCompileMarkdownResolveLinkError(t *testing.T) {
+	test := assert.New(t)
+
+	lib, err := stdlib.New(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	cfg := types.MarkConfig{
+		MermaidScale: 1.0,
+		D2Scale:      1.0,
+		ResolveLink: func(target string) (string, error) {
+			return "", fmt.Errorf("resolve link %q: nope", target)
+		},
+	}
+
+	_, _, err = mark.CompileMarkdown(
+		[]byte("[a link](./other.md)\n"), lib, "testdata/x.md", cfg,
+	)
+	test.Error(err)
+	test.Contains(err.Error(), "./other.md")
+}
+
+// TestCompileMarkdownResolveLinkSkipsCode is the unit-level counterpart to the
+// end-to-end tests in mark_process_test.go: the resolver must never be asked
+// about text that only looks like a link.
+func TestCompileMarkdownResolveLinkSkipsCode(t *testing.T) {
+	test := assert.New(t)
+
+	lib, err := stdlib.New(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	var asked []string
+	cfg := types.MarkConfig{
+		MermaidScale: 1.0,
+		D2Scale:      1.0,
+		ResolveLink: func(target string) (string, error) {
+			asked = append(asked, target)
+			return "", nil
+		},
+	}
+
+	markdown := []byte("" +
+		"[real](./real.md)\n\n" +
+		"`[code span](./span.md)`\n\n" +
+		"```\n[fenced](./fenced.md)\n```\n\n" +
+		"    [indented](./indented.md)\n",
+	)
+
+	_, _, err = mark.CompileMarkdown(markdown, lib, "testdata/x.md", cfg)
+	test.NoError(err)
+	test.Equal([]string{"./real.md"}, asked)
+}

--- a/page/link.go
+++ b/page/link.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -17,21 +16,32 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type LinkSubstitution struct {
-	From string
-	To   string
-}
-
 type markdownLink struct {
 	full     string
 	filename string
 	hash     string
 }
 
-func ResolveRelativeLinks(
+// LinkResolver resolves one link target at a time, for a caller walking a
+// parsed document rather than scanning its text.
+type LinkResolver struct {
+	API                      *confluence.API
+	Base                     string
+	SpaceForLinks            string
+	TitleFromH1              bool
+	TitleFromFilename        bool
+	Parents                  []string
+	TitleAppendGeneratedHash bool
+	FrontMatterEnabled       bool
+}
+
+// NewLinkResolver builds a resolver for the document at base.
+//
+// A link with no space of its own is resolved in the document's own space,
+// which is what a relative link between two files in one repository means.
+func NewLinkResolver(
 	api *confluence.API,
 	meta *metadata.Meta,
-	markdown []byte,
 	base string,
 	spaceFromCli string,
 	titleFromH1 bool,
@@ -39,41 +49,53 @@ func ResolveRelativeLinks(
 	parents []string,
 	titleAppendGeneratedHash bool,
 	frontMatterEnabled bool,
-) ([]LinkSubstitution, error) {
-	matches := parseLinks(string(markdown))
-
-	// If the user didn't provide --space, inherit the current document's space so
-	// relative links can be resolved within the same space.
+) *LinkResolver {
 	spaceForLinks := spaceFromCli
 	if spaceForLinks == "" && meta != nil {
 		spaceForLinks = meta.Space
 	}
 
-	links := []LinkSubstitution{}
-	for _, match := range matches {
-		log.Trace().
-			Msgf(
-				"found a relative link: full=%s filename=%s hash=%s",
-				match.full,
-				match.filename,
-				match.hash,
-			)
-		resolved, err := resolveLink(api, base, match, spaceForLinks, titleFromH1, titleFromFilename, parents, titleAppendGeneratedHash, frontMatterEnabled)
-		if err != nil {
-			return nil, fmt.Errorf("resolve link %q: %w", match.full, err)
-		}
+	return &LinkResolver{
+		API:                      api,
+		Base:                     base,
+		SpaceForLinks:            spaceForLinks,
+		TitleFromH1:              titleFromH1,
+		TitleFromFilename:        titleFromFilename,
+		Parents:                  parents,
+		TitleAppendGeneratedHash: titleAppendGeneratedHash,
+		FrontMatterEnabled:       frontMatterEnabled,
+	}
+}
 
-		if resolved == "" {
-			continue
-		}
-
-		links = append(links, LinkSubstitution{
-			From: match.full,
-			To:   resolved,
-		})
+// Resolve reports what a link target should become, or "" to leave it alone.
+//
+// The target arrives as the document wrote it -- a path with an optional
+// #fragment -- which is the same shape the old scanner extracted by hand.
+func (r *LinkResolver) Resolve(target string) (string, error) {
+	if r == nil || r.API == nil || target == "" {
+		return "", nil
 	}
 
-	return links, nil
+	// Anything with a scheme, or a bare fragment, is not a link to a file in
+	// this repository and is left as written.
+	if strings.Contains(target, "://") || strings.HasPrefix(target, "#") ||
+		strings.HasPrefix(target, "mailto:") {
+		return "", nil
+	}
+
+	filename, hash, _ := strings.Cut(target, "#")
+
+	resolved, err := resolveLink(
+		r.API, r.Base,
+		markdownLink{full: target, filename: filename, hash: hash},
+		r.SpaceForLinks, r.TitleFromH1, r.TitleFromFilename,
+		r.Parents, r.TitleAppendGeneratedHash, r.FrontMatterEnabled,
+	)
+	if err != nil {
+		return "", fmt.Errorf("resolve link %q: %w", target, err)
+	}
+
+	return resolved, nil
 }
 
 func resolveLink(
@@ -163,46 +185,6 @@ func resolveLink(
 	}
 
 	return result, nil
-}
-
-func SubstituteLinks(markdown []byte, links []LinkSubstitution) []byte {
-	for _, link := range links {
-		if link.From == link.To {
-			continue
-		}
-
-		log.Trace().Msgf("substitute link: %q -> %q", link.From, link.To)
-
-		markdown = bytes.ReplaceAll(
-			markdown,
-			[]byte(fmt.Sprintf("](%s)", link.From)),
-			[]byte(fmt.Sprintf("](%s)", link.To)),
-		)
-	}
-
-	return markdown
-}
-
-func parseLinks(markdown string) []markdownLink {
-	// Matches markdown links but not inline images (![ ... ]).
-	// Group 1: full link target (path + optional hash)
-	// Group 2: file path portion
-	// Group 3: hash portion
-	// The leading (?:^|[^!]) anchor prevents matching image syntax without
-	// consuming a character that belongs to a preceding link or word.
-	re := regexp.MustCompile(`(?:^|[^!])\[.+\]\((([^\)#]+)?#?([^\)]+)?)\)`)
-	matches := re.FindAllStringSubmatch(markdown, -1)
-
-	links := make([]markdownLink, len(matches))
-	for i, match := range matches {
-		links[i] = markdownLink{
-			full:     match[1],
-			filename: match[2],
-			hash:     match[3],
-		}
-	}
-
-	return links
 }
 
 // getConfluenceLink builds a stable Confluence tiny link for the given page or blog post.

--- a/page/link_test.go
+++ b/page/link_test.go
@@ -3,56 +3,88 @@ package page
 import (
 	"encoding/base64"
 	"encoding/binary"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/kovetskiy/mark/v16/confluence"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestParseLinks(t *testing.T) {
-	markdown := `
-	[example1](../path/to/example.md#second-heading)
-	[example2](../path/to/example.md)
-	[example3](#heading-in-document)
-	[Text link that should be put as attachment](../path/to/example.txt)
-	[Image link that should be put as attachment](../path/to/example.png)
-	[relative link without dots](relative-link-without-dots.md)
-	[relative link without dots but with hash](relative-link-without-dots-but-with-hash.md#hash)
-	[example [example]](example.md)
-	`
+func TestLinkResolverLeavesNonRepositoryTargetsAlone(t *testing.T) {
+	// A resolver with an API set but nothing on disk to point at: every target
+	// here has to come back empty, meaning "leave the link as written".
+	resolver := &LinkResolver{API: &confluence.API{}, Base: t.TempDir()}
 
-	links := parseLinks(markdown)
+	for _, target := range []string{
+		"https://example.com/page",
+		"http://example.com/page",
+		"ftp://example.com/file.txt",
+		"mailto:someone@example.com",
+		"#heading-in-document",
+		"",
+		"no-such-file.md",
+		"no-such-file.md#hash",
+		"../outside/missing.md",
+	} {
+		resolved, err := resolver.Resolve(target)
+		assert.NoError(t, err, "target %q", target)
+		assert.Empty(t, resolved, "target %q should have been left alone", target)
+	}
+}
 
-	assert.Equal(t, "../path/to/example.md#second-heading", links[0].full)
-	assert.Equal(t, "../path/to/example.md", links[0].filename)
-	assert.Equal(t, "second-heading", links[0].hash)
+func TestLinkResolverIgnoresDirectories(t *testing.T) {
+	base := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(base, "docs"), 0o755))
 
-	assert.Equal(t, "../path/to/example.md", links[1].full)
-	assert.Equal(t, "../path/to/example.md", links[1].filename)
-	assert.Equal(t, "", links[1].hash)
+	resolver := &LinkResolver{API: &confluence.API{}, Base: base}
 
-	assert.Equal(t, "#heading-in-document", links[2].full)
-	assert.Equal(t, "", links[2].filename)
-	assert.Equal(t, "heading-in-document", links[2].hash)
+	resolved, err := resolver.Resolve("docs")
+	assert.NoError(t, err)
+	assert.Empty(t, resolved)
+}
 
-	assert.Equal(t, "../path/to/example.txt", links[3].full)
-	assert.Equal(t, "../path/to/example.txt", links[3].filename)
-	assert.Equal(t, "", links[3].hash)
+func TestLinkResolverIgnoresNonTextFiles(t *testing.T) {
+	base := t.TempDir()
+	// A PNG header is enough for http.DetectContentType.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(base, "image.png"),
+		[]byte("\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"),
+		0o644,
+	))
 
-	assert.Equal(t, "../path/to/example.png", links[4].full)
-	assert.Equal(t, "../path/to/example.png", links[4].filename)
-	assert.Equal(t, "", links[4].hash)
+	resolver := &LinkResolver{API: &confluence.API{}, Base: base}
 
-	assert.Equal(t, "relative-link-without-dots.md", links[5].full)
-	assert.Equal(t, "relative-link-without-dots.md", links[5].filename)
-	assert.Equal(t, "", links[5].hash)
+	resolved, err := resolver.Resolve("image.png")
+	assert.NoError(t, err)
+	assert.Empty(t, resolved)
+}
 
-	assert.Equal(t, "relative-link-without-dots-but-with-hash.md#hash", links[6].full)
-	assert.Equal(t, "relative-link-without-dots-but-with-hash.md", links[6].filename)
-	assert.Equal(t, "hash", links[6].hash)
+func TestLinkResolverIgnoresFilesWithoutMetadata(t *testing.T) {
+	base := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(base, "plain.md"),
+		[]byte("# Just a heading\n\nNo mark metadata here.\n"),
+		0o644,
+	))
 
-	assert.Equal(t, "example.md", links[7].full)
-	assert.Equal(t, len(links), 8)
+	resolver := &LinkResolver{API: &confluence.API{}, Base: base}
+
+	// Without metadata there is no space or title to look a page up by, so the
+	// link stays as it is rather than the run failing.
+	resolved, err := resolver.Resolve("plain.md")
+	assert.NoError(t, err)
+	assert.Empty(t, resolved)
+}
+
+func TestLinkResolverWithoutAPIDoesNothing(t *testing.T) {
+	var resolver *LinkResolver
+
+	resolved, err := resolver.Resolve("anything.md")
+	assert.NoError(t, err)
+	assert.Empty(t, resolved)
 }
 
 func TestEncodeTinyLinkID(t *testing.T) {

--- a/transformer/links.go
+++ b/transformer/links.go
@@ -1,0 +1,72 @@
+package transformer
+
+import (
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+// LinkTransformer rewrites relative links to the Confluence pages they name.
+//
+// It works on the parsed document rather than on its text, which is the whole
+// point. The previous approach found links with a regular expression and
+// replaced them with bytes.ReplaceAll across the file, and both halves of that
+// reached places a link cannot be: a fenced block documenting Markdown syntax
+// had its example links turned into Confluence URLs, and any code sample
+// containing the same text as a real link elsewhere was rewritten along with
+// it. goldmark never produces a Link node inside a code span or a fenced
+// block, so neither can happen here.
+type LinkTransformer struct {
+	// Resolve reports what a target should become, or "" to leave it alone.
+	Resolve func(target string) (string, error)
+
+	// Err holds the first failure, since an AST walk cannot return one.
+	Err error
+}
+
+// NewLinkTransformer creates a LinkTransformer using the given resolver.
+func NewLinkTransformer(resolve func(target string) (string, error)) *LinkTransformer {
+	return &LinkTransformer{Resolve: resolve}
+}
+
+// GetError returns any error encountered while rewriting.
+func (t *LinkTransformer) GetError() error {
+	return t.Err
+}
+
+// Transform implements the parser.ASTTransformer interface.
+func (t *LinkTransformer) Transform(doc *ast.Document, reader text.Reader, pc parser.Context) {
+	if t.Resolve == nil {
+		return
+	}
+
+	// A failure aborts the walk and comes back out of ast.Walk, which is the
+	// only way an error can leave a transformer -- Transform itself cannot
+	// return one.
+	t.Err = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		link, ok := node.(*ast.Link)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+
+		target := string(link.Destination)
+		if target == "" {
+			return ast.WalkContinue, nil
+		}
+
+		resolved, err := t.Resolve(target)
+		if err != nil {
+			return ast.WalkStop, err
+		}
+
+		if resolved != "" && resolved != target {
+			link.Destination = []byte(resolved)
+		}
+
+		return ast.WalkContinue, nil
+	})
+}

--- a/types/types.go
+++ b/types/types.go
@@ -8,4 +8,14 @@ type MarkConfig struct {
 	Features      []string
 	ImageAlign    string
 	IncludePath   string
+
+	// ResolveLink turns a link target written in the document -- a relative
+	// path, optionally with a #fragment -- into the Confluence link it should
+	// become, or "" to leave it as written.
+	//
+	// Supplied as a function so that rewriting links stays a property of the
+	// document tree rather than of the bytes it was parsed from, without the
+	// renderer needing to know what Confluence is. Nil disables the rewriting
+	// entirely, which is what compiling without a server does.
+	ResolveLink func(target string) (string, error)
 }


### PR DESCRIPTION
## The bug

A relative link inside a code block was rewritten as though it were a link:

````markdown
See the source:

```markdown
[the other page](./other.md)
```
````

published as `[the other page](/wiki/x/7AM)`, so the one thing the fenced block existed to demonstrate was the one thing the reader never saw. Any page documenting Markdown, quoting a config file, or showing a command line containing `](` was affected.

## Why

Two independent mistakes, either of which was enough on its own:

1. Links were found with a regular expression over the raw file (`page.parseLinks`), which cannot distinguish a link from an example of one.
2. Each was then applied with `bytes.ReplaceAll` over the whole document (`page.SubstituteLinks`), so even a correctly identified link rewrote every other occurrence of the same text — including inside code.

## The fix

Resolution moves onto the parsed document, as a goldmark AST transformer. goldmark never produces an `ast.Link` inside a code span or a fenced or indented code block, so a walk over link nodes sees links and nothing else, and assigning `Destination` on the node it found touches that link alone.

The resolver itself is unchanged — same page lookup, same tiny links, same rules for which targets are left alone (schemes, `mailto:`, bare `#fragment`, directories, non-text files, files without mark metadata). It is reached through a new `types.MarkConfig.ResolveLink` hook; leaving it nil disables rewriting entirely.

One behaviour change beyond the fix: the transformer runs at priority 910, after includes and macros, so **links inside an included fragment are now resolved too**. Previously the scanner only saw the top-level file.

Since an AST transformer cannot return an error, the transformer keeps its first failure and `CompileMarkdown` collects it — the same pattern already used for `PipelineTransformer`. Without that step a lookup failure would be silently dropped and the page published with a dangling link.

`ResolveRelativeLinks`, `SubstituteLinks`, `parseLinks` and `LinkSubstitution` are deleted rather than left unused. They are the corrupting code path; keeping them exported invites their return.

## Verification

The two new end-to-end tests were run against unmodified `master` in a separate worktree and both fail there:

```
Error: "CDATA[[in a code block](/wiki/x/7AM)]]></ac:plain-text-body>..." should not contain "/wiki/"
--- FAIL: TestLinkInsideCodeBlockIsLeftAlone
--- PASS: TestRealLinkIsStillResolved
--- FAIL: TestLinkInsideCodeSpanIsLeftAlone
```

`TestRealLinkIsStillResolved` passes both before and after, which is what keeps the fix from being "stop resolving links".

Also added: `TestCompileMarkdownResolveLinkSkipsCode` (the resolver is asked about the real link and about nothing in a code span, fenced block, or indented block), `TestCompileMarkdownResolveLinkError` (verified to fail when the error collection is removed), and unit tests for `LinkResolver`'s skip rules replacing the deleted scanner's tests.

Full suite green under `-race`; `golangci-lint`: 0 issues.