### PR TITLE
feat: let a document opt out of publishing with Synchronized: false

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ appended to the values from front matter.
 <!-- Label: <label 1> -->
 <!-- Label: <label 2> -->
 <!-- Property: <key>=<value> -->
+<!-- Synchronized: <true|false> -->
 <!-- Image-Align: <left|center|right> -->
 
 <page contents>
@@ -862,6 +863,33 @@ the parsed document, so a link that appears inside a code span or a fenced or
 indented code block is left alone -- a page documenting Markdown gets to show
 its examples unchanged. Files pulled in with `Include` are resolved along with
 the document that includes them.
+
+### Leaving a document unpublished
+
+A document can ask to be left out of a run:
+
+```markdown
+<!-- Synchronized: false -->
+```
+
+or, in YAML front matter:
+
+```yaml
+---
+title: Runbook
+synchronized: false
+---
+```
+
+Mark skips the file before it asks Confluence anything, so a document that has
+opted out costs no page lookup and uploads no attachments. Saying nothing means
+the document is published, which is the ordinary case; opting out has to be
+deliberate.
+
+A page that was published before is left exactly as it is -- Mark does not
+delete it, and does not report it as having lost its source file. Setting
+`Synchronized: true` again, or removing the header, resumes publishing to the
+same page.
 
 ### Confluence content properties
 

--- a/mark.go
+++ b/mark.go
@@ -372,6 +372,26 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		meta = nil
 	}
 
+	// Before anything is asked of Confluence: a document that has opted out
+	// should cost nothing, not a page lookup and an attachment upload it will
+	// not use.
+	if !meta.Publish() {
+		log.Info().Msgf("%s is not synchronized; leaving it alone", file)
+
+		// Looked up purely to mark the path as seen. A page somebody stopped
+		// synchronising is one they chose to keep, and a run that did not
+		// account for the file would read it as gone: the page is reported as
+		// having no source file and its mapping is dropped, so synchronising it
+		// again later would no longer know which page was already its own.
+		if tracker != nil && meta != nil && meta.Space != "" {
+			if _, _, err := tracker.Lookup(meta.Space, file); err != nil {
+				return nil, nil, fmt.Errorf("unable to look up page mapping for %q: %w", file, err)
+			}
+		}
+
+		return nil, nil, nil
+	}
+
 	if config.PageID == "" && meta == nil {
 		return nil, nil, fmt.Errorf(
 			"specified file doesn't contain metadata and URL is not specified " +

--- a/mark_synchronized_test.go
+++ b/mark_synchronized_test.go
@@ -1,0 +1,152 @@
+package mark
+
+import (
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/kovetskiy/mark/v16/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func synchronizedServer(t *testing.T) *confluencetest.Server {
+	t.Helper()
+
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	return server
+}
+
+// TestSynchronizedFalseHeaderSkipsTheFile covers the header form.
+func TestSynchronizedFalseHeaderSkipsTheFile(t *testing.T) {
+	server := synchronizedServer(t)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Draft -->\n"+
+			"<!-- Synchronized: false -->\n\nNot ready.\n")
+
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"}, Output: io.Discard,
+	}))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	page, err := api.FindPage("DOCS", "Draft", "page")
+	require.NoError(t, err)
+	assert.Nil(t, page, "an unsynchronized document must not be published")
+}
+
+// TestSynchronizedFalseFrontMatterSkipsTheFile covers the front matter form.
+func TestSynchronizedFalseFrontMatterSkipsTheFile(t *testing.T) {
+	server := synchronizedServer(t)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md",
+		"---\ntitle: Draft\nspace: DOCS\nparents:\n  - Parent\nsynchronized: false\n---\n\nNot ready.\n")
+
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention", "frontmatter"},
+		Output: io.Discard,
+	}))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	page, err := api.FindPage("DOCS", "Draft", "page")
+	require.NoError(t, err)
+	assert.Nil(t, page, "an unsynchronized document must not be published")
+}
+
+// TestSynchronizedTrueAndAbsentBothPublish: opting out has to be deliberate,
+// and saying nothing is the ordinary case.
+func TestSynchronizedTrueAndAbsentBothPublish(t *testing.T) {
+	for name, header := range map[string]string{
+		"stated true": "<!-- Synchronized: true -->\n",
+		"not stated":  "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			server := synchronizedServer(t)
+
+			dir := t.TempDir()
+			writeFile(t, dir, "doc.md",
+				"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Doc -->\n"+
+					header+"\nBody.\n")
+
+			require.NoError(t, Run(Config{
+				BaseURL: server.URL, Username: "user", Password: "token",
+				Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+				Output: io.Discard,
+			}))
+
+			api := confluence.NewAPI(server.URL, "user", "token", false)
+			page, err := api.FindPage("DOCS", "Doc", "page")
+			require.NoError(t, err)
+			assert.NotNil(t, page)
+		})
+	}
+}
+
+// TestSynchronizedFalseKeepsTheMapping is the case that would hurt. Opting a
+// document out must not read as the file being gone: mark drops the page from
+// the manifest, and synchronising it again later would no longer know which
+// page was already its own -- publishing a second copy beside it.
+//
+// A second document in the same space is what makes this bite. Skipping every
+// file in a space leaves the manifest for that space unread, so nothing is
+// judged missing; it takes one page that does publish to load the mapping and
+// expose the skipped one as unaccounted for.
+func TestSynchronizedFalseKeepsTheMapping(t *testing.T) {
+	server := synchronizedServer(t)
+
+	dir := t.TempDir()
+	draft := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Draft -->\n"
+	writeFile(t, dir, "draft.md", draft+"\nBody.\n")
+	writeFile(t, dir, "other.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Other -->\n\nBody.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		TrackPages: true, Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	published, err := api.FindPage("DOCS", "Draft", "page")
+	require.NoError(t, err)
+	require.NotNil(t, published)
+
+	// Now the draft opts out, while its neighbour keeps publishing.
+	writeFile(t, dir, "draft.md", draft+"<!-- Synchronized: false -->\n\nBody.\n")
+	require.NoError(t, Run(config))
+
+	// The page is never deleted either way; a forgotten mapping is what causes
+	// a duplicate the next time it publishes.
+	require.NotNil(t, server.Page(published.ID))
+
+	entry, ok, err := manifest.NewStore(api).Lookup("DOCS", filepath.Join(dir, "draft.md"))
+	require.NoError(t, err)
+	require.True(t, ok, "the page mapping must survive a document opting out")
+	assert.Equal(t, published.ID, entry.PageID)
+}
+
+func TestSynchronizedRejectsANonBoolean(t *testing.T) {
+	server := synchronizedServer(t)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Title: Doc -->\n<!-- Synchronized: maybe -->\n\nBody.\n")
+
+	err := Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Output: io.Discard,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "true or false")
+}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -19,21 +19,22 @@ import (
 )
 
 const (
-	HeaderParent      = `Parent`
-	HeaderFolder      = `Folder`
-	HeaderSpace       = `Space`
-	HeaderType        = `Type`
-	HeaderTitle       = `Title`
-	HeaderLayout      = `Layout`
-	HeaderEmoji       = `Emoji`
-	HeaderAttachment  = `Attachment`
-	HeaderLabel       = `Label`
-	HeaderOrder       = `Order`
-	HeaderInclude     = `Include`
-	HeaderSidebar     = `Sidebar`
-	ContentAppearance = `Content-Appearance`
-	HeaderImageAlign  = `Image-Align`
-	HeaderProperty    = `Property`
+	HeaderParent       = `Parent`
+	HeaderFolder       = `Folder`
+	HeaderSpace        = `Space`
+	HeaderType         = `Type`
+	HeaderTitle        = `Title`
+	HeaderLayout       = `Layout`
+	HeaderEmoji        = `Emoji`
+	HeaderAttachment   = `Attachment`
+	HeaderLabel        = `Label`
+	HeaderOrder        = `Order`
+	HeaderInclude      = `Include`
+	HeaderSidebar      = `Sidebar`
+	ContentAppearance  = `Content-Appearance`
+	HeaderImageAlign   = `Image-Align`
+	HeaderProperty     = `Property`
+	HeaderSynchronized = `Synchronized`
 )
 
 type Meta struct {
@@ -48,6 +49,13 @@ type Meta struct {
 	Attachments       []string
 	Labels            []string
 	ContentAppearance string
+
+	// Synchronized is whether the document is published at all. Nil means it
+	// said nothing, which is not the same as false: a pointer keeps the
+	// difference between a document opting out and a Meta that simply never
+	// mentioned it, so that no code path can accidentally skip a page by
+	// leaving a field at its zero value.
+	Synchronized *bool
 
 	// Properties are Confluence content properties to set on the page.
 	//
@@ -85,6 +93,21 @@ func toStringSlice(val any) []string {
 		}
 	}
 	return res
+}
+
+// toBool reads a front matter boolean, which YAML gives as a bool but a quoted
+// document gives as a string.
+func toBool(val any) (bool, bool) {
+	switch v := val.(type) {
+	case bool:
+		return v, true
+	case string:
+		parsed, err := strconv.ParseBool(strings.TrimSpace(v))
+
+		return parsed, err == nil
+	default:
+		return false, false
+	}
 }
 
 // toStringMap reads a front matter mapping, keeping the values as written.
@@ -201,6 +224,14 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 				setContentAppearance(meta, toString(v))
 			case "imagealign":
 				meta.ImageAlign = strings.ToLower(toString(v))
+			case "synchronized":
+				value, ok := toBool(v)
+				if !ok {
+					return nil, nil, fmt.Errorf(
+						"synchronized must be true or false, got %v", v,
+					)
+				}
+				meta.Synchronized = &value
 			case "properties":
 				for key, value := range toStringMap(v) {
 					if meta.Properties == nil {
@@ -303,6 +334,16 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 
 				case HeaderImageAlign:
 					meta.ImageAlign = strings.ToLower(strings.TrimSpace(value))
+
+				case HeaderSynchronized:
+					synchronized, err := strconv.ParseBool(strings.TrimSpace(value))
+					if err != nil {
+						return nil, nil, fmt.Errorf(
+							"%s header must be true or false, got %q",
+							HeaderSynchronized, value,
+						)
+					}
+					meta.Synchronized = &synchronized
 
 				case HeaderProperty:
 					key, propValue, ok := strings.Cut(value, "=")
@@ -462,4 +503,17 @@ func parseHeaderComment(line string) (string, string, bool) {
 	key := strings.TrimSpace(content[:colonIdx])
 	value := strings.TrimSpace(content[colonIdx+1:])
 	return key, value, true
+}
+
+// Publish reports whether a document asks to be published.
+//
+// Saying nothing means yes: a repository full of documents that never mention
+// synchronisation is the ordinary case, and it is the opting out that has to be
+// deliberate.
+func (meta *Meta) Publish() bool {
+	if meta == nil || meta.Synchronized == nil {
+		return true
+	}
+
+	return *meta.Synchronized
 }


### PR DESCRIPTION
A repository often holds documents that are not for Confluence — a draft, a README about the docs themselves, a runbook that lives elsewhere. Until now the only way to keep one out of a run was to arrange the `--files` pattern around it, which puts the decision in the CI configuration rather than in the document it concerns.

## Both forms

```markdown
<!-- Synchronized: false -->
```

```yaml
---
title: Runbook
synchronized: false
---
```

Singular in both, because the value is one thing rather than a list — the way `Space`, `Title` and `Layout` already read. (`Parent`/`parents` and `Label`/`labels` differ only because those *are* lists.)

The file is skipped before Confluence is asked anything, so a document that has opted out costs no page lookup and uploads no attachments.

**Saying nothing means published.** The field is a `*bool` for that reason: it keeps "said nothing" apart from "said false", so no code path can skip a page by leaving a field at its zero value. `Order *int` already works this way for the same kind of reason.

## The part worth reviewing

A page whose document stops synchronising has to stay accounted for. Otherwise the run reads the file as gone: the page is reported as having lost its source file and **its mapping is dropped from the manifest** — so synchronising it again later would not know which page was already its own, and would publish a second copy beside it.

Note this is about the *mapping*, not the page: mark never deletes pages, and `PruneOrphans` only forgets them. The duplicate is the actual damage.

This has a subtlety I got wrong first time. My initial test asserted the mapping survived and **passed with the fix removed** — because if every file in a space is skipped, the manifest for that space is never read, so nothing is judged missing. It takes one page that *does* publish to load the mapping and expose the skipped one as unaccounted for. The test now includes a second document in the same space, and fails without the fix:

```
Error: Should be true
Messages: the page mapping must survive a document opting out
```

## Verification

Six tests: both forms skip the file; stated `true` and no header both publish (opting out must be deliberate); a non-boolean value is rejected; and the mapping case above.

Full suite green under `-race`; `golangci-lint`: 0 issues; README documents both forms and what happens to an already-published page.