### PR TITLE
fix: expand macros and includes on the AST, not on the file's text

### DIFF
--- a/markdown/macro_code_test.go
+++ b/markdown/macro_code_test.go
@@ -1,0 +1,112 @@
+package mark_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	mark "github.com/kovetskiy/mark/v16/markdown"
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const jiraMacro = "<!-- Macro: MYJIRA-\\d+\n" +
+	"     Template: ac:jira:ticket\n" +
+	"     Ticket: ${0} -->\n\n"
+
+func compile(t *testing.T, path string, markdown string) string {
+	t.Helper()
+
+	lib, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	out, _, err := mark.CompileMarkdown(
+		[]byte(markdown), lib, path,
+		types.MarkConfig{MermaidScale: 1.0, D2Scale: 1.0},
+	)
+	require.NoError(t, err)
+
+	return out
+}
+
+// TestMacroInsideCodeIsLeftAlone is the corruption this fixes. Macros were
+// applied to the file's text before it was parsed, so a page documenting a
+// macro had its own example expanded -- the one thing the code block existed
+// to show.
+func TestMacroInsideCodeIsLeftAlone(t *testing.T) {
+	out := compile(t, "testdata/x.md", jiraMacro+
+		"Prose mentions MYJIRA-123.\n\n"+
+		"```\nfenced MYJIRA-456\n```\n\n"+
+		"A span `MYJIRA-789` too.\n")
+
+	code := out[strings.Index(out, "<![CDATA["):strings.Index(out, "]]>")]
+	assert.Contains(t, code, "MYJIRA-456", "the fenced sample must survive")
+	assert.NotContains(t, code, "ac:structured-macro",
+		"a macro inside a fenced block must not be expanded")
+
+	assert.Contains(t, out, "<code>MYJIRA-789</code>",
+		"a macro inside a code span must not be expanded")
+
+	// ...while a real mention outside code still expands.
+	assert.Contains(t, out, `<ac:parameter ac:name="key">MYJIRA-123</ac:parameter>`,
+		"prose must still expand")
+}
+
+// TestMacroKeepsSurroundingText pins the spacing around an expansion. The
+// macro's replacement is parsed on its own, and a document does not begin with
+// a space, so the word before the macro ran into it.
+func TestMacroKeepsSurroundingText(t *testing.T) {
+	out := compile(t, "testdata/x.md", jiraMacro+"Prose mentions MYJIRA-123.\n")
+
+	assert.Contains(t, out, "mentions <ac:structured-macro",
+		"the space before the macro must survive")
+	assert.Contains(t, out, "</ac:structured-macro>.",
+		"the text after the macro must survive")
+}
+
+// TestMacroIsNotExpandedTwice guards the pipeline, which runs until the tree
+// stops changing. A macro whose output contains the text that matched it --
+// which the jira macro does -- would otherwise be expanded into itself.
+func TestMacroIsNotExpandedTwice(t *testing.T) {
+	out := compile(t, "testdata/x.md", jiraMacro+"Prose mentions MYJIRA-123.\n")
+
+	assert.Equal(t, 1, strings.Count(out, "ac:name=\"jira\""),
+		"the macro must be expanded exactly once")
+}
+
+// TestIncludeInsideCodeBlockIsLeftAlone is the same corruption for includes: a
+// page showing how to write an Include directive had the file pulled in.
+func TestIncludeInsideCodeBlockIsLeftAlone(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "frag.md"), []byte("INCLUDED-CONTENT\n"), 0o600,
+	))
+
+	out := compile(t, filepath.Join(dir, "doc.md"),
+		"Refer to a fragment like this:\n\n"+
+			"```markdown\n<!-- Include: frag.md -->\n```\n")
+
+	assert.NotContains(t, out, "INCLUDED-CONTENT",
+		"an Include directive inside a fenced block must not be expanded")
+	assert.Contains(t, out, "<![CDATA[<!-- Include: frag.md -->]]>",
+		"the directive must survive as written")
+}
+
+// TestIncludedContentStillGetsMacros pins the boundary between the two. Text an
+// include brings in is text the document asked for, and macros apply to it;
+// only a macro's own output is off limits.
+func TestIncludedContentStillGetsMacros(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "frag.md"), []byte("Fragment mentions MYJIRA-123.\n"), 0o600,
+	))
+
+	out := compile(t, filepath.Join(dir, "doc.md"),
+		jiraMacro+"<!-- Include: frag.md -->\n")
+
+	assert.Contains(t, out, `<ac:parameter ac:name="key">MYJIRA-123</ac:parameter>`,
+		"a macro must still apply to included text")
+}

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -173,41 +173,7 @@ func compileMarkdownWithExtension(markdown []byte, ext goldmark.Extender, logMes
 }
 
 func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib, path string, cfg types.MarkConfig) (string, []attachment.Attachment, error) {
-	var tmpl *template.Template
-	if stdlib != nil {
-		tmpl = stdlib.Templates
-	} else {
-		tmpl = template.New("stdlib")
-	}
-
 	var err error
-	var recurse bool
-	for {
-		tmpl, markdown, recurse, err = includes.ProcessIncludes(
-			filepath.Dir(path),
-			cfg.IncludePath,
-			markdown,
-			tmpl,
-		)
-		if err != nil {
-			return "", nil, fmt.Errorf("unable to process includes: %w", err)
-		}
-		if !recurse {
-			break
-		}
-	}
-
-	var macros []macro.Macro
-	macros, markdown, err = macro.ExtractMacros(filepath.Dir(path), cfg.IncludePath, markdown, tmpl)
-	if err != nil {
-		return "", nil, fmt.Errorf("unable to extract macros: %w", err)
-	}
-	for _, m := range macros {
-		markdown, err = m.Apply(markdown)
-		if err != nil {
-			return "", nil, fmt.Errorf("unable to apply macro %q: %w", m.Regexp.String(), err)
-		}
-	}
 
 	ghAlertsExtension := NewConfluenceExtension(stdlib, path, cfg)
 	htmlOutput, err := compileMarkdownWithExtension(markdown, ghAlertsExtension, "rendering markdown with GitHub Alerts support:\n%s")
@@ -295,8 +261,10 @@ func NewConfluenceExtension(stdlib *stdlib.Lib, path string, cfg types.MarkConfi
 		tmpl = stdlib.Templates
 	}
 	pipeline := ctransformer.NewPipelineTransformer(
-		ctransformer.NewMacroTransformer(path, path, cfg.IncludePath, tmpl),
-		ctransformer.NewIncludeTransformer(path, path, cfg.IncludePath, tmpl),
+		// The base directory is the file's directory, not the file: a relative
+		// include is written relative to the document that asks for it.
+		ctransformer.NewMacroTransformer(path, filepath.Dir(path), cfg.IncludePath, tmpl),
+		ctransformer.NewIncludeTransformer(path, filepath.Dir(path), cfg.IncludePath, tmpl),
 	)
 	return &ConfluenceExtension{
 		Config:          html.NewConfig(),

--- a/renderer/paragraph.go
+++ b/renderer/paragraph.go
@@ -23,10 +23,38 @@ func (r *ConfluenceParagraphRenderer) RegisterFuncs(reg renderer.NodeRendererFun
 	reg.Register(ast.KindParagraph, r.renderParagraph)
 }
 
+// startsWithRawMarkup reports whether a paragraph opens with markup that has to
+// reach Confluence as written.
+//
+// A paragraph that is really the opening tag of a macro must not be wrapped in
+// <p>: the tag stays open across the blocks that follow, and a <p> closed
+// around it produces markup Confluence rejects.
+//
+// Two shapes mean the same thing here. A tag parsed straight out of the
+// document is an ast.RawHTML. One that arrived by expanding a macro or an
+// include is an ast.String carrying its own bytes, because the expansion was
+// parsed from a different buffer than the document being rendered and a segment
+// into that buffer would be meaningless. Both are raw and code -- goldmark's
+// typographer also produces code strings, for em dashes and quotes, but never
+// marks them raw, so the pair is unambiguous.
+func startsWithRawMarkup(n ast.Node) bool {
+	if n == nil {
+		return false
+	}
+
+	if n.Kind() == ast.KindRawHTML {
+		return true
+	}
+
+	str, ok := n.(*ast.String)
+
+	return ok && str.IsRaw() && str.IsCode()
+}
+
 func (r *ConfluenceParagraphRenderer) renderParagraph(w util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
 	firstChild := n.FirstChild()
 	if entering {
-		if firstChild == nil || firstChild.Kind() != ast.KindRawHTML {
+		if !startsWithRawMarkup(firstChild) {
 			if n.Attributes() != nil {
 				_, _ = w.WriteString("<p")
 				html.RenderAttributes(w, n, html.ParagraphAttributeFilter)
@@ -36,7 +64,7 @@ func (r *ConfluenceParagraphRenderer) renderParagraph(w util.BufWriter, source [
 			}
 		}
 	} else {
-		if firstChild == nil || firstChild.Kind() != ast.KindRawHTML {
+		if !startsWithRawMarkup(firstChild) {
 			_, _ = w.WriteString("</p>")
 		}
 		_, _ = w.WriteString("\n")

--- a/transformer/include.go
+++ b/transformer/include.go
@@ -5,14 +5,10 @@ import (
 	"text/template"
 
 	"github.com/kovetskiy/mark/v16/includes"
-	cparser "github.com/kovetskiy/mark/v16/parser"
 	"github.com/rs/zerolog/log"
-	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
-	"github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/text"
-	"github.com/yuin/goldmark/util"
 )
 
 // IncludeTransformer transforms <!-- Include: ... --> directives in the Goldmark AST
@@ -119,16 +115,7 @@ func (t *IncludeTransformer) TransformWithModified(doc *ast.Document, reader tex
 		}
 		t.Templates = tmpl
 
-		p := goldmark.New(
-			goldmark.WithParserOptions(
-				parser.WithInlineParsers(
-					util.Prioritized(cparser.NewConfluenceTagParser(), 99),
-				),
-			),
-			goldmark.WithRendererOptions(
-				html.WithUnsafe(),
-			),
-		).Parser()
+		p := newSubParser()
 		subDoc := p.Parse(text.NewReader(expanded))
 		convertSegmentsToStrings(subDoc, expanded)
 

--- a/transformer/macro.go
+++ b/transformer/macro.go
@@ -5,14 +5,10 @@ import (
 	"text/template"
 
 	"github.com/kovetskiy/mark/v16/macro"
-	cparser "github.com/kovetskiy/mark/v16/parser"
 	"github.com/rs/zerolog/log"
-	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
-	"github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/text"
-	"github.com/yuin/goldmark/util"
 )
 
 // MacroTransformer extracts macro directives from HTML comment blocks in the Goldmark AST,
@@ -23,6 +19,13 @@ type MacroTransformer struct {
 	IncludePath string
 	Templates   *template.Template
 	Err         error
+
+	// macros accumulates across pipeline passes. A definition is removed from
+	// the tree as soon as it is read, so a transformer that rebuilt this list
+	// each pass would forget every macro it had already seen -- and the pass
+	// that matters is often a later one, after an include has brought in the
+	// text a macro was written for.
+	macros []macro.Macro
 }
 
 // NewMacroTransformer creates a new MacroTransformer instance.
@@ -99,7 +102,6 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 	})
 
 	modified := false
-	var extractedMacros []macro.Macro
 
 	for _, target := range targets {
 		macros, _, err := macro.ExtractMacros(t.BaseDir, t.IncludePath, target.fullRawContent, t.Templates)
@@ -115,7 +117,7 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 		if len(macros) == 0 {
 			continue
 		}
-		extractedMacros = append(extractedMacros, macros...)
+		t.macros = append(t.macros, macros...)
 
 		for _, n := range target.nodesToRemove {
 			if n.Parent() != nil {
@@ -126,7 +128,7 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 		modified = true
 	}
 
-	for _, m := range extractedMacros {
+	for _, m := range t.macros {
 		var textNodesToReplace []struct {
 			node    ast.Node
 			val     []byte
@@ -138,9 +140,26 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 				return ast.WalkContinue, nil
 			}
 
-			switch node.(type) {
-			case *ast.Paragraph, *ast.Text:
+			// Leaf text only. Matching whole paragraphs as well caught the
+			// same words twice, and a paragraph's text includes whatever is
+			// inside its code spans -- so a macro pattern mentioned in
+			// `backticks` was expanded along with the prose around it.
+			//
+			// Both kinds of leaf count. Text is what the document itself was
+			// parsed into; a plain String is text an include brought in, which
+			// a macro is just as entitled to act on. A String carrying markup
+			// is not text at all and is left alone.
+			switch n := node.(type) {
+			case *ast.Text:
+			case *ast.String:
+				if n.IsRaw() || n.IsCode() {
+					return ast.WalkContinue, nil
+				}
 			default:
+				return ast.WalkContinue, nil
+			}
+
+			if insideCode(node) || isExpansion(node) {
 				return ast.WalkContinue, nil
 			}
 
@@ -178,33 +197,23 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 				continue
 			}
 
-			p := goldmark.New(
-				goldmark.WithParserOptions(
-					parser.WithInlineParsers(
-						util.Prioritized(cparser.NewConfluenceTagParser(), 99),
-					),
-				),
-				goldmark.WithRendererOptions(
-					html.WithUnsafe(),
-				),
-			).Parser()
-			subDoc := p.Parse(text.NewReader(expanded))
-			convertSegmentsToStrings(subDoc, expanded)
+			// Whitespace at either end has to be held back and put in again
+			// afterwards. Parsing is what loses it: the expansion is parsed as
+			// a document of its own, and a document does not begin with a
+			// space, so " MYJIRA-123." came back as "<ac:.../>." and the word
+			// before it ran into the macro.
+			lead, trail, body := splitEdgeSpace(expanded)
+
+			p := newSubParser()
+			subDoc := p.Parse(text.NewReader(body))
+			convertSegmentsToStrings(subDoc, body)
 
 			parent := item.node.Parent()
 			if parent == nil {
 				continue
 			}
 
-			for subDoc.FirstChild() != nil {
-				child := subDoc.FirstChild()
-				subDoc.RemoveChild(subDoc, child)
-				parent.InsertBefore(parent, item.node, child)
-			}
-
-			if item.node.Parent() != nil {
-				item.node.Parent().RemoveChild(item.node.Parent(), item.node)
-			}
+			spliceExpansion(parent, item.node, subDoc, lead, trail)
 
 			modified = true
 		}

--- a/transformer/util.go
+++ b/transformer/util.go
@@ -4,7 +4,12 @@ import (
 	"bytes"
 	"sync"
 
+	cparser "github.com/kovetskiy/mark/v16/parser"
+	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/util"
 )
 
 var bufferPool = sync.Pool{
@@ -175,10 +180,163 @@ func convertSegmentsToStrings(doc ast.Node, source []byte) {
 		if parent != nil {
 			strNode := ast.NewString(item.val)
 			if item.isRaw {
+				// Both flags, and the second is the one that matters. goldmark's
+				// "raw" only means backslash escapes are not processed -- its
+				// RawWrite still runs every byte through EscapeHTMLByte, so a
+				// string marked raw alone comes out as &lt;ac:structured-macro.
+				// IsCode is what writes the value verbatim, which is what
+				// Confluence markup from a macro or an include has to be.
 				strNode.SetRaw(true)
+				strNode.SetCode(true)
 			}
 			parent.InsertBefore(parent, item.node, strNode)
 			parent.RemoveChild(parent, item.node)
 		}
 	}
+}
+
+// newSubParser builds the parser used for content that arrives by expanding a
+// macro or an include.
+//
+// It carries the block extensions the document itself is parsed with, because
+// the expansion is ordinary Markdown and an author expects it to behave that
+// way: a macro whose body is a table should produce a table, not a paragraph of
+// pipes. The mark extension is deliberately not among them -- it is what is
+// running right now, and the pipeline already re-runs until the tree settles,
+// so nesting a second copy here would only find the same work twice.
+func newSubParser() parser.Parser {
+	return goldmark.New(
+		goldmark.WithExtensions(
+			extension.Footnote,
+			extension.DefinitionList,
+			extension.NewTable(
+				extension.WithTableCellAlignMethod(extension.TableCellAlignStyle),
+			),
+			extension.GFM,
+		),
+		goldmark.WithParserOptions(
+			parser.WithInlineParsers(
+				// Above goldmark's link parser, so <ac:.../> tags are kept whole
+				// rather than picked apart.
+				util.Prioritized(cparser.NewConfluenceTagParser(), 99),
+			),
+		),
+	).Parser()
+}
+
+// insideCode reports whether a node sits within a code span.
+//
+// Text in a code span is a sample, not something to substitute into. Fenced and
+// indented blocks need no check: their content is a CodeBlock, which is not a
+// node kind macro substitution looks at in the first place.
+func insideCode(node ast.Node) bool {
+	for n := node; n != nil; n = n.Parent() {
+		if n.Kind() == ast.KindCodeSpan {
+			return true
+		}
+	}
+
+	return false
+}
+
+// expandedAttr marks a node as something a macro produced.
+//
+// The pipeline runs until the tree stops changing, so a macro's output is
+// offered back to it on the next pass. That matters because macro output
+// routinely contains the text that matched it -- the jira macro turns
+// MYJIRA-123 into a tag with MYJIRA-123 inside -- and without a marker the
+// second pass expands the expansion, nesting one macro inside another.
+//
+// Content brought in by an *include* is deliberately not marked. A document
+// that includes a fragment expects macros to apply to it, and that is the one
+// thing separating the two cases: an include yields text to work on, a macro
+// yields its own finished output.
+var expandedAttr = []byte("mark:macro-expanded")
+
+func markExpanded(node ast.Node) {
+	node.SetAttribute(expandedAttr, true)
+	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
+		markExpanded(child)
+	}
+}
+
+// isExpansion reports whether a node, or anything it sits inside, is macro
+// output.
+func isExpansion(node ast.Node) bool {
+	for n := node; n != nil; n = n.Parent() {
+		if _, ok := n.Attribute(expandedAttr); ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// spliceExpansion puts a macro's expansion where the text that matched it was.
+//
+// What the expansion replaces depends on its shape. One that parsed to a single
+// paragraph is inline -- an issue key becoming a status lozenge -- and its
+// inline children take the place of the matched text, leaving the surrounding
+// sentence intact. Anything else is a block: a macro wrapping a list or a
+// table cannot live inside the paragraph that named it, so it replaces that
+// paragraph outright.
+//
+// The block case is only taken when the matched text was the paragraph's whole
+// content. A paragraph holding a block macro and a sentence beside it has no
+// correct reading, and dropping the sentence to place the block would lose
+// what the author wrote.
+func spliceExpansion(parent ast.Node, matched ast.Node, subDoc ast.Node, lead, trail []byte) {
+	first := subDoc.FirstChild()
+	inline := first != nil && first == subDoc.LastChild() && first.Kind() == ast.KindParagraph
+
+	if !inline && parent.Kind() == ast.KindParagraph &&
+		parent.FirstChild() == matched && parent.LastChild() == matched &&
+		parent.Parent() != nil {
+		grandparent := parent.Parent()
+		for subDoc.FirstChild() != nil {
+			child := subDoc.FirstChild()
+			subDoc.RemoveChild(subDoc, child)
+			markExpanded(child)
+			grandparent.InsertBefore(grandparent, parent, child)
+		}
+		grandparent.RemoveChild(grandparent, parent)
+
+		return
+	}
+
+	source := subDoc
+	if inline {
+		// Unwrap: the paragraph the sub-parse wrapped its inlines in would
+		// otherwise be nested inside the paragraph being edited.
+		source = first
+	}
+
+	if inline && len(lead) > 0 {
+		parent.InsertBefore(parent, matched, ast.NewString(lead))
+	}
+
+	for source.FirstChild() != nil {
+		child := source.FirstChild()
+		source.RemoveChild(source, child)
+		markExpanded(child)
+		parent.InsertBefore(parent, matched, child)
+	}
+
+	if inline && len(trail) > 0 {
+		parent.InsertBefore(parent, matched, ast.NewString(trail))
+	}
+
+	parent.RemoveChild(parent, matched)
+}
+
+// splitEdgeSpace separates the whitespace at each end of an expansion from the
+// content between them.
+func splitEdgeSpace(data []byte) (lead, trail, body []byte) {
+	body = bytes.TrimLeft(data, " \t")
+	lead = data[:len(data)-len(body)]
+
+	trimmed := bytes.TrimRight(body, " \t")
+	trail = body[len(trimmed):]
+
+	return lead, trail, trimmed
 }


### PR DESCRIPTION
The last of the four text-level passes (after #887, #888, #889), and the worst of them.

## The bug

A page documenting a macro had its own example expanded:

````markdown
```
See task MYJIRA-123.
```
````

published with the fenced sample replaced by a Jira macro. Code spans were hit too, and there the markup was escaped into visible noise:

```
<code>&lt;ac:structured-macro ac:name=&quot;jira&quot;&gt;…</code>
```

Includes had the same defect — a fence showing `<!-- Include: frag.md -->` pulled the file in.

## Why this was more than deleting the text passes

`MacroTransformer` and `IncludeTransformer` already existed and were **already registered** in the pipeline. They were simply unreachable: the text passes consumed every directive before the parser ran, so the AST versions never found anything. Deleting the text passes is most of the diff — but it exposed eight defects that had never run in anger. Each is fixed here:

| Defect | Cause |
|---|---|
| Expanded markup escaped | goldmark's `SetRaw` only means *backslash escapes* are left alone; `RawWrite` still runs every byte through `EscapeHTMLByte`. `SetCode` is what writes verbatim. |
| Macro opening tag wrapped in `<p>` | The renderer suppressed `<p>` for a raw tag parsed from the document, but not for one that arrived by expansion. |
| Macro body of a table became a paragraph of pipes | The sub-parser had none of the extensions the document is parsed with. |
| Paragraph nested inside a paragraph | Inline and block expansions went down the same splice path. |
| `Prose MYJIRA-123` → `Prose<ac:…` | Edge whitespace lost: an expansion is parsed as its own document, and a document does not begin with a space. |
| Macro in `backticks` expanded | Matching per paragraph, whose text includes its code spans. Now per text node. |
| Macro never applied to included text | Definitions are removed from the tree as they are read, so a later pass — after an include expands — had none left. They now accumulate. |
| Macro expanded into itself | The pipeline runs to a fixed point and macro output routinely contains the text that matched it (`MYJIRA-123` → a tag containing `MYJIRA-123`). Output is now marked and not re-offered. |

That last one has a deliberate boundary: **text from an include is not marked**, because a document that includes a fragment expects macros to apply to it. Only a macro's own output is off limits.

## Behaviour change worth knowing

Macro patterns are now matched against individual text nodes rather than raw paragraph text. A pattern that spans inline markup — e.g. matching across `**bold**` — will no longer match. Simple token patterns (`:accept:`, `MYJIRA-\d+`) are unaffected. This is the same narrowing that makes code spans safe, so it is not separable from the fix.

## Verification

Of the five new tests, **two fail on master** and demonstrate the fix:

```
--- FAIL: TestMacroInsideCodeIsLeftAlone
--- FAIL: TestIncludeInsideCodeBlockIsLeftAlone
```

The other three — `TestMacroKeepsSurroundingText`, `TestMacroIsNotExpandedTwice`, `TestIncludedContentStillGetsMacros` — **pass on master**. They are not evidence of the fix; they guard regressions this implementation could introduce, and each one did fail at some point while building it.

The existing suite is the real check here: it covers the macro and include features heavily (`TestMacroRichTextBodyClosesOutsideBlockContent`, `TestDetailsMacroClosesOutsideBody`, the nested-pipeline tests), and all of it passes unchanged. Full suite green under `-race`; `golangci-lint`: 0 issues.

Given this touches mark's most-used feature, it deserves a closer look than the previous three.