### PR TITLE
fix: stop removing labels applied in Confluence, with --append-labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,6 +862,25 @@ indented code block is left alone -- a page documenting Markdown gets to show
 its examples unchanged. Files pulled in with `Include` are resolved along with
 the document that includes them.
 
+### Labels applied in Confluence
+
+A page ends up with exactly the labels its `Label` headers name: one added in
+the Confluence UI is removed on the next publish, because the document is taken
+as the whole truth about its labels.
+
+That is often not what a team wants. Labels drive macros, searches and reports,
+and are frequently applied by people who are not editing the Markdown.
+`--append-labels` adds what a document asks for without removing anything else:
+
+```bash
+mark --append-labels --files "docs/**/*.md"
+```
+
+The cost is that a label outlives the header that introduced it -- appending
+cannot tell a `Label` header somebody deleted from a label somebody added in
+Confluence. That is visible on the page and can be undone by hand, which the
+deletion it prevents is not.
+
 ### Checking that links go somewhere
 
 By default a link that cannot be resolved is left exactly as written, which in
@@ -1166,6 +1185,7 @@ GLOBAL OPTIONS:
    --include-path string                    Path for shared includes, used as a fallback if the include doesn't exist in the current directory. [$MARK_INCLUDE_PATH]
    --changes-only                           Avoids re-uploading pages that haven't changed since the last run. [$MARK_CHANGES_ONLY]
    --check-links string [ --check-links string ]  fail on links that do not resolve. Repeat or comma-separate any of: "internal" (relative links to other files in the repository), "confluence" (ac: links naming a page by title), "external" (requests each URL to see whether it answers), or "all". [$MARK_CHECK_LINKS]
+   --append-labels                          add the labels a document asks for without removing any others, so that labels applied in Confluence survive a publish. Without it, a page ends up with exactly the labels its Label headers name. [$MARK_APPEND_LABELS]
    --check-links-warn-only                  report links that do not resolve without failing the run. Only meaningful together with --check-links. [$MARK_CHECK_LINKS_WARN_ONLY]
    --no-overwrite                           Leave alone any page that has been edited in Confluence since mark last published it, instead of overwriting the edit. Requires --track-pages, which is where the last published version is remembered. [$MARK_NO_OVERWRITE]
    --track-pages                            Remember which page each file publishes to, so renaming a file or changing its title updates the existing page instead of creating a second one. Stores the mapping in Confluence (a space property on Cloud, a homepage content property on Server/Data Center); nothing is written to the repository. [$MARK_TRACK_PAGES]

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -307,6 +307,16 @@ func (s *Server) Page(id string) *Page {
 	return nil
 }
 
+// AddLabel stands in for somebody labelling a page in the Confluence web UI.
+func (s *Server) AddLabel(id, label string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if p, ok := s.pages[id]; ok {
+		p.Labels = append(p.Labels, label)
+	}
+}
+
 // EditPage stands in for somebody editing a page in the Confluence web UI: the
 // body changes and the version moves on, with no involvement from mark.
 func (s *Server) EditPage(id, body string) {

--- a/mark.go
+++ b/mark.go
@@ -73,6 +73,7 @@ type Config struct {
 	NoOverwrite        bool
 	CheckLinks         []string
 	CheckLinksWarnOnly bool
+	AppendLabels       bool
 
 	// Rendering
 	DropH1          bool
@@ -752,7 +753,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	}
 
 	if meta != nil {
-		if err := updateLabels(api, target, labels); err != nil {
+		if err := updateLabels(api, target, labels, config.AppendLabels); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -1007,7 +1008,15 @@ func resolveRenamedFile(
 	return pg, nil
 }
 
-func updateLabels(api *confluence.API, target *confluence.PageInfo, metaLabels []string) error {
+// updateLabels brings a page's labels in line with what its document asks for.
+//
+// Whether that means removing the others is the caller's choice. A page's
+// labels are not only mark's to decide: teams label pages in Confluence to
+// drive macros, searches and reports, and removing a label somebody added there
+// destroys work no document ever mentioned. Appending leaves them, at the cost
+// of a label outliving the Label header that introduced it -- which is visible
+// and reversible, unlike the deletion.
+func updateLabels(api *confluence.API, target *confluence.PageInfo, metaLabels []string, appendOnly bool) error {
 	labelInfo, err := api.GetPageLabels(target, "global")
 	if err != nil {
 		return err
@@ -1018,7 +1027,10 @@ func updateLabels(api *confluence.API, target *confluence.PageInfo, metaLabels [
 	log.Debug().Msg("Meta Labels:")
 	log.Debug().Interface("labels", metaLabels).Send()
 
-	delLabels := determineLabelsToRemove(labelInfo, metaLabels)
+	var delLabels []string
+	if !appendOnly {
+		delLabels = determineLabelsToRemove(labelInfo, metaLabels)
+	}
 	log.Debug().Msg("Del Labels:")
 	log.Debug().Interface("labels", delLabels).Send()
 

--- a/mark_labels_test.go
+++ b/mark_labels_test.go
@@ -1,0 +1,96 @@
+package mark
+
+import (
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// labelFixture publishes a page carrying the given Label headers and returns
+// the server, the page id and a config that republishes it.
+func labelFixture(t *testing.T, appendLabels bool, labels string) (*confluencetest.Server, string, Config) {
+	t.Helper()
+
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Doc -->\n"+labels+"\nBody.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files:        filepath.Join(dir, "doc.md"),
+		Features:     []string{"mention"},
+		AppendLabels: appendLabels,
+		Output:       io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	doc, err := api.FindPage("DOCS", "Doc", "page")
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+
+	return server, doc.ID, config
+}
+
+// TestLabelsRemovedByDefault pins the behaviour that has always been: the
+// document decides, and a label it does not name is taken off.
+func TestLabelsRemovedByDefault(t *testing.T) {
+	server, id, config := labelFixture(t, false, "<!-- Label: from-mark -->\n")
+
+	server.AddLabel(id, "added-by-hand")
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, []string{"from-mark"}, server.Page(id).Labels,
+		"without --append-labels a page carries exactly what its headers name")
+}
+
+// TestAppendLabelsKeepsLabelsAddedInConfluence is the fix. A label applied in
+// the web UI drives macros, searches and reports; removing it destroys work no
+// document ever mentioned.
+func TestAppendLabelsKeepsLabelsAddedInConfluence(t *testing.T) {
+	server, id, config := labelFixture(t, true, "<!-- Label: from-mark -->\n")
+
+	server.AddLabel(id, "added-by-hand")
+	require.NoError(t, Run(config))
+
+	assert.ElementsMatch(t, []string{"from-mark", "added-by-hand"}, server.Page(id).Labels,
+		"a label applied in Confluence must survive a publish")
+}
+
+// TestAppendLabelsStillAddsNewOnes: appending must not mean doing nothing.
+func TestAppendLabelsStillAddsNewOnes(t *testing.T) {
+	server, id, config := labelFixture(t, true, "<!-- Label: first -->\n")
+
+	dir := filepath.Dir(config.Files)
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Doc -->\n"+
+			"<!-- Label: first -->\n<!-- Label: second -->\n\nBody.\n")
+	require.NoError(t, Run(config))
+
+	assert.ElementsMatch(t, []string{"first", "second"}, server.Page(id).Labels)
+}
+
+// TestAppendLabelsKeepsARemovedHeadersLabel is the cost of the flag, written
+// down: a label outlives the header that introduced it.
+func TestAppendLabelsKeepsARemovedHeadersLabel(t *testing.T) {
+	server, id, config := labelFixture(t, true, "<!-- Label: first -->\n<!-- Label: second -->\n")
+
+	dir := filepath.Dir(config.Files)
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Doc -->\n"+
+			"<!-- Label: first -->\n\nBody.\n")
+	require.NoError(t, Run(config))
+
+	assert.ElementsMatch(t, []string{"first", "second"}, server.Page(id).Labels,
+		"appending cannot tell a dropped header from a label somebody added")
+}

--- a/util/cli.go
+++ b/util/cli.go
@@ -119,6 +119,7 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 		NoOverwrite:        cmd.Bool("no-overwrite"),
 		CheckLinks:         cmd.StringSlice("check-links"),
 		CheckLinksWarnOnly: cmd.Bool("check-links-warn-only"),
+		AppendLabels:       cmd.Bool("append-labels"),
 		PreserveComments:   cmd.Bool("preserve-comments"),
 
 		DropH1:          cmd.Bool("drop-h1"),

--- a/util/flags.go
+++ b/util/flags.go
@@ -205,6 +205,12 @@ var Flags = []cli.Flag{
 			altsrctoml.TOML("check-links", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.BoolFlag{
+		Name:    "append-labels",
+		Value:   false,
+		Usage:   "add the labels a document asks for without removing any others, so that labels applied in Confluence survive a publish. Without it, a page ends up with exactly the labels its Label headers name.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_APPEND_LABELS"), altsrctoml.TOML("append-labels", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
 		Name:    "check-links-warn-only",
 		Value:   false,
 		Usage:   "report links that do not resolve without failing the run. Only meaningful together with --check-links.",


### PR DESCRIPTION
## The bug

`determineLabelsToRemove` (`mark.go:1044`) deletes every label on a page that its `Label` headers do not name. So a label applied in the Confluence UI is silently removed on the next publish.

That matters more than it sounds. Labels drive macros, searches, reports and space navigation, and are routinely applied by people who never touch the Markdown. mark destroys their work without a word — the same class of problem `--no-overwrite` addressed for page bodies, unsolved for labels.

## The fix

`--append-labels` adds what a document asks for and removes nothing.

```bash
mark --append-labels --files "docs/**/*.md"
```

The cost is documented rather than hidden: appending cannot tell a `Label` header somebody deleted from a label somebody added in Confluence, so a label can outlive its header. That is visible on the page and undoable by hand — unlike the deletion it prevents. There is a test pinning exactly that trade-off, so nobody discovers it by surprise.

## Why it is opt-in — worth a second opinion

I left the default alone, on the grounds that the existing behaviour is not simply wrong: a repository that owns its documentation may legitimately want its `Label` headers to be the whole truth, and flipping the default changes what every current run does.

The argument the other way is real though: the two failure modes are not symmetric. Today's default **silently deletes somebody else's data**; the alternative leaves **a stale label somebody can see and remove**. If you would rather this were the default, it is a one-line change and I am happy to make it — it is your call as maintainer, not mine.

## A better version exists, later

The page manifest already records what mark published. It could remember the labels mark set and remove only those — precisely distinguishing "a header was deleted" from "a human added this", with no flag at all.

I did not build that here because it ties label behaviour to `--track-pages`, which makes the rule harder to explain ("labels are only removed if you enable tracking") and is a bigger decision than fixing the data loss.

## Verification

Four tests. With the flag ignored, the two that assert the fix fail and the two that pin surrounding behaviour pass:

```
--- PASS: TestLabelsRemovedByDefault
--- FAIL: TestAppendLabelsKeepsLabelsAddedInConfluence
--- PASS: TestAppendLabelsStillAddsNewOnes
--- FAIL: TestAppendLabelsKeepsARemovedHeadersLabel
```

`TestLabelsRemovedByDefault` matters as much as the others: it pins that the default is unchanged. `TestAppendLabelsStillAddsNewOnes` rules out "appending" degenerating into "doing nothing".

The in-memory Confluence fake grew an `AddLabel` helper standing in for somebody labelling a page in the web UI.

Full suite green under `-race`; `golangci-lint`: 0 issues; README documents the flag and its trade-off.