### PR TITLE
fix: rewrite attachment destinations on the AST, not on the file's text

### DIFF
--- a/attachment/attachment.go
+++ b/attachment/attachment.go
@@ -2,7 +2,6 @@ package attachment
 
 import (
 	"bytes"
-	"cmp"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -14,7 +13,6 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -261,56 +259,63 @@ func prepareAttachment(opener vfs.Opener, base, name string) (Attachment, error)
 	return attachment, nil
 }
 
-func CompileAttachmentLinks(markdown []byte, attachments []Attachment) []byte {
-	links := map[string]string{}
-	replaces := []string{}
+// Resolver maps the path a document wrote onto the attachment uploaded for it.
+type Resolver struct {
+	links map[string]string
+	used  map[string]bool
+}
 
+// NewResolver builds a resolver for the given attachments.
+//
+// Both spellings a document may use are accepted: the plain path, and the
+// legacy "attachment://" form. They map to the same upload, and the legacy one
+// is listed first so that Unused reports the pair once rather than twice.
+func NewResolver(attachments []Attachment) *Resolver {
+	links := make(map[string]string, len(attachments)*2)
 	for _, attachment := range attachments {
-		links[attachment.Replace] = parseAttachmentLink(attachment.Link)
-		replaces = append(replaces, attachment.Replace)
+		link := parseAttachmentLink(attachment.Link)
+		links[attachment.Replace] = link
+		links["attachment://"+attachment.Replace] = link
 	}
 
-	// sort by length so first items will have bigger length
-	// it's helpful for replacing in case of following names
-	// attachments/a.jpg
-	// attachments/a.jpg.jpg
-	// so we replace longer and then shorter
-	slices.SortStableFunc(replaces, func(a, b string) int {
-		return cmp.Compare(len(b), len(a))
-	})
+	return &Resolver{links: links, used: map[string]bool{}}
+}
 
-	for _, replace := range replaces {
-		to := links[replace]
+// Resolve reports the URL for a link or image destination, or "" to leave it
+// as the document wrote it.
+func (r *Resolver) Resolve(target string) string {
+	if r == nil {
+		return ""
+	}
 
-		// Anchor on the link/image target so only a real destination is
-		// rewritten. A bare bytes.ReplaceAll over the whole document also hit
-		// prose and code spans -- "see `diagram.png`" became a download URL --
-		// and, because the legacy branch below is a separate if rather than an
-		// else, it rewrote its own output a second time, producing a doubled
-		// path with two query strings.
-		legacy := []byte("](attachment://" + replace + ")")
-		plain := []byte("](" + replace + ")")
-		target := []byte("](" + to + ")")
+	link, ok := r.links[target]
+	if !ok {
+		return ""
+	}
 
-		found := false
-		if bytes.Contains(markdown, legacy) {
-			log.Debug().Msgf("replacing legacy link: %q -> %q", "attachment://"+replace, to)
-			markdown = bytes.ReplaceAll(markdown, legacy, target)
-			found = true
-		}
+	r.used[strings.TrimPrefix(target, "attachment://")] = true
+	log.Debug().Msgf("replacing link: %q -> %q", target, link)
 
-		if bytes.Contains(markdown, plain) {
-			log.Debug().Msgf("replacing link: %q -> %q", replace, to)
-			markdown = bytes.ReplaceAll(markdown, plain, target)
-			found = true
-		}
+	return link
+}
 
-		if !found {
-			log.Warn().Msgf("unused attachment: %s", replace)
+// Unused reports the attachments that were uploaded but never referred to.
+//
+// This is only known once the whole document has been walked, which is why it
+// is reported here rather than as each attachment is resolved.
+func (r *Resolver) Unused(attachments []Attachment) []string {
+	if r == nil {
+		return nil
+	}
+
+	var unused []string
+	for _, attachment := range attachments {
+		if !r.used[attachment.Replace] {
+			unused = append(unused, attachment.Replace)
 		}
 	}
 
-	return markdown
+	return unused
 }
 
 func GetChecksum(reader io.Reader) (string, error) {

--- a/attachment/attachment_test.go
+++ b/attachment/attachment_test.go
@@ -125,41 +125,70 @@ func TestParseAttachmentLink(t *testing.T) {
 	}
 }
 
-// CompileAttachmentLinks replaced attachment names with a bare ReplaceAll over
-// the whole document, which caused three distinct corruptions.
-func TestCompileAttachmentLinksAnchorsOnLinkTarget(t *testing.T) {
+// Attachment destinations used to be substituted with a bare ReplaceAll over
+// the whole document, which caused several distinct corruptions. Resolving a
+// destination at a time makes each of them unrepresentable; these pin that.
+func TestResolver(t *testing.T) {
 	single := []Attachment{{
 		Name: "a.png", Filename: "a.png", Replace: "a.png",
 		Link: "/download/attachments/12345/a.png?version=1",
 	}}
 
+	t.Run("plain form", func(t *testing.T) {
+		assert.Equal(t,
+			"/download/attachments/12345/a.png?version=1",
+			NewResolver(single).Resolve("a.png"),
+		)
+	})
+
 	t.Run("legacy form is substituted once", func(t *testing.T) {
 		// The legacy branch was an if rather than an else if, so the plain branch
 		// then matched "a.png" inside the URL the legacy branch had just written,
 		// yielding a doubled path with two query strings.
-		got := string(CompileAttachmentLinks([]byte("![x](attachment://a.png)"), single))
-		assert.Equal(t, "![x](/download/attachments/12345/a.png?version=1)", got)
+		assert.Equal(t,
+			"/download/attachments/12345/a.png?version=1",
+			NewResolver(single).Resolve("attachment://a.png"),
+		)
 	})
 
-	t.Run("plain form is substituted", func(t *testing.T) {
-		got := string(CompileAttachmentLinks([]byte("![x](a.png)"), single))
-		assert.Equal(t, "![x](/download/attachments/12345/a.png?version=1)", got)
-	})
-
-	t.Run("prose and code spans are untouched", func(t *testing.T) {
-		in := "See the file `a.png` in the repo."
-		got := string(CompileAttachmentLinks([]byte(in), single))
-		assert.Equal(t, in, got, "only a link target may be rewritten")
+	t.Run("text that is not a destination", func(t *testing.T) {
+		// "See the file `a.png`" used to become a download URL.
+		assert.Empty(t, NewResolver(single).Resolve("See the file a.png in the repo."))
+		assert.Empty(t, NewResolver(single).Resolve("b.png"))
+		assert.Empty(t, NewResolver(single).Resolve(""))
 	})
 
 	t.Run("one name being a substring of another", func(t *testing.T) {
-		// The length-descending sort only protects suffix collisions; "logo.png"
-		// also occurs inside the already-substituted URL for "sub/logo.png".
+		// The length-descending sort only protected suffix collisions;
+		// "logo.png" also occurs inside the URL written for "sub/logo.png".
 		two := []Attachment{
 			{Replace: "sub/logo.png", Link: "/dl/1/sub_logo.png?v=1"},
 			{Replace: "logo.png", Link: "/dl/1/logo.png?v=1"},
 		}
-		got := string(CompileAttachmentLinks([]byte("![a](logo.png) ![b](sub/logo.png)"), two))
-		assert.Equal(t, "![a](/dl/1/logo.png?v=1) ![b](/dl/1/sub_logo.png?v=1)", got)
+		resolver := NewResolver(two)
+		assert.Equal(t, "/dl/1/logo.png?v=1", resolver.Resolve("logo.png"))
+		assert.Equal(t, "/dl/1/sub_logo.png?v=1", resolver.Resolve("sub/logo.png"))
 	})
+}
+
+func TestResolverUnused(t *testing.T) {
+	attachments := []Attachment{
+		{Replace: "used.png", Link: "/dl/1/used.png"},
+		{Replace: "legacy.png", Link: "/dl/1/legacy.png"},
+		{Replace: "never.png", Link: "/dl/1/never.png"},
+	}
+
+	resolver := NewResolver(attachments)
+	resolver.Resolve("used.png")
+	// Referring to an attachment by its legacy spelling still counts as using
+	// it; reporting it unused would send someone looking for a second link.
+	resolver.Resolve("attachment://legacy.png")
+
+	assert.Equal(t, []string{"never.png"}, resolver.Unused(attachments))
+}
+
+func TestResolverNil(t *testing.T) {
+	var resolver *Resolver
+	assert.Empty(t, resolver.Resolve("a.png"))
+	assert.Nil(t, resolver.Unused([]Attachment{{Replace: "a.png"}}))
 }

--- a/mark.go
+++ b/mark.go
@@ -538,7 +538,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		return nil, nil, fmt.Errorf("unable to create/update attachments: %w", err)
 	}
 
-	markdown = attachment.CompileAttachmentLinks(markdown, attaches)
+	attachmentLinks := attachment.NewResolver(attaches)
 
 	if config.DropH1 {
 		log.Info().Msg("the leading H1 heading will be excluded from the Confluence output")
@@ -558,11 +558,18 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		ImageAlign:    imageAlign,
 		IncludePath:   config.IncludePath,
 		ResolveLink:   resolveLink,
+
+		ResolveAttachment: attachmentLinks.Resolve,
 	}
 
 	html, inlineAttachments, err := markmd.CompileMarkdown(markdown, std, file, cfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to compile markdown: %w", err)
+	}
+
+	// Only knowable once the document has been walked.
+	for _, unused := range attachmentLinks.Unused(attaches) {
+		log.Warn().Msgf("unused attachment: %s", unused)
 	}
 
 	if _, _, err = attachment.ResolveAttachmentsWithRemotes(

--- a/mark_process_test.go
+++ b/mark_process_test.go
@@ -1549,3 +1549,57 @@ func TestLinkInsideCodeSpanIsLeftAlone(t *testing.T) {
 	span := body[i:]
 	assert.Contains(t, span, "./a-other.md", "a code span must survive as written")
 }
+
+// TestAttachmentLinkInsideCodeBlockIsLeftAlone is the second half of the
+// corruption fixed for relative links. Attachment destinations were substituted
+// with a ReplaceAll over the whole document, so a page documenting how to refer
+// to an attachment had its own example turned into a download URL.
+func TestAttachmentLinkInsideCodeBlockIsLeftAlone(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	png := []byte{
+		0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a,
+		0x00, 0x00, 0x00, 0x0d, 'I', 'H', 'D', 'R',
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+		0x89,
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "logo.png"), png, 0o600))
+
+	file := writeFile(t, dir, "doc.md", "<!-- Space: DOCS -->\n"+
+		"<!-- Parent: Parent -->\n"+
+		"<!-- Title: Attachment Doc -->\n"+
+		"<!-- Attachment: logo.png -->\n\n"+
+		"Refer to an attachment like this:\n\n"+
+		"```markdown\n![logo](logo.png)\n```\n\n"+
+		"And here it is for real: ![logo](logo.png)\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: file, Features: []string{"mention"}, Output: io.Discard,
+	}
+
+	target, err := ProcessFile(file, api, config)
+	require.NoError(t, err)
+	require.NotNil(t, target)
+
+	body := server.Page(target.ID).Body
+
+	code := body[strings.Index(body, "<![CDATA["):strings.Index(body, "]]>")]
+	assert.Contains(t, code, "![logo](logo.png)",
+		"the code sample must survive exactly as written")
+	assert.NotContains(t, code, "/download/",
+		"an attachment link inside a code block must not be rewritten")
+
+	// ...while the real image still points at the upload. A declared
+	// attachment renders as a URL reference rather than ri:filename, because
+	// its destination is rewritten before the image renderer sees it.
+	assert.Contains(t, body, "download/attachments/",
+		"the real image should still resolve to the attachment")
+}

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -278,12 +278,13 @@ func CompileMarkdownLegacy(markdown []byte, stdlib *stdlib.Lib, path string, cfg
 // This is now the primary/default extension.
 type ConfluenceExtension struct {
 	html.Config
-	Stdlib      *stdlib.Lib
-	Path        string
-	MarkConfig  types.MarkConfig
-	Attachments []attachment.Attachment
-	Pipeline    *ctransformer.PipelineTransformer
-	Links       *ctransformer.LinkTransformer
+	Stdlib          *stdlib.Lib
+	Path            string
+	MarkConfig      types.MarkConfig
+	Attachments     []attachment.Attachment
+	Pipeline        *ctransformer.PipelineTransformer
+	Links           *ctransformer.LinkTransformer
+	AttachmentLinks *ctransformer.AttachmentTransformer
 }
 
 // NewConfluenceExtension creates a new instance of the GitHub Alerts extension
@@ -298,13 +299,14 @@ func NewConfluenceExtension(stdlib *stdlib.Lib, path string, cfg types.MarkConfi
 		ctransformer.NewIncludeTransformer(path, path, cfg.IncludePath, tmpl),
 	)
 	return &ConfluenceExtension{
-		Config:      html.NewConfig(),
-		Stdlib:      stdlib,
-		Path:        path,
-		MarkConfig:  cfg,
-		Attachments: []attachment.Attachment{},
-		Pipeline:    pipeline,
-		Links:       ctransformer.NewLinkTransformer(cfg.ResolveLink),
+		Config:          html.NewConfig(),
+		Stdlib:          stdlib,
+		Path:            path,
+		MarkConfig:      cfg,
+		Attachments:     []attachment.Attachment{},
+		Pipeline:        pipeline,
+		Links:           ctransformer.NewLinkTransformer(cfg.ResolveLink),
+		AttachmentLinks: ctransformer.NewAttachmentTransformer(cfg.ResolveAttachment),
 	}
 }
 
@@ -348,6 +350,9 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 		util.Prioritized(ctransformer.NewAnchorTransformer(), 900),
 		// After includes and macros have brought their content in, so links
 		// inside an included fragment are resolved too.
+		// Before link resolution, so that a path a document declared as an
+		// attachment is taken as one rather than looked up as a page.
+		util.Prioritized(c.AttachmentLinks, 905),
 		util.Prioritized(c.Links, 910),
 	))
 

--- a/transformer/attachments.go
+++ b/transformer/attachments.go
@@ -1,0 +1,68 @@
+package transformer
+
+import (
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+// AttachmentTransformer points links and images at the attachments uploaded
+// for them.
+//
+// Like link resolution this works on the parsed document rather than its text.
+// The previous version replaced "](path)" with bytes.ReplaceAll across the
+// whole file, so a fenced block showing how to reference an attachment had its
+// example rewritten into a download URL -- the same corruption relative links
+// suffered, from the same cause.
+//
+// Matching a destination also removes the need to try long paths before short
+// ones. The text version had to sort its replacements by length so that
+// "a.jpg" did not eat the front of "a.jpg.jpg"; a destination either is the
+// attachment's path or it is not, so there is nothing left to disambiguate.
+type AttachmentTransformer struct {
+	// Resolve reports the URL for an attachment path, or "" to leave the
+	// destination alone.
+	Resolve func(target string) string
+}
+
+// NewAttachmentTransformer creates an AttachmentTransformer using the given
+// resolver.
+func NewAttachmentTransformer(resolve func(target string) string) *AttachmentTransformer {
+	return &AttachmentTransformer{Resolve: resolve}
+}
+
+// Transform implements the parser.ASTTransformer interface.
+func (t *AttachmentTransformer) Transform(doc *ast.Document, reader text.Reader, pc parser.Context) {
+	if t.Resolve == nil {
+		return
+	}
+
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		// Images as well as links: an attachment is as often shown inline as it
+		// is linked to, and the text this replaces matched both.
+		var destination *[]byte
+		switch n := node.(type) {
+		case *ast.Link:
+			destination = &n.Destination
+		case *ast.Image:
+			destination = &n.Destination
+		default:
+			return ast.WalkContinue, nil
+		}
+
+		target := string(*destination)
+		if target == "" {
+			return ast.WalkContinue, nil
+		}
+
+		if resolved := t.Resolve(target); resolved != "" {
+			*destination = []byte(resolved)
+		}
+
+		return ast.WalkContinue, nil
+	})
+}

--- a/types/types.go
+++ b/types/types.go
@@ -18,4 +18,9 @@ type MarkConfig struct {
 	// renderer needing to know what Confluence is. Nil disables the rewriting
 	// entirely, which is what compiling without a server does.
 	ResolveLink func(target string) (string, error)
+
+	// ResolveAttachment turns a link or image destination into the URL of the
+	// attachment uploaded for it, or "" to leave it as written. Nil disables
+	// the rewriting.
+	ResolveAttachment func(target string) string
 }


### PR DESCRIPTION
## The bug

The other half of the corruption fixed in #887, from the same cause. A page documenting how to refer to an attachment:

````markdown
Refer to an attachment like this:

```markdown
![logo](logo.png)
```
````

published as `![logo](/wiki/download/attachments/1004/logo.png)` — the example destroyed by the thing it was documenting.

`CompileAttachmentLinks` substituted `](logo.png)` with `bytes.ReplaceAll` over the whole document, and a fenced block is text like any other. I fixed part of this earlier (anchoring on `](…)` so prose and code spans stopped being hit, and making the legacy branch an `else`), but left the document-wide replace in place, so fenced blocks stayed broken. This finishes it.

## The fix

A walk over `ast.Link` and `ast.Image` sets the destination on the node it found. goldmark never puts either inside a code span or a fenced or indented block. Both node kinds are handled because the text it replaces matched both — `](` appears in image syntax too.

Matching a whole destination instead of a substring also deletes machinery the text version needed:

- Replacements were applied **longest-first** so `a.jpg` would not eat the front of `a.jpg.jpg`.
- That sort only ever protected suffix collisions — `logo.png` still matched inside the URL already written for `sub/logo.png`.

A destination either is an attachment's path or it is not, so the sort and the collision it half-solved both go away. `CompileAttachmentLinks` is replaced by an `attachment.Resolver` reached through `types.MarkConfig.ResolveAttachment`.

The transformer runs at priority 905, before link resolution at 910, so a path explicitly declared as an attachment is taken as one rather than looked up as a page.

## The unused-attachment warning

`log.Warn("unused attachment: …")` could not move into the transformer as-is: an attachment is unused only if *nothing in the whole document* referred to it, which isn't known while walking. The resolver records which paths it was asked for and `ProcessFile` reports the remainder after compilation. Referring to an attachment by its legacy `attachment://` spelling counts as using it — reporting that unused would send someone hunting for a second reference that doesn't exist.

## Verification

The new end-to-end test was run against the parent branch and fails there:

```
Error: "<![CDATA[![logo](/wiki/download/attachments/1004/logo.png)" does not contain "![logo](logo.png)"
Error: "<![CDATA[![logo](/wiki/download/attachments/1004/logo.png)" should not contain "/download/"
```

It also asserts the real image outside the fence still resolves to the upload, so the fix cannot be "stop rewriting attachments". The unit tests for the three historical corruptions are rewritten against the resolver rather than deleted.

Note on rendering: a *declared* attachment renders as `<ri:url ri:value="…">` rather than `ri:filename`, because its destination is rewritten before the image renderer sees it. That is unchanged from before — the test pins it.

Full suite green under `-race`; `golangci-lint`: 0 issues.