### PR TITLE
feat: set Confluence content properties from a document or a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ appended to the values from front matter.
 <!-- Attachment: <local path> -->
 <!-- Label: <label 1> -->
 <!-- Label: <label 2> -->
+<!-- Property: <key>=<value> -->
 <!-- Image-Align: <left|center|right> -->
 
 <page contents>
@@ -862,6 +863,47 @@ indented code block is left alone -- a page documenting Markdown gets to show
 its examples unchanged. Files pulled in with `Include` are resolved along with
 the document that includes them.
 
+### Confluence content properties
+
+A page can carry arbitrary key/value data that macros, reports and scripts read
+back through the API. One `Property` header sets one of them, as many times as
+you like:
+
+```markdown
+<!-- Property: owner=platform-team -->
+<!-- Property: reviewed=2026-08 -->
+```
+
+In YAML front matter the same thing is a mapping under the plural key, the way
+`Parent` headers become a `parents` list:
+
+```yaml
+---
+title: Runbook
+properties:
+  owner: platform-team
+  reviewers: 3
+  tags:
+    - runbook
+    - on-call
+---
+```
+
+A content property holds JSON, so front matter can give a number, a list or a
+mapping as the value. A `Property` header can only say a string, which is the
+one difference between the two forms.
+
+`--global-properties` points at a YAML or JSON file of properties to set on
+every page:
+
+```bash
+mark --global-properties confluence-properties.yaml --files "docs/**/*.md"
+```
+
+A document naming a property the file also names wins for its own page. A
+property whose value has not changed is not written again, because Confluence
+versions each one and rewriting it fills its history for nothing.
+
 ### Labels applied in Confluence
 
 A page ends up with exactly the labels its `Label` headers name: one added in
@@ -1185,6 +1227,7 @@ GLOBAL OPTIONS:
    --include-path string                    Path for shared includes, used as a fallback if the include doesn't exist in the current directory. [$MARK_INCLUDE_PATH]
    --changes-only                           Avoids re-uploading pages that haven't changed since the last run. [$MARK_CHANGES_ONLY]
    --check-links string [ --check-links string ]  fail on links that do not resolve. Repeat or comma-separate any of: "internal" (relative links to other files in the repository), "confluence" (ac: links naming a page by title), "external" (requests each URL to see whether it answers), or "all". [$MARK_CHECK_LINKS]
+   --global-properties string               path to a YAML or JSON file of Confluence content properties to set on every page. A Property header or properties front matter in a document wins over the file for that page. [$MARK_GLOBAL_PROPERTIES]
    --append-labels                          add the labels a document asks for without removing any others, so that labels applied in Confluence survive a publish. Without it, a page ends up with exactly the labels its Label headers name. [$MARK_APPEND_LABELS]
    --check-links-warn-only                  report links that do not resolve without failing the run. Only meaningful together with --check-links. [$MARK_CHECK_LINKS_WARN_ONLY]
    --no-overwrite                           Leave alone any page that has been edited in Confluence since mark last published it, instead of overwriting the edit. Requires --track-pages, which is where the last published version is remembered. [$MARK_NO_OVERWRITE]

--- a/mark.go
+++ b/mark.go
@@ -74,6 +74,7 @@ type Config struct {
 	CheckLinks         []string
 	CheckLinksWarnOnly bool
 	AppendLabels       bool
+	GlobalProperties   string
 
 	// Rendering
 	DropH1          bool
@@ -129,6 +130,13 @@ func Run(config Config) error {
 	std, err := stdlib.New(api)
 	if err != nil {
 		return fmt.Errorf("unable to retrieve standard library: %w", err)
+	}
+
+	// Read once and before anything is published: a file that cannot be parsed
+	// should not be discovered halfway through a repository.
+	globalProperties, err := page.LoadGlobalProperties(config.GlobalProperties)
+	if err != nil {
+		return err
 	}
 
 	// Rejected before anything is published rather than on the first link that
@@ -200,7 +208,7 @@ func Run(config Config) error {
 	for _, file := range files {
 		log.Info().Msgf("processing %s", file)
 
-		target, placement, err := processFile(file, api, config, std, tracker, folders, checker)
+		target, placement, err := processFile(file, api, config, std, tracker, folders, checker, globalProperties)
 		if placement != nil {
 			ordered = append(ordered, *placement)
 		}
@@ -303,11 +311,19 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 		return nil, err
 	}
 
-	target, _, err := processFile(file, api, config, std, nil, nil, page.NewLinkChecker(linkChecks))
+	globalProperties, err := page.LoadGlobalProperties(config.GlobalProperties)
+	if err != nil {
+		return nil, err
+	}
+
+	target, _, err := processFile(
+		file, api, config, std, nil, nil,
+		page.NewLinkChecker(linkChecks), globalProperties,
+	)
 	return target, err
 }
 
-func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, folders page.FolderTracker, checker *page.LinkChecker) (*confluence.PageInfo, *page.Ordered, error) {
+func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, folders page.FolderTracker, checker *page.LinkChecker, globalProperties map[string]any) (*confluence.PageInfo, *page.Ordered, error) {
 	markdown, err := os.ReadFile(file)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to read file %q: %w", file, err)
@@ -756,6 +772,19 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		if err := updateLabels(api, target, labels, config.AppendLabels); err != nil {
 			return nil, nil, err
 		}
+	}
+
+	var documentProperties map[string]any
+	if meta != nil {
+		documentProperties = meta.Properties
+	}
+
+	if err := page.ApplyProperties(
+		api, target.ID,
+		page.MergeProperties(globalProperties, documentProperties),
+		config.DryRun,
+	); err != nil {
+		return nil, nil, err
 	}
 
 	// Where this page asked to sit among its siblings. Applied once the whole

--- a/mark_properties_test.go
+++ b/mark_properties_test.go
@@ -1,0 +1,174 @@
+package mark
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// propertiesFixture publishes one document and returns the server, the page id
+// and the config used, so a test can republish.
+func propertiesFixture(t *testing.T, doc string, config func(*Config)) (*confluencetest.Server, string, Config) {
+	t.Helper()
+
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md", doc)
+
+	cfg := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files:    filepath.Join(dir, "doc.md"),
+		Features: []string{"mention"},
+		Output:   io.Discard,
+	}
+	if config != nil {
+		config(&cfg)
+	}
+	require.NoError(t, Run(cfg))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	page, err := api.FindPage("DOCS", "Doc", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+
+	return server, page.ID, cfg
+}
+
+const propertyHeaders = "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Doc -->\n"
+
+// TestPropertyHeaderSetsAContentProperty covers the singular, repeatable header
+// form, which matches Parent, Label and Attachment.
+func TestPropertyHeaderSetsAContentProperty(t *testing.T) {
+	server, id, _ := propertiesFixture(t,
+		propertyHeaders+
+			"<!-- Property: team=platform -->\n"+
+			"<!-- Property: reviewed=2026-08 -->\n\nBody.\n", nil)
+
+	require.NotNil(t, server.SpaceProperty(id, "team"))
+	assert.JSONEq(t, `"platform"`, string(server.SpaceProperty(id, "team").Value))
+
+	require.NotNil(t, server.SpaceProperty(id, "reviewed"))
+	assert.JSONEq(t, `"2026-08"`, string(server.SpaceProperty(id, "reviewed").Value))
+}
+
+// TestPropertiesFrontMatterSetsProperties covers the plural front matter form,
+// which matches parents, labels and attachments -- and which, unlike the
+// header, can carry a value that is not a string.
+func TestPropertiesFrontMatterSetsProperties(t *testing.T) {
+	server, id, _ := propertiesFixture(t,
+		"---\n"+
+			"title: Doc\n"+
+			"space: DOCS\n"+
+			"parents:\n  - Parent\n"+
+			"properties:\n"+
+			"  team: platform\n"+
+			"  reviewers: 3\n"+
+			"  tags:\n    - one\n    - two\n"+
+			"---\n\nBody.\n",
+		func(c *Config) { c.Features = []string{"mention", "frontmatter"} })
+
+	require.NotNil(t, server.SpaceProperty(id, "team"))
+	assert.JSONEq(t, `"platform"`, string(server.SpaceProperty(id, "team").Value))
+
+	require.NotNil(t, server.SpaceProperty(id, "reviewers"))
+	assert.JSONEq(t, `3`, string(server.SpaceProperty(id, "reviewers").Value))
+
+	require.NotNil(t, server.SpaceProperty(id, "tags"))
+	assert.JSONEq(t, `["one","two"]`, string(server.SpaceProperty(id, "tags").Value))
+}
+
+func TestGlobalPropertiesApplyToEveryPage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "properties.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("owner: docs-team\nsource: git\n"), 0o600))
+
+	server, id, _ := propertiesFixture(t, propertyHeaders+"\nBody.\n",
+		func(c *Config) { c.GlobalProperties = path })
+
+	require.NotNil(t, server.SpaceProperty(id, "owner"))
+	assert.JSONEq(t, `"docs-team"`, string(server.SpaceProperty(id, "owner").Value))
+	require.NotNil(t, server.SpaceProperty(id, "source"))
+}
+
+// TestDocumentPropertyWinsOverGlobal: a document naming a property is being
+// specific about its own page, which is the more particular statement.
+func TestDocumentPropertyWinsOverGlobal(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "properties.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"owner": "docs-team"}`), 0o600))
+
+	server, id, _ := propertiesFixture(t,
+		propertyHeaders+"<!-- Property: owner=platform-team -->\n\nBody.\n",
+		func(c *Config) { c.GlobalProperties = path })
+
+	assert.JSONEq(t, `"platform-team"`, string(server.SpaceProperty(id, "owner").Value))
+}
+
+// TestPropertyUnchangedIsNotRewritten: a property holds a version Confluence
+// increments on every write, so rewriting an unchanged value would fill its
+// history the way republishing an unchanged page fills the page's.
+func TestPropertyUnchangedIsNotRewritten(t *testing.T) {
+	server, id, config := propertiesFixture(t,
+		propertyHeaders+"<!-- Property: team=platform -->\n\nBody.\n", nil)
+
+	first := server.SpaceProperty(id, "team").Version
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, first, server.SpaceProperty(id, "team").Version,
+		"an unchanged property must not be written again")
+}
+
+func TestPropertyChangedIsRewritten(t *testing.T) {
+	server, id, config := propertiesFixture(t,
+		propertyHeaders+"<!-- Property: team=platform -->\n\nBody.\n", nil)
+
+	first := server.SpaceProperty(id, "team").Version
+
+	writeFile(t, filepath.Dir(config.Files), "doc.md",
+		propertyHeaders+"<!-- Property: team=infrastructure -->\n\nBody.\n")
+	require.NoError(t, Run(config))
+
+	assert.Greater(t, server.SpaceProperty(id, "team").Version, first)
+	assert.JSONEq(t, `"infrastructure"`, string(server.SpaceProperty(id, "team").Value))
+}
+
+func TestPropertyHeaderMustBeKeyValue(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Title: Doc -->\n<!-- Property: nonsense -->\n\nBody.\n")
+
+	err := Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "doc.md"), Output: io.Discard,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "key=value")
+}
+
+func TestGlobalPropertiesFileMustParse(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "properties.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("owner: [unclosed\n"), 0o600))
+	writeFile(t, dir, "doc.md", "<!-- Space: DOCS -->\n<!-- Title: Doc -->\n\nBody.\n")
+
+	err := Run(Config{
+		BaseURL: "http://127.0.0.1:1", Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), GlobalProperties: path, Output: io.Discard,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "properties file")
+}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -33,6 +33,7 @@ const (
 	HeaderSidebar     = `Sidebar`
 	ContentAppearance = `Content-Appearance`
 	HeaderImageAlign  = `Image-Align`
+	HeaderProperty    = `Property`
 )
 
 type Meta struct {
@@ -47,6 +48,14 @@ type Meta struct {
 	Attachments       []string
 	Labels            []string
 	ContentAppearance string
+
+	// Properties are Confluence content properties to set on the page.
+	//
+	// Values are whatever the document wrote, because a content property holds
+	// JSON and a caller may reasonably want a number, a list or an object. The
+	// Property header can only express a string; front matter can express the
+	// rest.
+	Properties map[string]any
 
 	// Order positions this page among its siblings, smaller first. Nil means
 	// the document said nothing about order, which is not the same as zero:
@@ -76,6 +85,28 @@ func toStringSlice(val any) []string {
 		}
 	}
 	return res
+}
+
+// toStringMap reads a front matter mapping, keeping the values as written.
+//
+// A YAML mapping decodes to map[string]any, but a document nested inside
+// another structure can arrive as map[any]any, so both are accepted.
+func toStringMap(val any) map[string]any {
+	switch v := val.(type) {
+	case map[string]any:
+		return v
+	case map[any]any:
+		out := make(map[string]any, len(v))
+		for key, value := range v {
+			if name, ok := key.(string); ok {
+				out[name] = value
+			}
+		}
+
+		return out
+	default:
+		return nil
+	}
 }
 
 func toString(val any) string {
@@ -170,6 +201,13 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 				setContentAppearance(meta, toString(v))
 			case "imagealign":
 				meta.ImageAlign = strings.ToLower(toString(v))
+			case "properties":
+				for key, value := range toStringMap(v) {
+					if meta.Properties == nil {
+						meta.Properties = map[string]any{}
+					}
+					meta.Properties[key] = value
+				}
 			}
 		}
 
@@ -265,6 +303,27 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 
 				case HeaderImageAlign:
 					meta.ImageAlign = strings.ToLower(strings.TrimSpace(value))
+
+				case HeaderProperty:
+					key, propValue, ok := strings.Cut(value, "=")
+					if !ok {
+						return nil, nil, fmt.Errorf(
+							"%s header must be written as key=value, got %q",
+							HeaderProperty, value,
+						)
+					}
+
+					key = strings.TrimSpace(key)
+					if key == "" {
+						return nil, nil, fmt.Errorf(
+							"%s header has no name: %q", HeaderProperty, value,
+						)
+					}
+
+					if meta.Properties == nil {
+						meta.Properties = map[string]any{}
+					}
+					meta.Properties[key] = strings.TrimSpace(propValue)
 
 				default:
 					log.Error().

--- a/page/property.go
+++ b/page/property.go
@@ -1,0 +1,130 @@
+package page
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/rs/zerolog/log"
+	"go.yaml.in/yaml/v3"
+)
+
+// LoadGlobalProperties reads the properties to set on every page.
+//
+// YAML, which also reads the JSON a caller may prefer to write, since JSON is
+// valid YAML. An empty path means there are none.
+func LoadGlobalProperties(path string) (map[string]any, error) {
+	if path == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read properties file %q: %w", path, err)
+	}
+
+	var properties map[string]any
+	if err := yaml.Unmarshal(data, &properties); err != nil {
+		return nil, fmt.Errorf("unable to parse properties file %q: %w", path, err)
+	}
+
+	return properties, nil
+}
+
+// MergeProperties combines the properties every page gets with the ones a
+// document asked for, the document winning.
+//
+// A document naming a property the file also names is being specific about its
+// own page, which is the more particular statement of the two.
+func MergeProperties(global, document map[string]any) map[string]any {
+	if len(global) == 0 && len(document) == 0 {
+		return nil
+	}
+
+	merged := make(map[string]any, len(global)+len(document))
+	for key, value := range global {
+		merged[key] = value
+	}
+	for key, value := range document {
+		merged[key] = value
+	}
+
+	return merged
+}
+
+// ApplyProperties writes content properties onto a page.
+//
+// Only what changed is written. A property holds a version that Confluence
+// increments on every write, so rewriting an unchanged value would fill its
+// history as surely as republishing an unchanged page fills the page's.
+func ApplyProperties(api *confluence.API, pageID string, properties map[string]any, dryRun bool) error {
+	if len(properties) == 0 {
+		return nil
+	}
+
+	existing, err := api.ListContentProperties(pageID)
+	if err != nil {
+		return fmt.Errorf("unable to read properties of page %s: %w", pageID, err)
+	}
+
+	current := make(map[string]*confluence.Property, len(existing))
+	for i := range existing {
+		current[existing[i].Key] = &existing[i]
+	}
+
+	// Sorted so that a run writing several properties does so in the same order
+	// every time, which makes a page history readable.
+	keys := make([]string, 0, len(properties))
+	for key := range properties {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		value, err := json.Marshal(properties[key])
+		if err != nil {
+			return fmt.Errorf("unable to encode property %q: %w", key, err)
+		}
+
+		if held, ok := current[key]; ok && json.Valid(held.Value) &&
+			equalJSON(held.Value, value) {
+			continue
+		}
+
+		if dryRun {
+			log.Info().Msgf("property %q of page %s would be set to %s", key, pageID, value)
+			continue
+		}
+
+		log.Info().Msgf("setting property %q of page %s", key, pageID)
+		if err := api.SetContentProperty(pageID, key, value, current[key]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// equalJSON compares two encodings by what they mean rather than how they were
+// written, so that whitespace or key order coming back from Confluence does not
+// read as a change.
+func equalJSON(a, b []byte) bool {
+	var left, right any
+	if json.Unmarshal(a, &left) != nil || json.Unmarshal(b, &right) != nil {
+		return false
+	}
+
+	leftBytes, err := json.Marshal(left)
+	if err != nil {
+		return false
+	}
+
+	rightBytes, err := json.Marshal(right)
+	if err != nil {
+		return false
+	}
+
+	return string(leftBytes) == string(rightBytes)
+}

--- a/util/cli.go
+++ b/util/cli.go
@@ -120,6 +120,7 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 		CheckLinks:         cmd.StringSlice("check-links"),
 		CheckLinksWarnOnly: cmd.Bool("check-links-warn-only"),
 		AppendLabels:       cmd.Bool("append-labels"),
+		GlobalProperties:   cmd.String("global-properties"),
 		PreserveComments:   cmd.Bool("preserve-comments"),
 
 		DropH1:          cmd.Bool("drop-h1"),

--- a/util/flags.go
+++ b/util/flags.go
@@ -204,6 +204,13 @@ var Flags = []cli.Flag{
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHECK_LINKS"),
 			altsrctoml.TOML("check-links", altsrc.NewStringPtrSourcer(&filename))),
 	},
+	&cli.StringFlag{
+		Name:      "global-properties",
+		Value:     "",
+		Usage:     "path to a YAML or JSON file of Confluence content properties to set on every page. A Property header or properties front matter in a document wins over the file for that page.",
+		TakesFile: true,
+		Sources:   cli.NewValueSourceChain(cli.EnvVar("MARK_GLOBAL_PROPERTIES"), altsrctoml.TOML("global-properties", altsrc.NewStringPtrSourcer(&filename))),
+	},
 	&cli.BoolFlag{
 		Name:    "append-labels",
 		Value:   false,


### PR DESCRIPTION
A page can carry arbitrary key/value data that macros, reports and scripts read back through the API. mark had no way to set any of it — despite already writing content properties internally for the page manifest.

## The two forms, following the existing convention

You asked for the singular/plural split to match `Parent`, and it does. Singular as a repeatable header:

```markdown
<!-- Property: owner=platform-team -->
<!-- Property: reviewed=2026-08 -->
```

Plural as a mapping in front matter, the way `Parent` headers become a `parents` list:

```yaml
---
title: Runbook
properties:
  owner: platform-team
  reviewers: 3
  tags: [runbook, on-call]
---
```

`Parent`, `Label`, `Folder` and `Attachment` are all singular-as-header and plural-in-front-matter, so properties follow the pattern rather than inventing a second one.

**The two forms are not quite equal**, and that difference belongs to the formats rather than being a choice: a content property holds JSON, so front matter can give a number, a list or a mapping as the value, while a header line can only say a string. A test covers all three shapes through front matter.

## `--global-properties`

```bash
mark --global-properties confluence-properties.yaml --files "docs/**/*.md"
```

YAML, which is also how it reads JSON, since JSON is valid YAML — so a `.json` file works with no extra code. A document naming a property the file also names wins for its own page, being the more particular statement of the two.

The file is read once, before anything is published, so a malformed one is not discovered halfway through a repository.

## Unchanged properties are not rewritten

Confluence versions each content property. Rewriting an unchanged value would fill its history as surely as republishing an unchanged page fills the page's, so values are compared first — and compared by *what the JSON means* rather than how it was spelled, so whitespace or key order coming back from Confluence does not read as a change.

## Verification

Eight tests. With application stubbed out, the four that assert properties are set all fail. Separately, with only the unchanged-value skip removed:

```
--- FAIL: TestPropertyUnchangedIsNotRewritten
--- PASS: TestPropertyChangedIsRewritten
```

That pair matters together: the first proves the skip exists, the second proves it is not simply "never write". Also covered: global-vs-document precedence, a malformed `Property` header (must be `key=value`), and an unparseable properties file.

Full suite green under `-race`; `golangci-lint`: 0 issues; README documents both forms, the flag, and the JSON-value difference between them.