### PR TITLE
feat: leave a hand-edited page alone with --no-overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1097,6 +1097,7 @@ GLOBAL OPTIONS:
    --mermaid-scale float                    defines the scaling factor for mermaid renderings. (default: 1) [$MARK_MERMAID_SCALE]
    --include-path string                    Path for shared includes, used as a fallback if the include doesn't exist in the current directory. [$MARK_INCLUDE_PATH]
    --changes-only                           Avoids re-uploading pages that haven't changed since the last run. [$MARK_CHANGES_ONLY]
+   --no-overwrite                           Leave alone any page that has been edited in Confluence since mark last published it, instead of overwriting the edit. Requires --track-pages, which is where the last published version is remembered. [$MARK_NO_OVERWRITE]
    --track-pages                            Remember which page each file publishes to, so renaming a file or changing its title updates the existing page instead of creating a second one. Stores the mapping in Confluence (a space property on Cloud, a homepage content property on Server/Data Center); nothing is written to the repository. [$MARK_TRACK_PAGES]
    --preserve-comments                      Fetch and preserve inline comments on existing Confluence pages. [$MARK_PRESERVE_COMMENTS]
    --d2-scale float                         defines the scaling factor for d2 renderings. (default: 1) [$MARK_D2_SCALE]
@@ -1372,6 +1373,46 @@ are read in a single request and only the ones that changed are written back.
   absolute path.
 * `--track-pages` has no effect when publishing straight to a page ID, since the
   mapping is per space and per file and a page ID is neither.
+
+### Leaving hand-edited pages alone
+
+By default Mark overwrites whatever a page currently holds. `--no-overwrite`
+makes it skip any page that has been edited in Confluence since Mark last
+published it:
+
+```bash
+mark --track-pages --no-overwrite --files "docs/**/*.md"
+```
+
+```text
+WRN page "Runbook" was edited in Confluence since mark published it
+    (version 9, mark wrote 7); leaving it alone
+```
+
+It needs `--track-pages`, because the version Mark last wrote is remembered in
+the same manifest, and Mark refuses to run without it rather than appear to
+guard pages it is not guarding.
+
+A skipped page still counts as published: it is not reported as an orphan and
+not pruned. Nothing else about it is touched either -- no labels, no ordering,
+and its attachments are not re-uploaded.
+
+The warning repeats on every run until the difference is resolved, which is
+deliberate: a page drifting from its source is a standing problem, not a one-off
+event. To resolve it, either bring the edit back into the Markdown, or publish
+once without `--no-overwrite` to let Mark reclaim the page.
+
+Comparison is by version number, not by content. Confluence rewrites storage
+markup on save often enough that comparing bodies would report a difference on
+pages nobody had touched.
+
+#### Worth knowing about --no-overwrite
+
+* A page Mark has no recorded version for -- first run, or one published before
+  the version was tracked -- is published normally and recorded, rather than
+  frozen on the suspicion that it might have changed.
+* Anything that creates a version counts as an edit, including a comment added
+  in the web UI.
 
 ## Issues, Bugs & Contributions
 

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -307,6 +307,19 @@ func (s *Server) Page(id string) *Page {
 	return nil
 }
 
+// EditPage stands in for somebody editing a page in the Confluence web UI: the
+// body changes and the version moves on, with no involvement from mark.
+func (s *Server) EditPage(id, body string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if p, ok := s.pages[id]; ok {
+		p.Body = body
+		p.Version++
+		p.Message = "edited by hand"
+	}
+}
+
 // Attachments returns the attachments stored for a page.
 func (s *Server) Attachments(pageID string) []Attachment {
 	s.mu.Lock()

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -196,6 +196,12 @@ type Entry struct {
 	// only means the file is gone if the run was looking where the file would
 	// have been; a run narrowed to one directory says nothing about any other.
 	Glob string `json:"glob,omitempty"`
+
+	// Version is the page version mark last wrote. A page whose version has
+	// moved on since is one somebody else has edited, which is the whole basis
+	// of --no-overwrite. Zero means mark has never recorded one -- an entry
+	// written before this was tracked -- and nothing can be concluded from it.
+	Version int64 `json:"version,omitempty"`
 }
 
 // folderDocument is the folder mapping as stored.
@@ -702,6 +708,35 @@ func (s *Store) ResolveStaleTitle(spaceKey, title string) (string, bool, error) 
 
 	pageID, ok := state.titles[title]
 	return pageID, ok && pageID != "", nil
+}
+
+// RecordVersion notes the page version mark has just written.
+//
+// Separate from Record because the number is only known afterwards: Record runs
+// before the update so that a mapping survives a failed one, and the version
+// that update produces does not exist until it succeeds.
+func (s *Store) RecordVersion(spaceKey, path string, version int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path = Key(path)
+
+	state, err := s.load(spaceKey)
+	if err != nil {
+		return err
+	}
+
+	sh := &state.shards[shardFor(path)]
+	entry, ok := sh.pages[path]
+	if !ok || entry.Version == version {
+		return nil
+	}
+
+	entry.Version = version
+	sh.pages[path] = entry
+	sh.dirty = true
+
+	return nil
 }
 
 // RecordFolder notes which Confluence folder a declared folder path resolved

--- a/mark.go
+++ b/mark.go
@@ -70,6 +70,7 @@ type Config struct {
 	ChangesOnly      bool
 	PreserveComments bool
 	TrackPages       bool
+	NoOverwrite      bool
 
 	// Rendering
 	DropH1          bool
@@ -130,6 +131,14 @@ func Run(config Config) error {
 	// The manifest is only consulted when asked for. It changes how an existing
 	// page is found, which is not something to switch on under anyone without
 	// their say-so.
+	// Without the manifest there is nowhere to have remembered what mark last
+	// published, so there is nothing to compare a page against and the flag
+	// would quietly do nothing.
+	if config.NoOverwrite && !config.TrackPages {
+		return fmt.Errorf("--no-overwrite requires --track-pages: " +
+			"the version mark last published is remembered in the page manifest")
+	}
+
 	var tracker *manifest.Store
 	if config.TrackPages {
 		// A dry run resolves exactly as a real one does -- otherwise its preview
@@ -507,6 +516,34 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		}
 	}
 
+	// Checked here, before anything is written: attachments are uploaded a few
+	// lines below, and there is no point sending them for a page that is about
+	// to be left alone.
+	if config.NoOverwrite && !pageCreated && tracker != nil && meta != nil && target != nil {
+		drifted, recorded, err := hasDrifted(tracker, meta.Space, file, target)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if drifted {
+			log.Warn().Msgf(
+				"page %q was edited in Confluence since mark published it "+
+					"(version %d, mark wrote %d); leaving it alone",
+				target.Title, target.Version.Number, recorded,
+			)
+
+			// Recorded, so the page still counts as seen and is not mistaken
+			// for an orphan and deleted. The version is deliberately not
+			// updated: until somebody resolves the difference, every run should
+			// say so again.
+			if err := tracker.Record(meta.Space, file, target.ID, target.Title, sourceHash); err != nil {
+				return nil, nil, fmt.Errorf("unable to record page mapping for %q: %w", file, err)
+			}
+
+			return target, nil, nil
+		}
+	}
+
 	// Collect attachments declared via <!-- Attachment: --> directives.
 	var declaredAttachments []string
 	if meta != nil {
@@ -673,6 +710,16 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to update page: %w", err)
+		}
+	}
+
+	// What --no-overwrite compares against on the next run. UpdatePage advances
+	// the version it was given, so this reads the same either way: a run that
+	// wrote nothing still records what it found, so that a page nobody touches
+	// gets a version on the first run rather than staying unguarded forever.
+	if tracker != nil && meta != nil {
+		if err := tracker.RecordVersion(meta.Space, file, target.Version.Number); err != nil {
+			return nil, nil, fmt.Errorf("unable to record page version for %q: %w", file, err)
 		}
 	}
 
@@ -1393,4 +1440,31 @@ func mergeComments(newBody string, oldBody string, comments *confluence.InlineCo
 func Cleanup() {
 	d2.Cleanup()
 	mermaid.Cleanup()
+}
+
+// hasDrifted reports whether a page has been changed by somebody other than
+// mark since mark last published it, along with the version mark wrote.
+//
+// The comparison is against the version number rather than the page's content:
+// Confluence rewrites storage markup on save often enough that comparing bodies
+// would report a difference on pages nobody had touched.
+//
+// An entry with no recorded version cannot answer the question -- it was
+// written before versions were tracked, or by a run without --no-overwrite --
+// and a page is given the benefit of the doubt rather than frozen.
+func hasDrifted(
+	tracker *manifest.Store,
+	spaceKey, file string,
+	target *confluence.PageInfo,
+) (bool, int64, error) {
+	entry, ok, err := tracker.Lookup(spaceKey, file)
+	if err != nil {
+		return false, 0, fmt.Errorf("unable to look up page mapping for %q: %w", file, err)
+	}
+
+	if !ok || entry.Version == 0 || entry.PageID != target.ID {
+		return false, 0, nil
+	}
+
+	return target.Version.Number != entry.Version, entry.Version, nil
 }

--- a/mark_nooverwrite_test.go
+++ b/mark_nooverwrite_test.go
@@ -1,0 +1,126 @@
+package mark
+
+import (
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// noOverwriteFixture publishes one page and returns the server, its id and the
+// config that produced it.
+func noOverwriteFixture(t *testing.T) (*confluencetest.Server, string, Config) {
+	t.Helper()
+
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Doc -->\n\nFrom mark.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files:       filepath.Join(dir, "*.md"),
+		Features:    []string{"mention"},
+		TrackPages:  true,
+		NoOverwrite: true,
+		Output:      io.Discard,
+	}
+
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	doc, err := api.FindPage("DOCS", "Doc", "page")
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+
+	return server, doc.ID, config
+}
+
+// TestNoOverwriteSkipsAPageEditedInConfluence is the point of the flag: an edit
+// made in the web UI is not silently replaced on the next publish.
+func TestNoOverwriteSkipsAPageEditedInConfluence(t *testing.T) {
+	server, id, config := noOverwriteFixture(t)
+
+	server.EditPage(id, "<p>Written by a person.</p>")
+	edited := server.Page(id)
+
+	require.NoError(t, Run(config))
+
+	after := server.Page(id)
+	assert.Equal(t, "<p>Written by a person.</p>", after.Body,
+		"the hand-written body must survive the run")
+	assert.Equal(t, edited.Version, after.Version,
+		"a skipped page must not gain a version")
+}
+
+// TestNoOverwriteKeepsReportingUntilResolved checks that the warning is not a
+// one-off. The recorded version is deliberately left alone while a page is
+// skipped, so every later run says so again.
+func TestNoOverwriteKeepsReportingUntilResolved(t *testing.T) {
+	server, id, config := noOverwriteFixture(t)
+
+	server.EditPage(id, "<p>Written by a person.</p>")
+
+	require.NoError(t, Run(config))
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, "<p>Written by a person.</p>", server.Page(id).Body,
+		"the second run must skip the page as well")
+}
+
+// TestNoOverwritePublishesAnUntouchedPage is the control. Without it the fix
+// could be "stop publishing".
+func TestNoOverwritePublishesAnUntouchedPage(t *testing.T) {
+	server, id, config := noOverwriteFixture(t)
+
+	before := server.Page(id)
+	require.NoError(t, Run(config))
+
+	after := server.Page(id)
+	assert.Contains(t, after.Body, "From mark",
+		"a page nobody touched must still be published")
+	assert.Greater(t, after.Version, before.Version,
+		"an untouched page is updated as usual")
+}
+
+// TestNoOverwriteDoesNotOrphanASkippedPage pins that a skipped page still
+// counts as published. It is still on disk, and deleting it because a run
+// declined to write to it would be the worst possible reading of the flag.
+func TestNoOverwriteDoesNotOrphanASkippedPage(t *testing.T) {
+	server, id, config := noOverwriteFixture(t)
+
+	server.EditPage(id, "<p>Written by a person.</p>")
+	require.NoError(t, Run(config))
+
+	page := server.Page(id)
+	require.NotNil(t, page, "the page must not be deleted")
+	assert.Equal(t, "<p>Written by a person.</p>", page.Body,
+		"the page must have been skipped, which is the case being pinned")
+}
+
+// TestNoOverwriteRequiresTrackPages: without the manifest there is nowhere to
+// have remembered a version, so the flag could only appear to work.
+func TestNoOverwriteRequiresTrackPages(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md", "<!-- Space: DOCS -->\n<!-- Title: Doc -->\n\nBody.\n")
+
+	err := Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), NoOverwrite: true, Output: io.Discard,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--track-pages")
+}

--- a/util/cli.go
+++ b/util/cli.go
@@ -116,6 +116,7 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 		EditLock:         cmd.Bool("edit-lock"),
 		ChangesOnly:      cmd.Bool("changes-only"),
 		TrackPages:       cmd.Bool("track-pages"),
+		NoOverwrite:      cmd.Bool("no-overwrite"),
 		PreserveComments: cmd.Bool("preserve-comments"),
 
 		DropH1:          cmd.Bool("drop-h1"),

--- a/util/flags.go
+++ b/util/flags.go
@@ -199,6 +199,12 @@ var Flags = []cli.Flag{
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHANGES_ONLY"), altsrctoml.TOML("changes-only", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.BoolFlag{
+		Name:    "no-overwrite",
+		Value:   false,
+		Usage:   "Leave alone any page that has been edited in Confluence since mark last published it, instead of overwriting the edit. Requires --track-pages, which is where the last published version is remembered.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_NO_OVERWRITE"), altsrctoml.TOML("no-overwrite", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
 		Name:    "track-pages",
 		Value:   false,
 		Usage:   "Remember which page each file publishes to, so renaming a file or changing its title updates the existing page instead of creating a second one. Stores the mapping in Confluence (a space property on Cloud, a homepage content property on Server/Data Center); nothing is written to the repository.",


### PR DESCRIPTION
## The problem

Mark overwrites whatever a page currently holds. That is right for a repository that owns its documentation, and wrong the moment somebody fixes a typo in the web UI — the next run puts it back, silently, and whoever made the fix has no way to know it was reverted.

## The flag

```bash
mark --track-pages --no-overwrite --files "docs/**/*.md"
```

```text
WRN page "Runbook" was edited in Confluence since mark published it
    (version 9, mark wrote 7); leaving it alone
```

The manifest already recorded which page each file publishes to. This adds *what version it published*, so the check is a comparison against data the run has already fetched — **no extra API requests**.

## Design decisions worth reviewing

**Version, not content.** Comparing bodies would be the obvious approach and is the wrong one: Confluence rewrites storage markup on save often enough that it would report a difference on pages nobody had touched. A guard that cries wolf gets turned off. Version numbers are also what Confluence's own optimistic concurrency uses.

**A skipped page is still recorded.** Otherwise it would be absent from the run, mistaken for an orphan, and pruned — the worst possible reading of a flag whose entire purpose is to leave a page alone. `TestNoOverwriteDoesNotOrphanASkippedPage` pins this.

**The version is deliberately not updated while skipping.** A page drifting from its source is a standing problem, not a one-off event, so every later run reports it again. Resolve it by bringing the edit back into the Markdown, or by publishing once without the flag to let mark reclaim the page.

**Checked before any writes.** The check sits before attachment upload, so a page about to be skipped does not have its attachments re-uploaded first.

**No recorded version means publish.** A page mark has never recorded — first run, or one published before this existed — is published and recorded rather than frozen on the suspicion it might have changed.

**`--no-overwrite` without `--track-pages` is an error, not a warning.** There is nowhere to have remembered a version, so the flag could only appear to work. A guard that looks on while guarding nothing is worse than no guard.

## Verification

Five new end-to-end tests against the in-memory Confluence fake, which grew an `EditPage` helper standing in for a web-UI edit. With the drift comparison stubbed to `false`, the two that assert the skip fail and the control passes:

```
--- FAIL: TestNoOverwriteSkipsAPageEditedInConfluence
--- FAIL: TestNoOverwriteKeepsReportingUntilResolved
--- PASS: TestNoOverwritePublishesAnUntouchedPage
```

`TestNoOverwriteDoesNotOrphanASkippedPage` was strengthened after that check — as first written it passed with the feature disabled, since it only asserted the page still existed, which was true either way.

One bug found and fixed while building this: `UpdatePage` already advances `page.Version.Number` on success, so computing the published version as `+1` afterwards recorded a number one too high and no drift was ever detected. The recorded value is now read back from the page mark just wrote.

Full suite green under `-race`; `golangci-lint`: 0 issues; README documents the flag and its caveats.