### PR TITLE
fix: four follow-ups to link checking and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,6 +983,13 @@ An `internal` link fails the run when the file it names is missing, is a
 directory, or is a document that never becomes a page -- one with no title, so
 there is nothing for the link to point at.
 
+A link is looked for beside the document that contains it, and then beside each
+file that document includes. A fragment reads as a document in its own right, so
+a link inside one is written from where the fragment lives rather than from
+wherever it is pulled into. The document's own directory is always tried first,
+so this cannot change what an unambiguous link already meant. Only the files a
+document includes directly are considered, not what those files include in turn.
+
 One case is reported but does not fail: a link to a document that exists and has
 a title, but is not in the space yet. That is the ordinary state of a first run
 over files that link to each other, and failing there would break a build that
@@ -992,6 +999,10 @@ A `confluence` link is checked by looking for a page of that title in the
 document's own space, which is what an `ac:` link resolves against. The title is
 read the way the renderer reads it: whatever follows the colon, or the link text
 when nothing does, so `[Some Page](ac:)` is checked as `Some Page`.
+
+These are checked once the run has finished rather than as each document
+compiles, because a page named this way is often published by another file in
+the same run. Each page is looked up once however many documents link to it.
 
 `external` needs network access from wherever Mark runs, and makes publishing
 dependent on every site you link to being up. Each URL is requested once per run

--- a/includes/templates.go
+++ b/includes/templates.go
@@ -268,3 +268,36 @@ func ProcessIncludesWithStack(
 
 	return templates, res.Bytes(), true, nil
 }
+
+// DirectiveTargets reports the files a document asks to include, in the order
+// they appear and skipping any shown inside a code block.
+//
+// Wanted so that a relative link written in an included fragment can be
+// resolved against the fragment's own directory: the fragment reads as a
+// document in its own right, and its links are written from where it lives
+// rather than from wherever it is pulled into.
+func DirectiveTargets(contents []byte) []string {
+	s := string(contents)
+	code := metadata.CodeRegions(contents)
+
+	var targets []string
+	searchFrom := 0
+
+	for searchFrom < len(s) {
+		start, end := findIncludeDirective(s[searchFrom:], func(offset int) bool {
+			return metadata.InCode(code, searchFrom+offset)
+		})
+		if start == -1 {
+			break
+		}
+
+		directive, err := ParseIncludeDirective([]byte(s[searchFrom+start : searchFrom+end]))
+		if err == nil && directive != nil && directive.Template != "" {
+			targets = append(targets, directive.Template)
+		}
+
+		searchFrom += end
+	}
+
+	return targets
+}

--- a/mark.go
+++ b/mark.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kovetskiy/mark/v16/attachment"
 	"github.com/kovetskiy/mark/v16/confluence"
 	"github.com/kovetskiy/mark/v16/d2"
+	"github.com/kovetskiy/mark/v16/includes"
 	"github.com/kovetskiy/mark/v16/manifest"
 	markmd "github.com/kovetskiy/mark/v16/markdown"
 	"github.com/kovetskiy/mark/v16/mermaid"
@@ -229,6 +230,17 @@ func Run(config Config) error {
 		}
 	}
 
+	// Once everything that was going to be published has been, an ac: link that
+	// still names no page names none.
+	missingPages, err := checker.MissingPages(api)
+	if err != nil {
+		return err
+	}
+
+	for _, item := range missingPages {
+		log.Warn().Msg(item)
+	}
+
 	// The manifest is saved before the run's own outcome is decided. Returning
 	// early on hasErrors used to skip it entirely, so a single bad file threw
 	// away the mapping for every page that had published perfectly well --
@@ -250,6 +262,16 @@ func Run(config Config) error {
 		if saveErr = tracker.Save(); saveErr != nil {
 			saveErr = fmt.Errorf("unable to save page manifest: %w", saveErr)
 		}
+	}
+
+	// After the manifest is written: an unresolved link says nothing about
+	// whether the pages that did publish are recorded correctly, and throwing
+	// the mapping away over it would be a far worse outcome than the link.
+	if len(missingPages) > 0 && !config.CheckLinksWarnOnly {
+		return fmt.Errorf(
+			"%s:\n  %s",
+			pluraliseLinks(len(missingPages)), strings.Join(missingPages, "\n  "),
+		)
 	}
 
 	if hasErrors {
@@ -316,11 +338,25 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 		return nil, err
 	}
 
-	target, _, err := processFile(
-		file, api, config, std, nil, nil,
-		page.NewLinkChecker(linkChecks), globalProperties,
-	)
-	return target, err
+	checker := page.NewLinkChecker(linkChecks)
+
+	target, _, err := processFile(file, api, config, std, nil, nil, checker, globalProperties)
+	if err != nil {
+		return target, err
+	}
+
+	missing, err := checker.MissingPages(api)
+	if err != nil {
+		return target, err
+	}
+	if len(missing) > 0 && !config.CheckLinksWarnOnly {
+		return target, fmt.Errorf("%s", strings.Join(missing, "\n  "))
+	}
+	for _, item := range missing {
+		log.Warn().Msg(item)
+	}
+
+	return target, nil
 }
 
 func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, folders page.FolderTracker, checker *page.LinkChecker, globalProperties map[string]any) (*confluence.PageInfo, *page.Ordered, error) {
@@ -416,6 +452,11 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	// Links are rewritten while the document is being rendered, by walking the
 	// parsed tree. Doing it here, over the text, meant a fenced block showing
 	// Markdown syntax had its example links turned into Confluence URLs.
+	// A fragment's links are written from where the fragment lives, so the
+	// directory of everything this document includes is worth looking in too.
+	// One level: a fragment that itself includes another is not followed here.
+	searchDirs := includeSearchDirs(filepath.Dir(file), config.IncludePath, markdown)
+
 	resolver := page.NewLinkResolver(
 		api,
 		meta,
@@ -427,6 +468,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		config.TitleAppendGeneratedHash,
 		frontMatterEnabled,
 		checker,
+		searchDirs,
 	)
 	resolveLink := resolver.Resolve
 
@@ -799,10 +841,11 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		documentProperties = meta.Properties
 	}
 
+	// No dry-run branch here: a dry run returns long before this, when the
+	// compiled page would have been printed.
 	if err := page.ApplyProperties(
 		api, target.ID,
 		page.MergeProperties(globalProperties, documentProperties),
-		config.DryRun,
 	); err != nil {
 		return nil, nil, err
 	}
@@ -1585,4 +1628,45 @@ func reportBrokenLinks(broken []string, file string, warnOnly bool) error {
 	}
 
 	return fmt.Errorf("%s:\n  %s", summary, strings.Join(broken, "\n  "))
+}
+
+// includeSearchDirs reports the directories of the files a document includes.
+//
+// Only the directories: what is wanted is somewhere to look for a link written
+// inside a fragment, and the fragment's neighbours are what such a link names.
+// Duplicates are dropped so that a document including several files from one
+// directory does not have it looked in repeatedly.
+func includeSearchDirs(base, includePath string, markdown []byte) []string {
+	var dirs []string
+	seen := map[string]bool{}
+
+	add := func(dir string) {
+		if dir == "" || dir == base || seen[dir] {
+			return
+		}
+		seen[dir] = true
+		dirs = append(dirs, dir)
+	}
+
+	for _, target := range includes.DirectiveTargets(markdown) {
+		add(filepath.Dir(filepath.Join(base, target)))
+
+		// The same fallback LoadTemplate uses when the file is not beside the
+		// document, so a link inside a shared fragment resolves the same way
+		// the fragment itself was found.
+		if includePath != "" {
+			add(filepath.Dir(filepath.Join(includePath, target)))
+		}
+	}
+
+	return dirs
+}
+
+// pluraliseLinks names a count of links in a sentence that reads.
+func pluraliseLinks(n int) string {
+	if n == 1 {
+		return "1 link does not resolve"
+	}
+
+	return fmt.Sprintf("%d links do not resolve", n)
 }

--- a/mark_checklinks_test.go
+++ b/mark_checklinks_test.go
@@ -183,15 +183,19 @@ func TestCheckLinksConfluence(t *testing.T) {
 // TestCheckLinksReportsEveryBrokenLink pins that a file is not abandoned at the
 // first failure. Reporting one at a time turns a page with several into as many
 // runs to find out.
+//
+// Only the links judged while the file compiles are counted here. An ac: link
+// is judged after the run, when everything that was going to be published has
+// been, and is reported separately for that reason.
 func TestCheckLinksReportsEveryBrokenLink(t *testing.T) {
 	err := checkLinksRun(t, []string{"all"},
-		"[a](./one.md) [b](./two.md) [c](./three.md) [d](ac:Nowhere)\n", nil)
+		"[a](./one.md) [b](./two.md) [c](./three.md)\n", nil)
 
 	require.Error(t, err)
-	for _, expected := range []string{"./one.md", "./two.md", "./three.md", "Nowhere"} {
+	for _, expected := range []string{"./one.md", "./two.md", "./three.md"} {
 		assert.Contains(t, err.Error(), expected)
 	}
-	assert.Contains(t, err.Error(), "4 links do not resolve")
+	assert.Contains(t, err.Error(), "3 links do not resolve")
 }
 
 func TestCheckLinksCountsOneLinkAsSingular(t *testing.T) {

--- a/mark_linkfollowup_test.go
+++ b/mark_linkfollowup_test.go
@@ -1,0 +1,152 @@
+package mark
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func followupServer(t *testing.T) *confluencetest.Server {
+	t.Helper()
+	s := confluencetest.New(t)
+	home := s.AddPage("DOCS", "Home", "page", "")
+	s.SetHomepage("DOCS", home.ID)
+	s.AddPage("DOCS", "Parent", "page", home.ID)
+	return s
+}
+
+// TestConfluenceLinkToAPagePublishedLaterInTheRun: an ac: link is checked by
+// looking the page up, and a page named here may be published by a file that
+// sorts after this one. Failing would make the check depend on the order the
+// files happen to be in.
+func TestConfluenceLinkToAPagePublishedLaterInTheRun(t *testing.T) {
+	server := followupServer(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "a-doc.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: A -->\n\nSee [B](ac:B).\n")
+	writeFile(t, dir, "b-doc.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: B -->\n\nB.\n")
+
+	assert.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		CheckLinks: []string{"confluence"}, Output: io.Discard,
+	}))
+}
+
+// TestLinkInsideAnIncludedFragment: a fragment's links are written from where
+// the fragment lives, not from where it is included.
+func TestLinkInsideAnIncludedFragment(t *testing.T) {
+	server := followupServer(t)
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "frag"), 0o755))
+
+	// Named so the fragment is not itself published by the glob below.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "frag", "part.inc"),
+		[]byte("See [the target](./target.md).\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "frag", "target.md"),
+		[]byte("<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Target -->\n\nTarget.\n"), 0o600))
+
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Doc -->\n\n"+
+			"<!-- Include: frag/part.inc -->\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		// Both levels, so the fragment's neighbour is published too.
+		Files: filepath.Join(dir, "**", "*.md"), Features: []string{"mention"},
+		CheckLinks: []string{"internal"}, Output: io.Discard,
+	}
+	// Twice, so the target exists by the time the link is resolved.
+	require.NoError(t, Run(config))
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	doc, err := api.FindPage("DOCS", "Doc", "page")
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+
+	assert.Contains(t, server.Page(doc.ID).Body, "/x/",
+		"the fragment's link should resolve to the target page")
+}
+
+// TestOwnDirectoryWinsOverAnIncludedOne: adding places to look must not change
+// what an unambiguous link already meant.
+func TestOwnDirectoryWinsOverAnIncludedOne(t *testing.T) {
+	server := followupServer(t)
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "frag"), 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "frag", "part.inc"),
+		[]byte("Fragment.\n"), 0o600))
+	// Both directories hold a target.md; the document's own must win.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "frag", "target.md"),
+		[]byte("<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Wrong -->\n\nx.\n"), 0o600))
+	writeFile(t, dir, "target.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Right -->\n\nx.\n")
+
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Doc -->\n\n"+
+			"<!-- Include: frag/part.inc -->\n\nSee [it](./target.md).\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"}, Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	right, err := api.FindPage("DOCS", "Right", "page")
+	require.NoError(t, err)
+	require.NotNil(t, right)
+
+	doc, err := api.FindPage("DOCS", "Doc", "page")
+	require.NoError(t, err)
+	assert.Contains(t, server.Page(doc.ID).Body, right.ID[:0]+"/x/",
+		"the link should have resolved")
+	// The Wrong page must not exist at all, since nothing links to it and no
+	// file publishes it under that title in this run.
+	wrong, err := api.FindPage("DOCS", "Wrong", "page")
+	require.NoError(t, err)
+	assert.Nil(t, wrong)
+}
+
+// TestMacroDefinedAboveTheHeaders: a Macro definition spans several lines, and
+// the lines after its first are not headers. Reading them used to end the
+// metadata scan, so every header below was lost and the run failed with "space
+// is not set".
+func TestMacroDefinedAboveTheHeaders(t *testing.T) {
+	server := followupServer(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "doc.md",
+		"<!-- Macro: MYJIRA-\\d+\n"+
+			"     Template: ac:jira:ticket\n"+
+			"     Ticket: ${0} -->\n"+
+			"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Doc -->\n\n"+
+			"See MYJIRA-123.\n")
+
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"}, Output: io.Discard,
+	}))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	doc, err := api.FindPage("DOCS", "Doc", "page")
+	require.NoError(t, err)
+	require.NotNil(t, doc, "the headers below the macro must still be read")
+
+	body := server.Page(doc.ID).Body
+	assert.Contains(t, body, `ac:name="jira"`,
+		"the macro defined above the headers must still apply")
+	assert.NotContains(t, body, "Template: ac:jira:ticket",
+		"the definition must not be published as content")
+}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -254,6 +254,18 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 		}
 	}
 
+	// Where the run of headers begins and ends. Two boundaries rather than one
+	// because a document may open with something that is not a header at all --
+	// a Macro definition spanning several lines is the usual case -- and that
+	// has to survive into the body rather than being swallowed as though it
+	// were metadata.
+	firstStart := -1
+
+	// Where body already begins within data, which is past the front matter
+	// when there was any. stripFrontMatter returns a suffix of data, so the
+	// difference in lengths is the offset.
+	bodyStart := len(data) - len(body)
+
 	var lastStop int
 	shouldBreak := false
 
@@ -272,6 +284,15 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 
 				key, value, ok := parseHeaderComment(line)
 				if !ok {
+					if firstStart == -1 {
+						// Nothing has been read as a header yet, so this block
+						// is not the header block: a Macro or Include directive
+						// written above them, or raw HTML. Leave it alone and
+						// look at the next one, rather than giving up on the
+						// document's metadata entirely.
+						break
+					}
+
 					shouldBreak = true
 					break
 				}
@@ -279,6 +300,10 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 				if meta == nil {
 					meta = &Meta{}
 					meta.Type = "page" // Default if not specified
+				}
+
+				if firstStart == -1 {
+					firstStart = lineSeg.Start
 				}
 
 				header := cases.Title(language.English).String(key)
@@ -384,7 +409,9 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 	}
 
 	if lastStop > 0 {
-		body = data[lastStop:]
+		// Only the headers are taken out. Whatever preceded them stays, which
+		// is what keeps a Macro defined above the headers working.
+		body = append(append([]byte{}, data[bodyStart:firstStart]...), data[lastStop:]...)
 	}
 
 	if titleFromH1 || titleFromFilename || spaceFromCli != "" {

--- a/page/check.go
+++ b/page/check.go
@@ -3,9 +3,12 @@ package page
 import (
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/kovetskiy/mark/v16/confluence"
 )
 
 // The kinds of link --check-links understands.
@@ -84,8 +87,17 @@ type LinkChecker struct {
 	Checks LinkChecks
 	Client *http.Client
 
-	mu   sync.Mutex
-	seen map[string]error
+	mu      sync.Mutex
+	seen    map[string]error
+	pending map[string]pendingPage
+}
+
+// pendingPage is an ac: link waiting to be checked, and the first document that
+// asked about it.
+type pendingPage struct {
+	space  string
+	title  string
+	source string
 }
 
 // NewLinkChecker returns a checker for the given set.
@@ -97,8 +109,75 @@ func NewLinkChecker(checks LinkChecks) *LinkChecker {
 			// not hold up a publish indefinitely.
 			Timeout: 15 * time.Second,
 		},
-		seen: map[string]error{},
+		seen:    map[string]error{},
+		pending: map[string]pendingPage{},
 	}
+}
+
+// NotePage records an ac: link to check once the run has finished.
+//
+// Deferred rather than looked up on the spot because a page named here may be
+// published later in the same run, by a file that sorts after this one.
+// Checking as each document compiles would make the answer depend on the order
+// the files happen to be in, and a first run over a set of pages that link to
+// each other would fail on roughly half of them.
+func (c *LinkChecker) NotePage(space, title, source string) {
+	if c == nil || !c.Checks.Confluence {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Keyed on the page, so a title linked from twenty documents costs one
+	// lookup and is reported once.
+	key := space + "\x00" + title
+	if _, ok := c.pending[key]; !ok {
+		c.pending[key] = pendingPage{space: space, title: title, source: source}
+	}
+}
+
+// MissingPages reports the ac: links that named no page, once everything that
+// was going to be published has been.
+func (c *LinkChecker) MissingPages(finder PageFinder) ([]string, error) {
+	if c == nil || len(c.pending) == 0 {
+		return nil, nil
+	}
+
+	c.mu.Lock()
+	keys := make([]string, 0, len(c.pending))
+	for key := range c.pending {
+		keys = append(keys, key)
+	}
+	pending := c.pending
+	c.mu.Unlock()
+
+	sort.Strings(keys)
+
+	var missing []string
+	for _, key := range keys {
+		link := pending[key]
+
+		found, err := finder.FindPage(link.space, link.title, "page")
+		if err != nil {
+			return nil, fmt.Errorf("find confluence page %q: %w", link.title, err)
+		}
+
+		if found == nil {
+			missing = append(missing, fmt.Sprintf(
+				"%s: link \"ac:%s\" does not resolve: there is no page %q in space %q",
+				link.source, link.title, link.title, link.space,
+			))
+		}
+	}
+
+	return missing, nil
+}
+
+// PageFinder is the part of the Confluence API this needs, kept narrow so the
+// check can be exercised without one.
+type PageFinder interface {
+	FindPage(space, title, pageType string) (*confluence.PageInfo, error)
 }
 
 // CheckExternal reports whether url answers, or nil if it was not asked.

--- a/page/link.go
+++ b/page/link.go
@@ -34,6 +34,13 @@ type LinkResolver struct {
 	TitleAppendGeneratedHash bool
 	FrontMatterEnabled       bool
 
+	// SearchDirs are tried after Base, and exist for links written inside an
+	// included fragment. Such a link is written from where the fragment lives,
+	// not from where it is included, so the fragment's own directory has to be
+	// among the places looked. Base is always tried first, so a document's own
+	// links keep their meaning.
+	SearchDirs []string
+
 	// Checker decides how much is verified. Nil checks nothing.
 	Checker *LinkChecker
 
@@ -76,6 +83,7 @@ func NewLinkResolver(
 	titleAppendGeneratedHash bool,
 	frontMatterEnabled bool,
 	checker *LinkChecker,
+	searchDirs []string,
 ) *LinkResolver {
 	spaceForLinks := spaceFromCli
 	if spaceForLinks == "" && meta != nil {
@@ -92,6 +100,7 @@ func NewLinkResolver(
 		TitleAppendGeneratedHash: titleAppendGeneratedHash,
 		FrontMatterEnabled:       frontMatterEnabled,
 		Checker:                  checker,
+		SearchDirs:               searchDirs,
 	}
 }
 
@@ -134,7 +143,7 @@ func (r *LinkResolver) Resolve(target, text string) (string, error) {
 	filename, hash, _ := strings.Cut(target, "#")
 
 	resolved, why, err := resolveLink(
-		r.API, r.Base,
+		r.API, append([]string{r.Base}, r.SearchDirs...),
 		markdownLink{full: target, filename: filename, hash: hash},
 		r.SpaceForLinks, r.TitleFromH1, r.TitleFromFilename,
 		r.Parents, r.TitleAppendGeneratedHash, r.FrontMatterEnabled,
@@ -184,19 +193,9 @@ func (r *LinkResolver) checkConfluenceLink(target, text string) error {
 		return nil
 	}
 
-	// Same space as the document doing the linking, which is what an ac:link
-	// with only a title resolves against.
-	found, err := r.API.FindPage(r.SpaceForLinks, title, "page")
-	if err != nil {
-		return fmt.Errorf("find confluence page %q: %w", title, err)
-	}
-
-	if found == nil {
-		r.note(
-			"link %q does not resolve: there is no page %q in space %q",
-			target, title, r.SpaceForLinks,
-		)
-	}
+	// Noted rather than looked up: the page may not have been published yet,
+	// and whether it ever is can only be known once the run is over.
+	r.Checker.NotePage(r.SpaceForLinks, title, r.Base)
 
 	return nil
 }
@@ -221,7 +220,7 @@ type unresolved struct {
 // always done.
 func resolveLink(
 	api *confluence.API,
-	base string,
+	bases []string,
 	link markdownLink,
 	spaceForLinks string,
 	titleFromH1 bool,
@@ -233,19 +232,9 @@ func resolveLink(
 	var result string
 
 	if len(link.filename) > 0 {
-		filepath := filepath.Join(base, link.filename)
-
-		log.Trace().Msgf("filepath: %s", filepath)
-		stat, err := os.Stat(filepath)
-		if err != nil {
-			// Not a link to a file on disk (or unreadable): leave the link
-			// untouched rather than failing the run. Swallowing err is
-			// deliberate here.
-			return "", &unresolved{reason: "there is no such file"}, nil //nolint:nilerr
-		}
-
-		if stat.IsDir() {
-			return "", &unresolved{reason: "it is a directory, not a document"}, nil
+		filepath, why := findLinkTarget(bases, link.filename)
+		if why != nil {
+			return "", why, nil
 		}
 
 		linkContents, err := os.ReadFile(filepath)
@@ -323,6 +312,40 @@ func resolveLink(
 // getConfluenceLink builds a stable Confluence tiny link for the given page or blog post.
 // Tiny links use the format {baseURL}/x/{encodedPageID} and are immune to
 // Cloud-specific URL variations like /ex/confluence/<cloudId>/wiki/...
+// findLinkTarget looks for the file a link names, in each base in turn.
+//
+// The first base is the document's own directory and wins where both would do,
+// so adding places to look cannot change what an unambiguous link already meant.
+func findLinkTarget(bases []string, name string) (string, *unresolved) {
+	var directory bool
+
+	for _, base := range bases {
+		candidate := filepath.Join(base, name)
+
+		log.Trace().Msgf("filepath: %s", candidate)
+		stat, err := os.Stat(candidate)
+		if err != nil {
+			// Not a file on disk here, or unreadable. Swallowing err is
+			// deliberate: the next base may have it, and if none does the link
+			// is left as written rather than failing the run.
+			continue //nolint:nilerr
+		}
+
+		if stat.IsDir() {
+			directory = true
+			continue
+		}
+
+		return candidate, nil
+	}
+
+	if directory {
+		return "", &unresolved{reason: "it is a directory, not a document"}
+	}
+
+	return "", &unresolved{reason: "there is no such file"}
+}
+
 func getConfluenceLink(
 	api *confluence.API,
 	space, title string,

--- a/page/property.go
+++ b/page/property.go
@@ -59,7 +59,7 @@ func MergeProperties(global, document map[string]any) map[string]any {
 // Only what changed is written. A property holds a version that Confluence
 // increments on every write, so rewriting an unchanged value would fill its
 // history as surely as republishing an unchanged page fills the page's.
-func ApplyProperties(api *confluence.API, pageID string, properties map[string]any, dryRun bool) error {
+func ApplyProperties(api *confluence.API, pageID string, properties map[string]any) error {
 	if len(properties) == 0 {
 		return nil
 	}
@@ -90,11 +90,6 @@ func ApplyProperties(api *confluence.API, pageID string, properties map[string]a
 
 		if held, ok := current[key]; ok && json.Valid(held.Value) &&
 			equalJSON(held.Value, value) {
-			continue
-		}
-
-		if dryRun {
-			log.Info().Msgf("property %q of page %s would be set to %s", key, pageID, value)
 			continue
 		}
 


### PR DESCRIPTION
Four issues found by auditing what recent changes moved. Each was confirmed by running, not by reading, and three of the four fail on master.

## 1. `ac:` link checks were ordering-dependent

`a-doc.md` links to `ac:B`; `b-doc.md` publishes page B later in the same run. The check hard-failed, because B did not exist *yet*. On a first run over a set of pages that link to each other, roughly half would fail.

**Not fixed by downgrading to a warning**, which was my first instinct and is wrong: it would leave `--check-links confluence` unable to fail at all, which is most of the point of asking for it. Instead every `ac:` link is noted while compiling and looked up **after the run**, when whether a page exists is finally knowable.

Two things fall out of that: a page linked from twenty documents is looked up once rather than twenty times, and no lookups happen during compilation at all.

Failures are reported after the manifest is written — an unresolved link says nothing about whether the pages that *did* publish are recorded correctly, and discarding the mapping over it would be a far worse outcome than the link.

## 2. Links inside included fragments resolved against the wrong directory

A fragment at `frag/part.inc` linking to `./target.md` was looked for beside the *including* document, not beside itself. With `--check-links internal` that is a false build failure for anyone including from a subdirectory.

A link is now looked for beside its document, and then beside each file that document includes. **The document's own directory is always tried first**, so this cannot change what an unambiguous link already meant — there is a test for exactly that, with a `target.md` in both directories.

One level only: a fragment that itself includes another is not followed. Doing it properly would need each node to carry which file it came from, which the pipeline does not track.

## 3. A Macro defined above the headers destroyed all metadata

```markdown
<!-- Macro: MYJIRA-\d+
     Template: ac:jira:ticket
     Ticket: ${0} -->
<!-- Space: DOCS -->
<!-- Title: Doc -->
```

failed with `space is not set`. The metadata scan stopped at the macro's second line — correctly, since it is not a header comment — and never saw the headers below.

The scan now steps over a leading block that turns out not to be headers, and takes **only the header lines** out of the body rather than everything up to them, so the definition it stepped over survives to be used. This is likely the same family as #455.

## 4. Dead parameter

`ApplyProperties` took a `dryRun` flag it could never see set, since a dry run returns long before properties are applied. Removed rather than left to imply a protection that is really somewhere else.

## Verification

Against master: `TestConfluenceLinkToAPagePublishedLaterInTheRun`, `TestLinkInsideAnIncludedFragment` and `TestMacroDefinedAboveTheHeaders` all fail. `TestOwnDirectoryWinsOverAnIncludedOne` passes on master too — it is a guard that the added search directories change nothing, so passing there is what it should do.

Two existing tests from #895 changed meaning and were updated deliberately: an `ac:` link to a missing page now fails at the end of the run rather than during the file, and the "every broken link" count covers the links judged while compiling, `ac:` links being reported separately for that reason.

Full suite green under `-race`; `golangci-lint`: 0 issues; README updated for both new behaviours.