### PR TITLE
fix: do not treat an ac:ignore marker inside a code block as a marker

### DIFF
--- a/metadata/ignore.go
+++ b/metadata/ignore.go
@@ -3,6 +3,10 @@ package metadata
 import (
 	"fmt"
 	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
 )
 
 const (
@@ -36,19 +40,32 @@ const (
 // file. A missing end marker is nearly always a typo, and quietly publishing
 // half a page is a worse answer than refusing.
 func StripIgnoredBlocks(data []byte) ([]byte, error) {
-	text := string(data)
-	if !strings.Contains(strings.ToLower(text), IgnoreStart) {
+	content := string(data)
+	if !strings.Contains(strings.ToLower(content), IgnoreStart) {
 		return data, nil
 	}
 
-	lines := strings.Split(text, "\n")
+	// A marker inside a code block is a code sample, not an instruction. Which
+	// lines are code is a question for the parser -- guessing at fences by hand
+	// gets indented blocks, tildes and nesting wrong -- so goldmark is asked,
+	// even though the stripping itself has to stay textual: it runs before the
+	// headers are read, and an ignored region is meant to take its headers with
+	// it.
+	code := codeLines(data)
+
+	lines := strings.Split(content, "\n")
 	kept := make([]string, 0, len(lines))
 
 	ignoring := false
 	openedAt := 0
 
 	for i, line := range lines {
-		switch ignoreMarker(line) {
+		marker := markerNone
+		if !code[i] {
+			marker = ignoreMarker(line)
+		}
+
+		switch marker {
 		case markerStart:
 			if ignoring {
 				return nil, fmt.Errorf(
@@ -121,4 +138,58 @@ func ignoreMarker(line string) marker {
 	default:
 		return markerNone
 	}
+}
+
+// codeLines reports which lines of the document are inside a code block.
+//
+// Both kinds count: a fenced block and an indented one. The fence lines
+// themselves are not included, which does not matter -- a fence is never a
+// marker -- and neither is a code span, since a marker has to be alone on its
+// line to be one at all.
+func codeLines(data []byte) map[int]bool {
+	code := map[int]bool{}
+
+	doc := goldmark.New().Parser().Parse(text.NewReader(data))
+
+	// Line numbers come from counting newlines before an offset, so the offsets
+	// are collected first and turned into lines in one pass over the document.
+	var spans [][2]int
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		switch node.(type) {
+		case *ast.FencedCodeBlock, *ast.CodeBlock:
+		default:
+			return ast.WalkContinue, nil
+		}
+
+		lines := node.Lines()
+		if lines.Len() == 0 {
+			return ast.WalkContinue, nil
+		}
+		spans = append(spans, [2]int{lines.At(0).Start, lines.At(lines.Len() - 1).Stop})
+
+		return ast.WalkContinue, nil
+	})
+
+	if len(spans) == 0 {
+		return code
+	}
+
+	line := 0
+	for offset := range data {
+		for _, span := range spans {
+			if offset >= span[0] && offset < span[1] {
+				code[line] = true
+				break
+			}
+		}
+		if data[offset] == '\n' {
+			line++
+		}
+	}
+
+	return code
 }

--- a/metadata/ignore_test.go
+++ b/metadata/ignore_test.go
@@ -92,3 +92,51 @@ func TestStripIgnoredBlocksDoesNotPanicOnShortComments(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "<!-->\nA\n", strings.TrimSuffix(string(out), "\n")+"\n")
 }
+
+// TestStripIgnoredBlocksSkipsCode covers markers that are code samples rather
+// than instructions. The scan used to be purely line-based, so a page
+// documenting the feature had the example stripped out of it -- the one thing
+// the block existed to show.
+func TestStripIgnoredBlocksSkipsCode(t *testing.T) {
+	t.Run("fenced block", func(t *testing.T) {
+		in := "Docs:\n\n```markdown\n<!-- ac:ignore -->\nSAMPLE\n<!-- ac:ignore end -->\n```\n"
+		out, err := StripIgnoredBlocks([]byte(in))
+		require.NoError(t, err)
+		assert.Equal(t, in, string(out))
+	})
+
+	t.Run("tilde fence", func(t *testing.T) {
+		in := "~~~\n<!-- ac:ignore -->\nSAMPLE\n<!-- ac:ignore end -->\n~~~\n"
+		out, err := StripIgnoredBlocks([]byte(in))
+		require.NoError(t, err)
+		assert.Equal(t, in, string(out))
+	})
+
+	t.Run("indented block", func(t *testing.T) {
+		in := "Docs:\n\n    <!-- ac:ignore -->\n    SAMPLE\n    <!-- ac:ignore end -->\n"
+		out, err := StripIgnoredBlocks([]byte(in))
+		require.NoError(t, err)
+		assert.Equal(t, in, string(out))
+	})
+
+	t.Run("an unclosed marker in code is not an error", func(t *testing.T) {
+		// Documenting the opening marker on its own must not fail the run with
+		// "is never closed".
+		in := "```\n<!-- ac:ignore -->\n```\n"
+		out, err := StripIgnoredBlocks([]byte(in))
+		require.NoError(t, err)
+		assert.Equal(t, in, string(out))
+	})
+
+	t.Run("a real region still works alongside a documented one", func(t *testing.T) {
+		out, err := StripIgnoredBlocks([]byte(
+			"```\n<!-- ac:ignore -->\nSAMPLE\n<!-- ac:ignore end -->\n```\n" +
+				"<!-- ac:ignore -->\nGONE\n<!-- ac:ignore end -->\n" +
+				"KEPT\n",
+		))
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "SAMPLE")
+		assert.Contains(t, string(out), "KEPT")
+		assert.NotContains(t, string(out), "GONE")
+	})
+}


### PR DESCRIPTION
Independent of #887 / #888 — branched from master, no overlap.

## The bug

`ac:ignore` (added in #886) scanned lines, so a page documenting the feature had its own example stripped:

````markdown
```markdown
<!-- ac:ignore -->
John Doe's profile
<!-- ac:ignore end -->
```
````

published as an empty code block. Worse, a fence showing just the opening marker failed the whole run with `<!-- ac:ignore --> on line N is never closed`, since the scanner counted a code sample as an unbalanced region.

This is the same family as #887 and #888 — my own feature, and I introduced it with the defect.

## Why this one is not a transformer

`ac:ignore` cannot move into the AST the way links and attachments did. Stripping runs **before** the headers are read, deliberately (`mark.go:293-298`), so that an ignored region takes its headers with it — you can wrap `<!-- Title: -->` in one. By the time an AST transformer runs, `ExtractMeta` has long since consumed those headers. Moving it would silently change that behaviour.

So the stripping stays textual, and only *"which lines are code"* moves to the parser: goldmark parses the document, `FencedCodeBlock` and `CodeBlock` spans are collected, and markers on those lines are left as text.

Recognising fences by hand looked tempting and is a trap — tildes, indented blocks, closing fences longer than their opener, and nesting are all easy to get subtly wrong, and goldmark already knows. Code spans need no handling: a marker must be alone on its line to be one at all.

## Verification

All five new subtests were run against master in a worktree and all five fail there — fenced, tilde-fenced, indented, the spurious "never closed" error, and a mixed document where a documented region and a real region appear together (the real one must still be stripped, so the fix cannot be "stop stripping").

Full suite green under `-race`; `golangci-lint`: 0 issues.