### PR TITLE
feat: archive or delete pages whose source files are gone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1265,6 +1265,8 @@ GLOBAL OPTIONS:
    --mermaid-scale float                    defines the scaling factor for mermaid renderings. (default: 1) [$MARK_MERMAID_SCALE]
    --include-path string                    Path for shared includes, used as a fallback if the include doesn't exist in the current directory. [$MARK_INCLUDE_PATH]
    --changes-only                           Avoids re-uploading pages that haven't changed since the last run. [$MARK_CHANGES_ONLY]
+   --on-orphan string                       what to do about a page whose source file is gone: "report" says so and does nothing (the default), "archive" archives the page (Confluence Cloud only), "delete" moves it to the trash. Requires --track-pages. [$MARK_ON_ORPHAN]
+   --orphans-under string                   limit --on-orphan to pages below this page or folder, given by title or id. Without it, every tracked page the --files pattern would have published is in scope. [$MARK_ORPHANS_UNDER]
    --check-links string [ --check-links string ]  fail on links that do not resolve. Repeat or comma-separate any of: "internal" (relative links to other files in the repository), "confluence" (ac: links naming a page by title), "external" (requests each URL to see whether it answers), or "all". [$MARK_CHECK_LINKS]
    --global-properties string               path to a YAML or JSON file of Confluence content properties to set on every page. A Property header or properties front matter in a document wins over the file for that page. [$MARK_GLOBAL_PROPERTIES]
    --append-labels                          add the labels a document asks for without removing any others, so that labels applied in Confluence survive a publish. Without it, a page ends up with exactly the labels its Label headers name. [$MARK_APPEND_LABELS]
@@ -1535,6 +1537,53 @@ It is split over sixteen properties rather than held in one because Confluence
 bounds how large a single property value may be, and one blob would cap how many
 files a repository may have. Each path is assigned a shard by hash; all of them
 are read in a single request and only the ones that changed are written back.
+
+### Removing pages whose files are gone
+
+By default Mark reports a tracked page whose source file has disappeared and
+does nothing about it. `--on-orphan` chooses otherwise:
+
+| Value | Effect |
+| --- | --- |
+| `report` | say so and leave the page alone (the default) |
+| `archive` | archive the page. Confluence Cloud only |
+| `delete` | move the page to the trash |
+
+```bash
+mark --track-pages --on-orphan delete --files "docs/**/*.md"
+```
+
+`delete` means the trash, which Confluence keeps recoverable. Mark never purges
+a page: that second step is left to a person.
+
+`--orphans-under` narrows it further to the pages below one page or folder,
+named by title or by id:
+
+```bash
+mark --track-pages --on-orphan delete --orphans-under "Team Handbook" \
+     --files "docs/**/*.md"
+```
+
+Without it, every tracked page the `--files` pattern would have published is in
+scope -- which is already narrower than the space, since a pattern is only
+evidence about where it was looking.
+
+#### What stops a page being removed
+
+* `--track-pages` is required, and Mark refuses to start without it. Only the
+  manifest knows which pages Mark published, and a guess from titles is not one
+  worth making about deletion.
+* A page holding **child pages** is left alone and reported, because removing it
+  would take them with it and they may be pages nobody wrote in this repository.
+* A run in which **any file failed** removes nothing: a file that failed to
+  process is indistinguishable from one that was deleted.
+* A run that **published nothing** removes nothing, so a failed checkout cannot
+  empty a space.
+* A document that opted out with `Synchronized: false` still counts as present.
+* `--dry-run` reports what would go and touches nothing.
+
+A page that is left alone stays in the manifest, so the next run finds it again
+rather than losing sight of it.
 
 #### Worth knowing
 

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -1527,6 +1527,52 @@ func (api *API) GetChildPages(parentID string) ([]PageInfo, error) {
 // parent. Atlassian warn against using it when the target is a top-level page,
 // where it can move content to the root of the space; callers are expected not
 // to.
+// DeletePage moves a page to the space's trash.
+//
+// Trash, not oblivion: Confluence keeps a deleted page recoverable until
+// somebody purges it, and purging is a second call this deliberately does not
+// make. A tool that removes pages because a file left a repository should leave
+// the last word to a person.
+func (api *API) DeletePage(contentID string) error {
+	request, err := api.rest.Res("content").Id(contentID, &struct{}{}).Delete()
+	if err != nil {
+		return fmt.Errorf("unable to delete content %s: %w", contentID, err)
+	}
+
+	// 204 is the documented answer; 200 is accepted because some versions send
+	// it, and a page already gone is the outcome that was wanted anyway.
+	switch request.Raw.StatusCode {
+	case http.StatusNoContent, http.StatusOK, http.StatusNotFound:
+		return nil
+	default:
+		return newErrorStatusNotOK(request)
+	}
+}
+
+// ArchivePage archives a page, which is gentler than the trash: it leaves the
+// page findable and restorable without an administrator.
+//
+// Cloud only. Server and Data Center have no archive, and say so with a 404,
+// which is reported rather than swallowed so that a run asking to archive is
+// not silently doing nothing.
+func (api *API) ArchivePage(contentID string) error {
+	payload := map[string]any{
+		"pages": []map[string]string{{"id": contentID}},
+	}
+
+	request, err := api.rest.Res("content").Res("archive", &struct{}{}).Post(payload)
+	if err != nil {
+		return fmt.Errorf("unable to archive content %s: %w", contentID, err)
+	}
+
+	switch request.Raw.StatusCode {
+	case http.StatusOK, http.StatusAccepted, http.StatusNoContent:
+		return nil
+	default:
+		return newErrorStatusNotOK(request)
+	}
+}
+
 func (api *API) MoveContentAfter(contentID, siblingID string) error {
 	return api.moveContent(contentID, "after", siblingID)
 }

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -34,6 +34,11 @@ type Page struct {
 	Message  string
 	Body     string
 	Labels   []string
+
+	// Trashed and Archived record what became of a page, so a test can tell
+	// "moved to the trash" from "gone" and from "archived".
+	Trashed  bool
+	Archived bool
 }
 
 // Attachment is a file attached to a page.
@@ -263,6 +268,36 @@ func (s *Server) DeletePage(id string) {
 	delete(s.pages, id)
 }
 
+// archiveContent serves the bulk archive endpoint, which takes a list of pages
+// rather than addressing one by id.
+func (s *Server) archiveContent(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var payload struct {
+		Pages []struct {
+			ID string `json:"id"`
+		} `json:"pages"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"message": "bad body"})
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, item := range payload.Pages {
+		if p, ok := s.pages[item.ID]; ok {
+			p.Archived = true
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"id": "archive-task"})
+}
+
 // SetHomepage marks a page as the space homepage.
 func (s *Server) SetHomepage(spaceKey, pageID string) {
 	s.mu.Lock()
@@ -487,6 +522,9 @@ func (s *Server) handleV1(w http.ResponseWriter, r *http.Request, path string) {
 
 	case strings.HasPrefix(path, "/space/"):
 		s.getSpace(w, strings.TrimPrefix(path, "/space/"))
+
+	case path == "/content/archive":
+		s.archiveContent(w, r)
 
 	case strings.HasPrefix(path, "/content/"):
 		rest := strings.TrimPrefix(path, "/content/")
@@ -954,6 +992,16 @@ func (s *Server) contentByID(w http.ResponseWriter, r *http.Request, id string) 
 	}
 
 	switch r.Method {
+	case http.MethodDelete:
+		// Confluence moves a page to the trash; purging is a separate call with
+		// status=trashed, which mark deliberately never makes.
+		if r.URL.Query().Get("status") == "trashed" {
+			delete(s.pages, id)
+		} else {
+			p.Trashed = true
+		}
+		w.WriteHeader(http.StatusNoContent)
+
 	case http.MethodGet:
 		writeJSON(w, http.StatusOK, s.pageJSON(p))
 	case http.MethodPut:

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -782,6 +782,52 @@ func (s *Store) LookupFolder(spaceKey, folderPath string) (string, bool, error) 
 // genuine deletions in a list of files that are perfectly present. Entries with
 // no recorded pattern predate this and are never reported, because there is no
 // way to know what they were in scope of.
+// Orphan is a tracked page whose source file was not seen in the run, together
+// with what is known about it.
+type Orphan struct {
+	Path  string
+	Entry Entry
+}
+
+// OrphanEntries is Orphans with the page each path published to, for a caller
+// that means to do something about them rather than only say so.
+func (s *Store) OrphanEntries(spaceKey string) []Orphan {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, ok := s.spaces[spaceKey]
+	if !ok {
+		return nil
+	}
+
+	var orphans []Orphan
+	for _, path := range s.orphans(spaceKey) {
+		orphans = append(orphans, Orphan{
+			Path:  path,
+			Entry: state.shards[shardFor(path)].pages[path],
+		})
+	}
+
+	return orphans
+}
+
+// Published reports how many pages this run actually published in a space.
+//
+// Nothing published means nothing to compare against: a checkout that failed,
+// or a pattern that matched no files, looks exactly like every document having
+// been deleted at once, and acting on that reading would empty a space.
+func (s *Store) Published(spaceKey string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, ok := s.spaces[spaceKey]
+	if !ok {
+		return 0
+	}
+
+	return len(state.seen)
+}
+
 func (s *Store) Orphans(spaceKey string) []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/mark.go
+++ b/mark.go
@@ -76,6 +76,8 @@ type Config struct {
 	CheckLinksWarnOnly bool
 	AppendLabels       bool
 	GlobalProperties   string
+	OnOrphan           string
+	OrphansUnder       string
 
 	// Rendering
 	DropH1          bool
@@ -103,6 +105,35 @@ func (c Config) output() io.Writer {
 
 // Run processes all files matching Config.Files and publishes them to Confluence.
 func Run(config Config) error {
+	// Settings are checked before anything else happens. A value that cannot be
+	// acted on should be said so plainly, not after a glob has been resolved
+	// and a connection opened -- and least of all part way through publishing.
+	onOrphan, err := page.ParseOnOrphan(config.OnOrphan)
+	if err != nil {
+		return err
+	}
+
+	// Removing a page needs to know mark put it there, and only the manifest
+	// knows that. Without it the flag could only guess from titles, which is
+	// not a guess worth making about deletion.
+	if onOrphan != page.OnOrphanReport && !config.TrackPages {
+		return fmt.Errorf(
+			"--on-orphan %s requires --track-pages: "+
+				"only the page manifest knows which pages mark published",
+			onOrphan,
+		)
+	}
+
+	if config.NoOverwrite && !config.TrackPages {
+		return fmt.Errorf("--no-overwrite requires --track-pages: " +
+			"the version mark last published is remembered in the page manifest")
+	}
+
+	linkChecks, err := page.ParseLinkChecks(config.CheckLinks)
+	if err != nil {
+		return err
+	}
+
 	api := confluence.NewAPI(config.BaseURL, config.Username, config.Password, config.InsecureSkipTLSVerify)
 
 	// Folder resolutions are cached in a package-level map that outlives this
@@ -140,12 +171,6 @@ func Run(config Config) error {
 		return err
 	}
 
-	// Rejected before anything is published rather than on the first link that
-	// happens to be checked.
-	linkChecks, err := page.ParseLinkChecks(config.CheckLinks)
-	if err != nil {
-		return err
-	}
 	checker := page.NewLinkChecker(linkChecks)
 
 	if config.CheckLinksWarnOnly && !linkChecks.Any() {
@@ -153,14 +178,6 @@ func Run(config Config) error {
 			"--check-links-warn-only has no effect without --check-links: " +
 				"no links are being checked at all",
 		)
-	}
-
-	// Without the manifest there is nowhere to have remembered what mark last
-	// published, so there is nothing to compare a page against and the flag
-	// would quietly do nothing.
-	if config.NoOverwrite && !config.TrackPages {
-		return fmt.Errorf("--no-overwrite requires --track-pages: " +
-			"the version mark last published is remembered in the page manifest")
 	}
 
 	// The manifest is only consulted when asked for. It changes how an existing
@@ -258,6 +275,9 @@ func Run(config Config) error {
 	var saveErr error
 	if tracker != nil {
 		reportOrphans(tracker, hasErrors)
+		if err := actOnOrphans(tracker, api, config, onOrphan, hasErrors); err != nil {
+			return err
+		}
 		pruneOrphans(tracker, hasErrors, config.DryRun)
 		if saveErr = tracker.Save(); saveErr != nil {
 			saveErr = fmt.Errorf("unable to save page manifest: %w", saveErr)
@@ -1669,4 +1689,86 @@ func pluraliseLinks(n int) string {
 	}
 
 	return fmt.Sprintf("%d links do not resolve", n)
+}
+
+// actOnOrphans archives or deletes the pages whose source files are gone.
+//
+// Nothing happens under the default, which only reports. Everything else is
+// hedged about, because this is the one thing mark does that a person cannot
+// simply run again to undo.
+func actOnOrphans(
+	tracker *manifest.Store,
+	api *confluence.API,
+	config Config,
+	action string,
+	hadErrors bool,
+) error {
+	if action == page.OnOrphanReport {
+		return nil
+	}
+
+	if hadErrors {
+		// A file that failed to process is indistinguishable from one that was
+		// deleted, and this is not a distinction to get wrong.
+		log.Warn().Msg("some files failed to process; orphaned pages are left alone")
+
+		return nil
+	}
+
+	for _, space := range tracker.Spaces() {
+		orphans := tracker.OrphanEntries(space)
+		if len(orphans) == 0 {
+			continue
+		}
+
+		// A run that published nothing in a space says nothing about that
+		// space: a failed checkout and every document having been deleted look
+		// exactly alike.
+		//
+		// A second line of defence rather than the first -- a pattern matching
+		// no files stops the run well before this -- and kept because the cost
+		// of it being needed once is a space emptied by a bad checkout.
+		if tracker.Published(space) == 0 {
+			log.Warn().Msgf(
+				"space %q: nothing was published in this run, so its %d orphaned page(s) are left alone",
+				space, len(orphans),
+			)
+
+			continue
+		}
+
+		scopeID, err := page.ResolveScope(api, space, config.OrphansUnder)
+		if err != nil {
+			return err
+		}
+
+		candidates := make([]page.Orphan, 0, len(orphans))
+		for _, orphan := range orphans {
+			candidates = append(candidates, page.Orphan{
+				Path:   orphan.Path,
+				PageID: orphan.Entry.PageID,
+				Title:  orphan.Entry.Title,
+			})
+		}
+
+		handled, err := page.HandleOrphans(api, action, scopeID, candidates, config.DryRun)
+		if err != nil {
+			return err
+		}
+
+		if config.DryRun {
+			continue
+		}
+
+		// Only what was actually dealt with is forgotten. A page left alone --
+		// out of scope, or holding children -- stays in the manifest so the
+		// next run finds it again instead of losing sight of it.
+		for _, path := range handled {
+			if err := tracker.Forget(space, path); err != nil {
+				return fmt.Errorf("unable to update page manifest for %q: %w", path, err)
+			}
+		}
+	}
+
+	return nil
 }

--- a/mark_orphan_test.go
+++ b/mark_orphan_test.go
@@ -1,0 +1,259 @@
+package mark
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// orphanFixture publishes two documents under Parent and then removes one of
+// them from disk, which is what makes its page an orphan.
+func orphanFixture(t *testing.T, onOrphan, under string) (*confluencetest.Server, string, string) {
+	t.Helper()
+
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	header := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n"
+	writeFile(t, dir, "keep.md", header+"<!-- Title: Keep -->\n\nKeep.\n")
+	writeFile(t, dir, "gone.md", header+"<!-- Title: Gone -->\n\nGone.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		TrackPages: true, OnOrphan: onOrphan, OrphansUnder: under,
+		Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	gone, err := api.FindPage("DOCS", "Gone", "page")
+	require.NoError(t, err)
+	require.NotNil(t, gone)
+
+	require.NoError(t, os.Remove(filepath.Join(dir, "gone.md")))
+	require.NoError(t, Run(config))
+
+	return server, gone.ID, dir
+}
+
+func TestOnOrphanReportLeavesThePage(t *testing.T) {
+	server, id, _ := orphanFixture(t, "report", "")
+
+	page := server.Page(id)
+	require.NotNil(t, page)
+	assert.False(t, page.Trashed, "report must not remove anything")
+	assert.False(t, page.Archived)
+}
+
+func TestOnOrphanDeleteTrashesThePage(t *testing.T) {
+	server, id, _ := orphanFixture(t, "delete", "")
+
+	page := server.Page(id)
+	require.NotNil(t, page, "the page must be trashed, not purged")
+	assert.True(t, page.Trashed)
+}
+
+func TestOnOrphanArchiveArchivesThePage(t *testing.T) {
+	server, id, _ := orphanFixture(t, "archive", "")
+
+	page := server.Page(id)
+	require.NotNil(t, page)
+	assert.True(t, page.Archived)
+	assert.False(t, page.Trashed, "archiving is not trashing")
+}
+
+// TestOnOrphanRequiresTrackPages: without the manifest there is no way to know
+// mark put the page there, which is not a guess to make about deletion.
+func TestOnOrphanRequiresTrackPages(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md", "<!-- Space: DOCS -->\n<!-- Title: Doc -->\n\nBody.\n")
+
+	err := Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), OnOrphan: "delete", Output: io.Discard,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--track-pages")
+}
+
+func TestOnOrphanRejectsAnUnknownAction(t *testing.T) {
+	err := Run(Config{
+		BaseURL: "http://127.0.0.1:1", Username: "user", Password: "token",
+		Files: "none", OnOrphan: "incinerate", TrackPages: true, Output: io.Discard,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "report")
+}
+
+// TestOnOrphanDryRunActsOnNothing.
+func TestOnOrphanDryRunActsOnNothing(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	header := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n"
+	writeFile(t, dir, "keep.md", header+"<!-- Title: Keep -->\n\nKeep.\n")
+	writeFile(t, dir, "gone.md", header+"<!-- Title: Gone -->\n\nGone.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		TrackPages: true, OnOrphan: "delete", Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	gone, err := api.FindPage("DOCS", "Gone", "page")
+	require.NoError(t, err)
+	require.NotNil(t, gone)
+
+	require.NoError(t, os.Remove(filepath.Join(dir, "gone.md")))
+	config.DryRun = true
+	require.NoError(t, Run(config))
+
+	assert.False(t, server.Page(gone.ID).Trashed, "a dry run must remove nothing")
+}
+
+// TestOnOrphanLeavesAPageWithChildren: trashing a page takes its children with
+// it, and those may be pages nobody in this repository ever wrote.
+func TestOnOrphanLeavesAPageWithChildren(t *testing.T) {
+	server, id := orphanFixtureWithChild(t)
+
+	page := server.Page(id)
+	require.NotNil(t, page)
+	assert.False(t, page.Trashed,
+		"a page holding children must be left alone")
+}
+
+func orphanFixtureWithChild(t *testing.T) (*confluencetest.Server, string) {
+	t.Helper()
+
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	header := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n"
+	writeFile(t, dir, "keep.md", header+"<!-- Title: Keep -->\n\nKeep.\n")
+	writeFile(t, dir, "gone.md", header+"<!-- Title: Gone -->\n\nGone.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		TrackPages: true, OnOrphan: "delete", Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	gone, err := api.FindPage("DOCS", "Gone", "page")
+	require.NoError(t, err)
+	require.NotNil(t, gone)
+
+	// Somebody adds a child page under it in Confluence.
+	server.AddPage("DOCS", "Written by hand", "page", gone.ID)
+
+	require.NoError(t, os.Remove(filepath.Join(dir, "gone.md")))
+	require.NoError(t, Run(config))
+
+	return server, gone.ID
+}
+
+// TestOnOrphanLeavesEverythingWhenNothingPublished pins the property rather
+// than any one mechanism: a run that publishes nothing must remove nothing.
+//
+// Today an empty file set stops the run before orphans are even considered, so
+// this passes with the guard in actOnOrphans removed. It is written against the
+// behaviour on purpose -- whichever check is doing the work, moving orphan
+// handling ahead of the other one should fail here rather than quietly enable
+// mass deletion from a failed checkout.
+func TestOnOrphanLeavesEverythingWhenNothingPublished(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	header := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n"
+	writeFile(t, dir, "one.md", header+"<!-- Title: One -->\n\nOne.\n")
+	writeFile(t, dir, "two.md", header+"<!-- Title: Two -->\n\nTwo.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		TrackPages: true, OnOrphan: "delete", Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	one, err := api.FindPage("DOCS", "One", "page")
+	require.NoError(t, err)
+	require.NotNil(t, one)
+
+	// The checkout is empty this time, but the pattern is the same.
+	require.NoError(t, os.Remove(filepath.Join(dir, "one.md")))
+	require.NoError(t, os.Remove(filepath.Join(dir, "two.md")))
+
+	config.CI = true // so that no files matched is not itself an error
+	require.NoError(t, Run(config))
+
+	assert.False(t, server.Page(one.ID).Trashed,
+		"a run that published nothing must remove nothing")
+}
+
+// TestOrphansUnderLimitsScope: only pages below the named parent are in scope.
+func TestOrphansUnderLimitsScope(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Inside", "page", home.ID)
+	server.AddPage("DOCS", "Outside", "page", home.ID)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "in.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Inside -->\n<!-- Title: In -->\n\nIn.\n")
+	writeFile(t, dir, "out.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Outside -->\n<!-- Title: Out -->\n\nOut.\n")
+	writeFile(t, dir, "keep.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Inside -->\n<!-- Title: Keep -->\n\nKeep.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		TrackPages: true, OnOrphan: "delete", OrphansUnder: "Inside",
+		Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	in, err := api.FindPage("DOCS", "In", "page")
+	require.NoError(t, err)
+	require.NotNil(t, in)
+	out, err := api.FindPage("DOCS", "Out", "page")
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	// Both source files go; only the one under "Inside" is in scope.
+	require.NoError(t, os.Remove(filepath.Join(dir, "in.md")))
+	require.NoError(t, os.Remove(filepath.Join(dir, "out.md")))
+	require.NoError(t, Run(config))
+
+	assert.True(t, server.Page(in.ID).Trashed, "the page below Inside is in scope")
+	assert.False(t, server.Page(out.ID).Trashed, "the page below Outside is not")
+}

--- a/page/orphan.go
+++ b/page/orphan.go
@@ -1,0 +1,206 @@
+package page
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/rs/zerolog/log"
+)
+
+// What to do about a page whose source file is gone.
+const (
+	// OnOrphanReport says so and does nothing, which is what mark has always
+	// done and remains the default.
+	OnOrphanReport = "report"
+
+	// OnOrphanArchive archives the page. Cloud only.
+	OnOrphanArchive = "archive"
+
+	// OnOrphanDelete moves the page to the trash, where a person can still
+	// change their mind.
+	OnOrphanDelete = "delete"
+)
+
+// ParseOnOrphan reads the value given to --on-orphan.
+func ParseOnOrphan(value string) (string, error) {
+	switch action := strings.ToLower(strings.TrimSpace(value)); action {
+	case "", OnOrphanReport:
+		return OnOrphanReport, nil
+	case OnOrphanArchive:
+		return OnOrphanArchive, nil
+	case OnOrphanDelete:
+		return OnOrphanDelete, nil
+	default:
+		return "", fmt.Errorf(
+			"unknown --on-orphan value %q: expected %s, %s or %s",
+			value, OnOrphanReport, OnOrphanArchive, OnOrphanDelete,
+		)
+	}
+}
+
+// Orphan is a tracked page whose source file was not seen in the run.
+type Orphan struct {
+	Path   string
+	PageID string
+	Title  string
+}
+
+// OrphanScope limits which orphans may be acted on.
+type OrphanScope struct {
+	// Under is a page or folder whose descendants alone are in scope. Empty
+	// means the whole space, as far as the run's own file pattern reaches.
+	Under string
+}
+
+// ResolveScope finds the page or folder --orphans-under names.
+//
+// A title or an id, and a page or a folder, because the thing people want to
+// put a boundary around is a place in the tree and mark's tree has both in it.
+func ResolveScope(api *confluence.API, spaceKey, under string) (string, error) {
+	under = strings.TrimSpace(under)
+	if under == "" {
+		return "", nil
+	}
+
+	// An id, if it looks like one and something is there.
+	if isNumeric(under) {
+		if found, err := api.GetPageByID(under); err == nil && found != nil {
+			return found.ID, nil
+		}
+	}
+
+	found, err := api.FindPage(spaceKey, under, "page")
+	if err != nil {
+		return "", fmt.Errorf("unable to find %q in space %q: %w", under, spaceKey, err)
+	}
+	if found != nil {
+		return found.ID, nil
+	}
+
+	folder, err := api.FindFolder(spaceKey, under, "")
+	if err != nil {
+		return "", fmt.Errorf("unable to find folder %q in space %q: %w", under, spaceKey, err)
+	}
+	if folder != nil {
+		return folder.ID, nil
+	}
+
+	return "", fmt.Errorf(
+		"--orphans-under names %q, which is not a page or folder in space %q",
+		under, spaceKey,
+	)
+}
+
+func isNumeric(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return s != ""
+}
+
+// InScope reports whether an orphan sits beneath the scope's boundary.
+//
+// Answered from the page's own ancestors rather than by listing the boundary's
+// descendants: there are few orphans and there may be very many descendants.
+func InScope(api *confluence.API, scopeID string, orphan Orphan) (bool, error) {
+	if scopeID == "" {
+		return true, nil
+	}
+
+	page, err := api.GetPageByIDExpanded(orphan.PageID, "ancestors")
+	if err != nil {
+		return false, fmt.Errorf("unable to read page %s: %w", orphan.PageID, err)
+	}
+
+	if page == nil {
+		// Already gone from Confluence. Out of scope for acting on, and the
+		// caller forgets it either way.
+		return false, nil
+	}
+
+	for _, ancestor := range page.Ancestors {
+		if ancestor.ID == scopeID {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// HandleOrphans acts on the pages whose source files are gone.
+//
+// Returns the paths that were dealt with, which the caller stops tracking. A
+// page that could not be acted on stays in the manifest, so the next run finds
+// it again rather than losing sight of it.
+func HandleOrphans(
+	api *confluence.API,
+	action string,
+	scopeID string,
+	orphans []Orphan,
+	dryRun bool,
+) ([]string, error) {
+	var handled []string
+
+	for _, orphan := range orphans {
+		inScope, err := InScope(api, scopeID, orphan)
+		if err != nil {
+			return handled, err
+		}
+
+		if !inScope {
+			log.Debug().Msgf(
+				"page %q is outside the orphan scope; leaving it alone", orphan.Title,
+			)
+
+			continue
+		}
+
+		if action == OnOrphanReport {
+			handled = append(handled, orphan.Path)
+
+			continue
+		}
+
+		// Trashing a page takes its children with it, and those may be pages
+		// nobody in this repository ever wrote.
+		children, err := api.GetChildPages(orphan.PageID)
+		if err != nil {
+			return handled, fmt.Errorf("unable to list children of %s: %w", orphan.PageID, err)
+		}
+
+		if len(children) > 0 {
+			log.Warn().Msgf(
+				"page %q has %d child page(s) and is left alone: removing it would take them too",
+				orphan.Title, len(children),
+			)
+
+			continue
+		}
+
+		if dryRun {
+			log.Info().Msgf("page %q would be %sd", orphan.Title, action)
+			handled = append(handled, orphan.Path)
+
+			continue
+		}
+
+		log.Info().Msgf("%s page %q (%s)", action, orphan.Title, orphan.PageID)
+
+		if action == OnOrphanArchive {
+			err = api.ArchivePage(orphan.PageID)
+		} else {
+			err = api.DeletePage(orphan.PageID)
+		}
+		if err != nil {
+			return handled, fmt.Errorf("unable to %s page %q: %w", action, orphan.Title, err)
+		}
+
+		handled = append(handled, orphan.Path)
+	}
+
+	return handled, nil
+}

--- a/util/cli.go
+++ b/util/cli.go
@@ -121,6 +121,8 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 		CheckLinksWarnOnly: cmd.Bool("check-links-warn-only"),
 		AppendLabels:       cmd.Bool("append-labels"),
 		GlobalProperties:   cmd.String("global-properties"),
+		OnOrphan:           cmd.String("on-orphan"),
+		OrphansUnder:       cmd.String("orphans-under"),
 		PreserveComments:   cmd.Bool("preserve-comments"),
 
 		DropH1:          cmd.Bool("drop-h1"),

--- a/util/flags.go
+++ b/util/flags.go
@@ -198,6 +198,20 @@ var Flags = []cli.Flag{
 		Usage:   "Avoids re-uploading pages that haven't changed since the last run.",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHANGES_ONLY"), altsrctoml.TOML("changes-only", altsrc.NewStringPtrSourcer(&filename))),
 	},
+	&cli.StringFlag{
+		Name:  "on-orphan",
+		Value: "report",
+		Usage: "what to do about a page whose source file is gone: \"report\" says so and does nothing (the default), \"archive\" archives the page (Confluence Cloud only), \"delete\" moves it to the trash. Requires --track-pages.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_ON_ORPHAN"),
+			altsrctoml.TOML("on-orphan", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:  "orphans-under",
+		Value: "",
+		Usage: "limit --on-orphan to pages below this page or folder, given by title or id. Without it, every tracked page the --files pattern would have published is in scope.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_ORPHANS_UNDER"),
+			altsrctoml.TOML("orphans-under", altsrc.NewStringPtrSourcer(&filename))),
+	},
 	&cli.StringSliceFlag{
 		Name:  "check-links",
 		Usage: "fail on links that do not resolve. Repeat or comma-separate any of: \"internal\" (relative links to other files in the repository), \"confluence\" (ac: links naming a page by title), \"external\" (requests each URL to see whether it answers), or \"all\".",


### PR DESCRIPTION
Closes the long-standing "what happens when I delete a file" question (#98). mark reported an orphaned page and left the rest to a person, because it had no way to know the page was its own to remove. The manifest is that way — it records which page each file published to, so a page can be *identified* as mark's work rather than guessed at by title.

```bash
mark --track-pages --on-orphan delete --files "docs/**/*.md"
```

| Value | Effect |
| --- | --- |
| `report` | say so and leave the page alone — the default, and unchanged behaviour |
| `archive` | archive the page (Cloud only) |
| `delete` | move the page to the trash |

## Scoping

`--orphans-under` narrows it to the pages below one page or folder, by title or id, for a repository sharing a space with anything else:

```bash
mark --track-pages --on-orphan delete --orphans-under "Team Handbook" --files "docs/**/*.md"
```

Membership is answered from each orphan's **own ancestors** rather than by listing the boundary's descendants — there are few of the former and possibly very many of the latter. Title or id, page or folder, because the thing people want to draw a boundary around is a place in the tree and mark's tree has both in it.

Without it, scope is every tracked page the `--files` pattern would have published — already narrower than the space, since a pattern is only evidence about where it was looking.

## Deletion means the trash

`DELETE /content/{id}` moves a page to the trash and Confluence keeps it recoverable. Purging is a second call with `?status=trashed` that **mark deliberately never makes**. A tool that removes pages because a file left a repository should leave the last word to a person.

## The refusals, which are most of the change

This is the one thing mark does that cannot be undone by running it again:

- **`--track-pages` is required** and mark will not start without it.
- **A page holding child pages is left alone** and reported — removing it would take them too, and they may be pages nobody here wrote.
- **A run in which any file failed removes nothing**: a file that failed to process is indistinguishable from one that was deleted.
- **A run that published nothing removes nothing**, so a failed checkout cannot empty a space.
- `Synchronized: false` still counts as present.
- `--dry-run` reports and touches nothing.
- **A page left alone stays in the manifest**, so the next run finds it again rather than losing sight of it.

## Verification, including one honest caveat

With the children check and the scope check disabled, their tests fail:

```
--- FAIL: TestOnOrphanLeavesAPageWithChildren
--- FAIL: TestOrphansUnderLimitsScope
--- PASS: TestOnOrphanLeavesEverythingWhenNothingPublished
```

That third one **passes with its guard removed**, and I have left it in saying so. An empty file set already stops the run before orphans are considered, so the guard in `actOnOrphans` is a second line of defence rather than the thing doing the work. The test is written against the *property* — a run that publishes nothing removes nothing — so that moving orphan handling ahead of the other check fails here rather than quietly enabling mass deletion from a bad checkout. Both the comment and the test say which is which.

Also covered: report/archive/delete each doing what they say, `--dry-run`, the missing `--track-pages`, and an unknown action value.

`archive` uses the documented bulk endpoint and is exercised against the fake; **it is the one part I cannot verify against a real Cloud instance**, so it deserves a look before release.

Settings are now validated at the top of `Run`, before the glob is resolved — a typo'd flag was previously reported only after "no files matched".

Full suite green under `-race`; `golangci-lint`: 0 issues.