### PR TITLE
fix: restore macros that span blocks, keeping code samples safe

### DIFF
--- a/includes/templates.go
+++ b/includes/templates.go
@@ -22,6 +22,13 @@ type IncludeDirective struct {
 }
 
 func findIncludeDirectiveBounds(s string) (startIdx int, endIdx int) {
+	return findIncludeDirective(s, nil)
+}
+
+// findIncludeDirective finds the first Include directive that skip does not
+// reject, which is how a directive shown inside a code block is passed over
+// rather than acted on.
+func findIncludeDirective(s string, skip func(offset int) bool) (startIdx int, endIdx int) {
 	searchFrom := 0
 	for {
 		start := strings.Index(s[searchFrom:], "<!--")
@@ -41,7 +48,7 @@ func findIncludeDirectiveBounds(s string) (startIdx int, endIdx int) {
 
 		comment := s[startIdx:endIdx]
 		trimmed := strings.TrimSpace(comment[4 : len(comment)-3])
-		if strings.HasPrefix(trimmed, "Include:") {
+		if strings.HasPrefix(trimmed, "Include:") && (skip == nil || !skip(startIdx)) {
 			return startIdx, endIdx
 		}
 
@@ -199,7 +206,14 @@ func ProcessIncludesWithStack(
 	}
 
 	s := string(contents)
-	startIdx, endIdx := findIncludeDirectiveBounds(s)
+
+	// A directive inside a code block is a code sample: a page documenting how
+	// to write an Include had the file pulled in where its own example should
+	// have been.
+	code := metadata.CodeRegions(contents)
+	startIdx, endIdx := findIncludeDirective(s, func(offset int) bool {
+		return metadata.InCode(code, offset)
+	})
 	if startIdx == -1 {
 		return templates, contents, false, nil
 	}

--- a/macro/macro.go
+++ b/macro/macro.go
@@ -8,6 +8,7 @@ import (
 	"text/template"
 
 	"github.com/kovetskiy/mark/v16/includes"
+	"github.com/kovetskiy/mark/v16/metadata"
 	"github.com/rs/zerolog/log"
 	"go.yaml.in/yaml/v3"
 )
@@ -81,8 +82,15 @@ func (macro *Macro) Apply(
 ) ([]byte, error) {
 	var err error
 
-	content = macro.Regexp.ReplaceAllFunc(
-		content,
+	// Where the code is, so that a macro pattern shown inside a fenced block or
+	// a code span is left as the sample it is. Only the start of a match is
+	// judged: a macro that wraps a region of the document may perfectly well
+	// have code inside it, and refusing that would break the very macros this
+	// is protecting.
+	code := metadata.CodeRegions(content)
+
+	content = replaceAllOutsideCode(
+		macro.Regexp, content, code,
 		func(match []byte) []byte {
 			config := map[string]any{}
 
@@ -124,6 +132,37 @@ func (macro *Macro) Apply(
 	)
 
 	return content, err
+}
+
+// replaceAllOutsideCode is regexp.ReplaceAllFunc with the matches that begin
+// inside code left alone.
+func replaceAllOutsideCode(
+	re *regexp.Regexp,
+	content []byte,
+	code []metadata.Region,
+	expand func(match []byte) []byte,
+) []byte {
+	matches := re.FindAllIndex(content, -1)
+	if len(matches) == 0 {
+		return content
+	}
+
+	var out bytes.Buffer
+	last := 0
+
+	for _, match := range matches {
+		if metadata.InCode(code, match[0]) {
+			continue
+		}
+
+		out.Write(content[last:match[0]])
+		out.Write(expand(content[match[0]:match[1]]))
+		last = match[1]
+	}
+
+	out.Write(content[last:])
+
+	return out.Bytes()
 }
 
 func (macro *Macro) configure(node any, groups [][]byte) any {

--- a/markdown/macro_code_test.go
+++ b/markdown/macro_code_test.go
@@ -110,3 +110,52 @@ func TestIncludedContentStillGetsMacros(t *testing.T) {
 	assert.Contains(t, out, `<ac:parameter ac:name="key">MYJIRA-123</ac:parameter>`,
 		"a macro must still apply to included text")
 }
+
+// TestRegionMacroWrapsBlocks covers a macro whose pattern spans block
+// boundaries: two markers with everything between them captured, which is how
+// the ac:details collapsible is written.
+//
+// This is the shape an AST-based expansion cannot express. Matching per text
+// node can never see across a paragraph into a list, and the definition itself
+// contains "-->", so the parser ended the directive halfway through it and the
+// rest of the definition rendered as an indented code block.
+func TestRegionMacroWrapsBlocks(t *testing.T) {
+	out := compile(t, "testdata/x.md",
+		"<!-- Macro: <!-- ac:details -->([^:][\\s\\S]*?)<!-- ac:details end -->\n"+
+			"     Template: ac:details\n"+
+			"     Body: ${1} -->\n\n"+
+			"Before.\n\n"+
+			"<!-- ac:details -->\n"+
+			"Hidden paragraph.\n\n"+
+			"- a list item\n"+
+			"<!-- ac:details end -->\n\n"+
+			"After.\n")
+
+	assert.Contains(t, out, `<ac:structured-macro ac:name="details"`,
+		"the region must become a details macro")
+	assert.Contains(t, out, "<li>a list item</li>",
+		"blocks inside the region must still be parsed as blocks")
+	assert.Contains(t, out, "</ac:rich-text-body></ac:structured-macro>",
+		"the macro must close after the region")
+	assert.NotContains(t, out, "ac:details end",
+		"the markers must be consumed")
+	assert.NotContains(t, out, "Body: ${1}",
+		"the definition must not survive into the page")
+}
+
+// TestRegionMacroKeepsCodeInsideIt: a region macro may perfectly well wrap a
+// fenced block, and refusing that would break the macros the code check exists
+// to protect.
+func TestRegionMacroKeepsCodeInsideIt(t *testing.T) {
+	out := compile(t, "testdata/x.md",
+		"<!-- Macro: <!-- ac:details -->([^:][\\s\\S]*?)<!-- ac:details end -->\n"+
+			"     Template: ac:details\n"+
+			"     Body: ${1} -->\n\n"+
+			"<!-- ac:details -->\n"+
+			"```\nsample code\n```\n"+
+			"<!-- ac:details end -->\n")
+
+	assert.Contains(t, out, `<ac:structured-macro ac:name="details"`,
+		"a region containing code must still expand")
+	assert.Contains(t, out, "sample code")
+}

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -173,7 +173,41 @@ func compileMarkdownWithExtension(markdown []byte, ext goldmark.Extender, logMes
 }
 
 func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib, path string, cfg types.MarkConfig) (string, []attachment.Attachment, error) {
+	var tmpl *template.Template
+	if stdlib != nil {
+		tmpl = stdlib.Templates
+	} else {
+		tmpl = template.New("stdlib")
+	}
+
 	var err error
+	var recurse bool
+	for {
+		tmpl, markdown, recurse, err = includes.ProcessIncludes(
+			filepath.Dir(path),
+			cfg.IncludePath,
+			markdown,
+			tmpl,
+		)
+		if err != nil {
+			return "", nil, fmt.Errorf("unable to process includes: %w", err)
+		}
+		if !recurse {
+			break
+		}
+	}
+
+	var macros []macro.Macro
+	macros, markdown, err = macro.ExtractMacros(filepath.Dir(path), cfg.IncludePath, markdown, tmpl)
+	if err != nil {
+		return "", nil, fmt.Errorf("unable to extract macros: %w", err)
+	}
+	for _, m := range macros {
+		markdown, err = m.Apply(markdown)
+		if err != nil {
+			return "", nil, fmt.Errorf("unable to apply macro %q: %w", m.Regexp.String(), err)
+		}
+	}
 
 	ghAlertsExtension := NewConfluenceExtension(stdlib, path, cfg)
 	htmlOutput, err := compileMarkdownWithExtension(markdown, ghAlertsExtension, "rendering markdown with GitHub Alerts support:\n%s")
@@ -261,10 +295,8 @@ func NewConfluenceExtension(stdlib *stdlib.Lib, path string, cfg types.MarkConfi
 		tmpl = stdlib.Templates
 	}
 	pipeline := ctransformer.NewPipelineTransformer(
-		// The base directory is the file's directory, not the file: a relative
-		// include is written relative to the document that asks for it.
-		ctransformer.NewMacroTransformer(path, filepath.Dir(path), cfg.IncludePath, tmpl),
-		ctransformer.NewIncludeTransformer(path, filepath.Dir(path), cfg.IncludePath, tmpl),
+		ctransformer.NewMacroTransformer(path, path, cfg.IncludePath, tmpl),
+		ctransformer.NewIncludeTransformer(path, path, cfg.IncludePath, tmpl),
 	)
 	return &ConfluenceExtension{
 		Config:          html.NewConfig(),

--- a/metadata/ignore.go
+++ b/metadata/ignore.go
@@ -140,51 +140,112 @@ func ignoreMarker(line string) marker {
 	}
 }
 
-// codeLines reports which lines of the document are inside a code block.
+// Region is a half-open byte range within a document.
+type Region struct {
+	Start int
+	Stop  int
+}
+
+// Contains reports whether offset falls inside the region.
+func (r Region) Contains(offset int) bool {
+	return offset >= r.Start && offset < r.Stop
+}
+
+// InCode reports whether offset falls inside any of the regions.
+func InCode(regions []Region, offset int) bool {
+	for _, region := range regions {
+		if region.Contains(offset) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// CodeRegions reports where the code is in a document.
 //
-// Both kinds count: a fenced block and an indented one. The fence lines
-// themselves are not included, which does not matter -- a fence is never a
-// marker -- and neither is a code span, since a marker has to be alone on its
-// line to be one at all.
-func codeLines(data []byte) map[int]bool {
-	code := map[int]bool{}
+// Fenced blocks, indented blocks and code spans, which between them are every
+// place a reader is being shown text rather than told something. Anything that
+// rewrites a document -- a macro, an include directive, an ignore marker -- has
+// to leave these alone, or a page documenting the feature has its own example
+// eaten by it.
+//
+// Asking the parser rather than looking for backticks is deliberate: tildes,
+// indented blocks, closing fences longer than their opener and nesting are all
+// easy to get subtly wrong, and goldmark already knows.
+func CodeRegions(data []byte) []Region {
+	var regions []Region
 
 	doc := goldmark.New().Parser().Parse(text.NewReader(data))
 
-	// Line numbers come from counting newlines before an offset, so the offsets
-	// are collected first and turned into lines in one pass over the document.
-	var spans [][2]int
 	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
 		}
 
-		switch node.(type) {
-		case *ast.FencedCodeBlock, *ast.CodeBlock:
-		default:
-			return ast.WalkContinue, nil
-		}
+		switch node.Kind() {
+		case ast.KindFencedCodeBlock, ast.KindCodeBlock:
+			lines := node.Lines()
+			if lines.Len() == 0 {
+				return ast.WalkContinue, nil
+			}
+			regions = append(regions, Region{
+				Start: lines.At(0).Start,
+				Stop:  lines.At(lines.Len() - 1).Stop,
+			})
 
-		lines := node.Lines()
-		if lines.Len() == 0 {
-			return ast.WalkContinue, nil
+		case ast.KindCodeSpan:
+			// A span's own segments live on its children.
+			first, last := node.FirstChild(), node.LastChild()
+			if first == nil || last == nil {
+				return ast.WalkContinue, nil
+			}
+			start, ok := segmentStart(first)
+			if !ok {
+				return ast.WalkContinue, nil
+			}
+			stop, ok := segmentStop(last)
+			if !ok {
+				return ast.WalkContinue, nil
+			}
+			regions = append(regions, Region{Start: start, Stop: stop})
 		}
-		spans = append(spans, [2]int{lines.At(0).Start, lines.At(lines.Len() - 1).Stop})
 
 		return ast.WalkContinue, nil
 	})
 
+	return regions
+}
+
+func segmentStart(node ast.Node) (int, bool) {
+	if t, ok := node.(*ast.Text); ok {
+		return t.Segment.Start, true
+	}
+
+	return 0, false
+}
+
+func segmentStop(node ast.Node) (int, bool) {
+	if t, ok := node.(*ast.Text); ok {
+		return t.Segment.Stop, true
+	}
+
+	return 0, false
+}
+
+// codeLines reports which lines of the document are inside code.
+func codeLines(data []byte) map[int]bool {
+	code := map[int]bool{}
+
+	spans := CodeRegions(data)
 	if len(spans) == 0 {
 		return code
 	}
 
 	line := 0
 	for offset := range data {
-		for _, span := range spans {
-			if offset >= span[0] && offset < span[1] {
-				code[line] = true
-				break
-			}
+		if InCode(spans, offset) {
+			code[line] = true
 		}
 		if data[offset] == '\n' {
 			line++

--- a/renderer/paragraph.go
+++ b/renderer/paragraph.go
@@ -23,38 +23,10 @@ func (r *ConfluenceParagraphRenderer) RegisterFuncs(reg renderer.NodeRendererFun
 	reg.Register(ast.KindParagraph, r.renderParagraph)
 }
 
-// startsWithRawMarkup reports whether a paragraph opens with markup that has to
-// reach Confluence as written.
-//
-// A paragraph that is really the opening tag of a macro must not be wrapped in
-// <p>: the tag stays open across the blocks that follow, and a <p> closed
-// around it produces markup Confluence rejects.
-//
-// Two shapes mean the same thing here. A tag parsed straight out of the
-// document is an ast.RawHTML. One that arrived by expanding a macro or an
-// include is an ast.String carrying its own bytes, because the expansion was
-// parsed from a different buffer than the document being rendered and a segment
-// into that buffer would be meaningless. Both are raw and code -- goldmark's
-// typographer also produces code strings, for em dashes and quotes, but never
-// marks them raw, so the pair is unambiguous.
-func startsWithRawMarkup(n ast.Node) bool {
-	if n == nil {
-		return false
-	}
-
-	if n.Kind() == ast.KindRawHTML {
-		return true
-	}
-
-	str, ok := n.(*ast.String)
-
-	return ok && str.IsRaw() && str.IsCode()
-}
-
 func (r *ConfluenceParagraphRenderer) renderParagraph(w util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
 	firstChild := n.FirstChild()
 	if entering {
-		if !startsWithRawMarkup(firstChild) {
+		if firstChild == nil || firstChild.Kind() != ast.KindRawHTML {
 			if n.Attributes() != nil {
 				_, _ = w.WriteString("<p")
 				html.RenderAttributes(w, n, html.ParagraphAttributeFilter)
@@ -64,7 +36,7 @@ func (r *ConfluenceParagraphRenderer) renderParagraph(w util.BufWriter, source [
 			}
 		}
 	} else {
-		if !startsWithRawMarkup(firstChild) {
+		if firstChild == nil || firstChild.Kind() != ast.KindRawHTML {
 			_, _ = w.WriteString("</p>")
 		}
 		_, _ = w.WriteString("\n")

--- a/transformer/include.go
+++ b/transformer/include.go
@@ -5,10 +5,14 @@ import (
 	"text/template"
 
 	"github.com/kovetskiy/mark/v16/includes"
+	cparser "github.com/kovetskiy/mark/v16/parser"
 	"github.com/rs/zerolog/log"
+	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
 )
 
 // IncludeTransformer transforms <!-- Include: ... --> directives in the Goldmark AST
@@ -115,7 +119,16 @@ func (t *IncludeTransformer) TransformWithModified(doc *ast.Document, reader tex
 		}
 		t.Templates = tmpl
 
-		p := newSubParser()
+		p := goldmark.New(
+			goldmark.WithParserOptions(
+				parser.WithInlineParsers(
+					util.Prioritized(cparser.NewConfluenceTagParser(), 99),
+				),
+			),
+			goldmark.WithRendererOptions(
+				html.WithUnsafe(),
+			),
+		).Parser()
 		subDoc := p.Parse(text.NewReader(expanded))
 		convertSegmentsToStrings(subDoc, expanded)
 

--- a/transformer/macro.go
+++ b/transformer/macro.go
@@ -5,10 +5,14 @@ import (
 	"text/template"
 
 	"github.com/kovetskiy/mark/v16/macro"
+	cparser "github.com/kovetskiy/mark/v16/parser"
 	"github.com/rs/zerolog/log"
+	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer/html"
 	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
 )
 
 // MacroTransformer extracts macro directives from HTML comment blocks in the Goldmark AST,
@@ -19,13 +23,6 @@ type MacroTransformer struct {
 	IncludePath string
 	Templates   *template.Template
 	Err         error
-
-	// macros accumulates across pipeline passes. A definition is removed from
-	// the tree as soon as it is read, so a transformer that rebuilt this list
-	// each pass would forget every macro it had already seen -- and the pass
-	// that matters is often a later one, after an include has brought in the
-	// text a macro was written for.
-	macros []macro.Macro
 }
 
 // NewMacroTransformer creates a new MacroTransformer instance.
@@ -102,6 +99,7 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 	})
 
 	modified := false
+	var extractedMacros []macro.Macro
 
 	for _, target := range targets {
 		macros, _, err := macro.ExtractMacros(t.BaseDir, t.IncludePath, target.fullRawContent, t.Templates)
@@ -117,7 +115,7 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 		if len(macros) == 0 {
 			continue
 		}
-		t.macros = append(t.macros, macros...)
+		extractedMacros = append(extractedMacros, macros...)
 
 		for _, n := range target.nodesToRemove {
 			if n.Parent() != nil {
@@ -128,7 +126,7 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 		modified = true
 	}
 
-	for _, m := range t.macros {
+	for _, m := range extractedMacros {
 		var textNodesToReplace []struct {
 			node    ast.Node
 			val     []byte
@@ -140,26 +138,9 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 				return ast.WalkContinue, nil
 			}
 
-			// Leaf text only. Matching whole paragraphs as well caught the
-			// same words twice, and a paragraph's text includes whatever is
-			// inside its code spans -- so a macro pattern mentioned in
-			// `backticks` was expanded along with the prose around it.
-			//
-			// Both kinds of leaf count. Text is what the document itself was
-			// parsed into; a plain String is text an include brought in, which
-			// a macro is just as entitled to act on. A String carrying markup
-			// is not text at all and is left alone.
-			switch n := node.(type) {
-			case *ast.Text:
-			case *ast.String:
-				if n.IsRaw() || n.IsCode() {
-					return ast.WalkContinue, nil
-				}
+			switch node.(type) {
+			case *ast.Paragraph, *ast.Text:
 			default:
-				return ast.WalkContinue, nil
-			}
-
-			if insideCode(node) || isExpansion(node) {
 				return ast.WalkContinue, nil
 			}
 
@@ -197,23 +178,33 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 				continue
 			}
 
-			// Whitespace at either end has to be held back and put in again
-			// afterwards. Parsing is what loses it: the expansion is parsed as
-			// a document of its own, and a document does not begin with a
-			// space, so " MYJIRA-123." came back as "<ac:.../>." and the word
-			// before it ran into the macro.
-			lead, trail, body := splitEdgeSpace(expanded)
-
-			p := newSubParser()
-			subDoc := p.Parse(text.NewReader(body))
-			convertSegmentsToStrings(subDoc, body)
+			p := goldmark.New(
+				goldmark.WithParserOptions(
+					parser.WithInlineParsers(
+						util.Prioritized(cparser.NewConfluenceTagParser(), 99),
+					),
+				),
+				goldmark.WithRendererOptions(
+					html.WithUnsafe(),
+				),
+			).Parser()
+			subDoc := p.Parse(text.NewReader(expanded))
+			convertSegmentsToStrings(subDoc, expanded)
 
 			parent := item.node.Parent()
 			if parent == nil {
 				continue
 			}
 
-			spliceExpansion(parent, item.node, subDoc, lead, trail)
+			for subDoc.FirstChild() != nil {
+				child := subDoc.FirstChild()
+				subDoc.RemoveChild(subDoc, child)
+				parent.InsertBefore(parent, item.node, child)
+			}
+
+			if item.node.Parent() != nil {
+				item.node.Parent().RemoveChild(item.node.Parent(), item.node)
+			}
 
 			modified = true
 		}

--- a/transformer/util.go
+++ b/transformer/util.go
@@ -4,12 +4,7 @@ import (
 	"bytes"
 	"sync"
 
-	cparser "github.com/kovetskiy/mark/v16/parser"
-	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
-	"github.com/yuin/goldmark/extension"
-	"github.com/yuin/goldmark/parser"
-	"github.com/yuin/goldmark/util"
 )
 
 var bufferPool = sync.Pool{
@@ -180,163 +175,10 @@ func convertSegmentsToStrings(doc ast.Node, source []byte) {
 		if parent != nil {
 			strNode := ast.NewString(item.val)
 			if item.isRaw {
-				// Both flags, and the second is the one that matters. goldmark's
-				// "raw" only means backslash escapes are not processed -- its
-				// RawWrite still runs every byte through EscapeHTMLByte, so a
-				// string marked raw alone comes out as &lt;ac:structured-macro.
-				// IsCode is what writes the value verbatim, which is what
-				// Confluence markup from a macro or an include has to be.
 				strNode.SetRaw(true)
-				strNode.SetCode(true)
 			}
 			parent.InsertBefore(parent, item.node, strNode)
 			parent.RemoveChild(parent, item.node)
 		}
 	}
-}
-
-// newSubParser builds the parser used for content that arrives by expanding a
-// macro or an include.
-//
-// It carries the block extensions the document itself is parsed with, because
-// the expansion is ordinary Markdown and an author expects it to behave that
-// way: a macro whose body is a table should produce a table, not a paragraph of
-// pipes. The mark extension is deliberately not among them -- it is what is
-// running right now, and the pipeline already re-runs until the tree settles,
-// so nesting a second copy here would only find the same work twice.
-func newSubParser() parser.Parser {
-	return goldmark.New(
-		goldmark.WithExtensions(
-			extension.Footnote,
-			extension.DefinitionList,
-			extension.NewTable(
-				extension.WithTableCellAlignMethod(extension.TableCellAlignStyle),
-			),
-			extension.GFM,
-		),
-		goldmark.WithParserOptions(
-			parser.WithInlineParsers(
-				// Above goldmark's link parser, so <ac:.../> tags are kept whole
-				// rather than picked apart.
-				util.Prioritized(cparser.NewConfluenceTagParser(), 99),
-			),
-		),
-	).Parser()
-}
-
-// insideCode reports whether a node sits within a code span.
-//
-// Text in a code span is a sample, not something to substitute into. Fenced and
-// indented blocks need no check: their content is a CodeBlock, which is not a
-// node kind macro substitution looks at in the first place.
-func insideCode(node ast.Node) bool {
-	for n := node; n != nil; n = n.Parent() {
-		if n.Kind() == ast.KindCodeSpan {
-			return true
-		}
-	}
-
-	return false
-}
-
-// expandedAttr marks a node as something a macro produced.
-//
-// The pipeline runs until the tree stops changing, so a macro's output is
-// offered back to it on the next pass. That matters because macro output
-// routinely contains the text that matched it -- the jira macro turns
-// MYJIRA-123 into a tag with MYJIRA-123 inside -- and without a marker the
-// second pass expands the expansion, nesting one macro inside another.
-//
-// Content brought in by an *include* is deliberately not marked. A document
-// that includes a fragment expects macros to apply to it, and that is the one
-// thing separating the two cases: an include yields text to work on, a macro
-// yields its own finished output.
-var expandedAttr = []byte("mark:macro-expanded")
-
-func markExpanded(node ast.Node) {
-	node.SetAttribute(expandedAttr, true)
-	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
-		markExpanded(child)
-	}
-}
-
-// isExpansion reports whether a node, or anything it sits inside, is macro
-// output.
-func isExpansion(node ast.Node) bool {
-	for n := node; n != nil; n = n.Parent() {
-		if _, ok := n.Attribute(expandedAttr); ok {
-			return true
-		}
-	}
-
-	return false
-}
-
-// spliceExpansion puts a macro's expansion where the text that matched it was.
-//
-// What the expansion replaces depends on its shape. One that parsed to a single
-// paragraph is inline -- an issue key becoming a status lozenge -- and its
-// inline children take the place of the matched text, leaving the surrounding
-// sentence intact. Anything else is a block: a macro wrapping a list or a
-// table cannot live inside the paragraph that named it, so it replaces that
-// paragraph outright.
-//
-// The block case is only taken when the matched text was the paragraph's whole
-// content. A paragraph holding a block macro and a sentence beside it has no
-// correct reading, and dropping the sentence to place the block would lose
-// what the author wrote.
-func spliceExpansion(parent ast.Node, matched ast.Node, subDoc ast.Node, lead, trail []byte) {
-	first := subDoc.FirstChild()
-	inline := first != nil && first == subDoc.LastChild() && first.Kind() == ast.KindParagraph
-
-	if !inline && parent.Kind() == ast.KindParagraph &&
-		parent.FirstChild() == matched && parent.LastChild() == matched &&
-		parent.Parent() != nil {
-		grandparent := parent.Parent()
-		for subDoc.FirstChild() != nil {
-			child := subDoc.FirstChild()
-			subDoc.RemoveChild(subDoc, child)
-			markExpanded(child)
-			grandparent.InsertBefore(grandparent, parent, child)
-		}
-		grandparent.RemoveChild(grandparent, parent)
-
-		return
-	}
-
-	source := subDoc
-	if inline {
-		// Unwrap: the paragraph the sub-parse wrapped its inlines in would
-		// otherwise be nested inside the paragraph being edited.
-		source = first
-	}
-
-	if inline && len(lead) > 0 {
-		parent.InsertBefore(parent, matched, ast.NewString(lead))
-	}
-
-	for source.FirstChild() != nil {
-		child := source.FirstChild()
-		source.RemoveChild(source, child)
-		markExpanded(child)
-		parent.InsertBefore(parent, matched, child)
-	}
-
-	if inline && len(trail) > 0 {
-		parent.InsertBefore(parent, matched, ast.NewString(trail))
-	}
-
-	parent.RemoveChild(parent, matched)
-}
-
-// splitEdgeSpace separates the whitespace at each end of an expansion from the
-// content between them.
-func splitEdgeSpace(data []byte) (lead, trail, body []byte) {
-	body = bytes.TrimLeft(data, " \t")
-	lead = data[:len(data)-len(body)]
-
-	trimmed := bytes.TrimRight(body, " \t")
-	trail = body[len(trimmed):]
-
-	return lead, trail, trimmed
 }


### PR DESCRIPTION
**Fixes a regression I introduced in #893.** Reported against the collapsible-section idiom:

```markdown
<!-- Macro: <!-- ac:details -->([^:][\s\S]*?)<!-- ac:details end -->
     Template: ac:details
     Body: ${1} -->
```

## What broke

On master this does not merely fail to expand — the page is wrecked:

```html
<!-- Macro: <!-- ac:details -->([^:][\s\S]*?)<!-- ac:details end -->
<ac:structured-macro ac:name="code">…<![CDATA[ Template: ac:details
 Body: ${1} -->]]></ac:plain-text-body></ac:structured-macro>
```

The definition is emitted raw, its continuation lines are published as a **code block**, and the markers pass through untouched.

**Two independent causes, both fatal:**

1. **The definition is truncated.** goldmark ends an HTML block at the first `-->`. This regex *contains* `-->`, so the transformer's "join siblings until `-->`" logic never fires — it sees one already on line 1. The orphaned lines are 5-space indented, hence the code block.
2. **The pattern cannot match regardless.** `[\s\S]*?` has to span block boundaries; #893 matches per leaf text node, which can never see out of one block into the next.

Fixing (1) alone would not help. (2) is architectural: **a macro is a regular expression over the document, and documents rely on that.** An AST-node-scoped expansion cannot express it.

## The fix

Expansion goes back to the text, and only *where the code is* moves to the parser — exactly the arrangement `ac:ignore` already uses (#889).

Fenced blocks, indented blocks and code spans are collected before a macro is applied, and a match beginning inside one is passed over. Same for `Include` directives. So a page documenting a macro keeps its example, which is what #893 was for.

**Only the start of a match is judged.** A region macro may perfectly well wrap a fenced block, and refusing to expand one that does would break the very macros this protects. There is a test for that.

`metadata.CodeRegions` is now shared by all three callers, and `codeLines` (from #889) is reimplemented on top of it rather than duplicating the walk.

## Verification

The two properties have never both held before. Same four tests, three states:

| | region macros | code samples safe |
|---|---|---|
| before #893 | ✅ | ❌ |
| master today | ❌ | ✅ |
| this branch | ✅ | ✅ |

Confirmed by running the tests in worktrees at each commit — `TestRegionMacroWrapsBlocks` fails on master, `TestMacroInsideCodeIsLeftAlone` fails on `4bc7558^`.

## What this gives up

The AST transformers go back to being shadowed by the text passes, as they were before #893, and the escaping/splicing/paragraph fixes from that PR go with the revert. They are in the history if the AST route is ever taken again — but it would need a way to express a match across blocks before it could replace this.

Full suite green under `-race`; `golangci-lint`: 0 issues.