### PR TITLE
feat: resolve links between pages published together in one run

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,6 +951,20 @@ cannot tell a `Label` header somebody deleted from a label somebody added in
 Confluence. That is visible on the page and can be undone by hand, which the
 deletion it prevents is not.
 
+### Links between pages published together
+
+A link is resolved by finding the page it points at, so a document linking to
+another that the same run is creating has nothing to find yet.
+
+Mark notes those documents and publishes them again once everything exists, so
+links resolve within a single run. Only the documents that were waiting are
+published a second time, and only on the run that creates their targets: once
+the pages are there, later runs find them the first time and nothing is
+published twice.
+
+Nothing is published again on `--dry-run` or `--compile-only`, where no page is
+being created for a link to wait for.
+
 ### Checking that links go somewhere
 
 By default a link that cannot be resolved is left exactly as written, which in
@@ -991,9 +1005,9 @@ so this cannot change what an unambiguous link already meant. Only the files a
 document includes directly are considered, not what those files include in turn.
 
 One case is reported but does not fail: a link to a document that exists and has
-a title, but is not in the space yet. That is the ordinary state of a first run
-over files that link to each other, and failing there would break a build that
-succeeds on the second attempt.
+a title, but is not in the space and is not being published by this run either.
+A page the run is about to create is waited for rather than complained about --
+see below -- so this is left for the genuinely absent.
 
 A `confluence` link is checked by looking for a page of that title in the
 document's own space, which is what an `ac:` link resolves against. The title is

--- a/mark.go
+++ b/mark.go
@@ -217,6 +217,17 @@ func Run(config Config) error {
 		tracker.SetRunFiles(config.Files, files)
 	}
 
+	// A link is resolved by finding the page it points at, so a document linking
+	// to another this run is about to create has nothing to find. Collected
+	// while publishing and dealt with afterwards.
+	//
+	// Not on a dry run or a compile: nothing is published, so nothing a link is
+	// waiting for will come to exist, and the wait is worth reporting instead.
+	var deferrals *page.Deferrals
+	if !config.DryRun && !config.CompileOnly {
+		deferrals = page.NewDeferrals()
+	}
+
 	// Pages that asked for a position among their siblings, collected as they
 	// publish and applied once at the end -- the order of one page only means
 	// anything alongside the others.
@@ -226,7 +237,7 @@ func Run(config Config) error {
 	for _, file := range files {
 		log.Info().Msgf("processing %s", file)
 
-		target, placement, err := processFile(file, api, config, std, tracker, folders, checker, globalProperties)
+		target, placement, err := processFile(file, api, config, std, tracker, folders, checker, globalProperties, deferrals)
 		if placement != nil {
 			ordered = append(ordered, *placement)
 		}
@@ -242,6 +253,34 @@ func Run(config Config) error {
 		if target != nil {
 			log.Info().Msgf("page successfully updated: %s", api.BaseURL+target.Links.Full)
 			if _, err := fmt.Fprintln(config.output(), api.BaseURL+target.Links.Full); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Everything exists now, so the documents that were waiting on a page this
+	// run created can be published again with their links resolved.
+	if waiting := deferrals.Files(); len(waiting) > 0 && !hasErrors {
+		log.Info().Msgf(
+			"%d document(s) linked to pages created in this run; publishing them again",
+			len(waiting),
+		)
+
+		for _, file := range waiting {
+			log.Info().Msgf("processing %s again", file)
+
+			// Nil deferrals: this is the last look, so a link that still does
+			// not resolve is reported rather than waited on again.
+			if _, _, err := processFile(
+				file, api, config, std, tracker, folders, checker, globalProperties, nil,
+			); err != nil {
+				if config.ContinueOnError {
+					log.Error().Err(err).Msgf("processing %s", file)
+					hasErrors = true
+
+					continue
+				}
+
 				return err
 			}
 		}
@@ -360,7 +399,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 
 	checker := page.NewLinkChecker(linkChecks)
 
-	target, _, err := processFile(file, api, config, std, nil, nil, checker, globalProperties)
+	target, _, err := processFile(file, api, config, std, nil, nil, checker, globalProperties, nil)
 	if err != nil {
 		return target, err
 	}
@@ -379,7 +418,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 	return target, nil
 }
 
-func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, folders page.FolderTracker, checker *page.LinkChecker, globalProperties map[string]any) (*confluence.PageInfo, *page.Ordered, error) {
+func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, folders page.FolderTracker, checker *page.LinkChecker, globalProperties map[string]any, deferrals *page.Deferrals) (*confluence.PageInfo, *page.Ordered, error) {
 	markdown, err := os.ReadFile(file)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to read file %q: %w", file, err)
@@ -490,6 +529,9 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		checker,
 		searchDirs,
 	)
+	resolver.SourceFile = file
+	resolver.Deferrals = deferrals
+
 	resolveLink := resolver.Resolve
 
 	if config.DryRun {

--- a/mark_twopass_test.go
+++ b/mark_twopass_test.go
@@ -1,0 +1,154 @@
+package mark
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func twoPassServer(t *testing.T) *confluencetest.Server {
+	t.Helper()
+	s := confluencetest.New(t)
+	home := s.AddPage("DOCS", "Home", "page", "")
+	s.SetHomepage("DOCS", home.ID)
+	s.AddPage("DOCS", "Parent", "page", home.ID)
+	return s
+}
+
+// TestLinksResolveOnTheFirstRun is the point of the change. A document linking
+// to another the same run creates had nothing to find, so the link stayed dead
+// until somebody ran mark a second time.
+func TestLinksResolveOnTheFirstRun(t *testing.T) {
+	server := twoPassServer(t)
+	dir := t.TempDir()
+	header := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n"
+
+	writeFile(t, dir, "a-doc.md", header+"<!-- Title: A -->\n\nSee [B](./b-doc.md).\n")
+	writeFile(t, dir, "b-doc.md", header+"<!-- Title: B -->\n\nB.\n")
+
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		Output: io.Discard,
+	}))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	a, err := api.FindPage("DOCS", "A", "page")
+	require.NoError(t, err)
+	require.NotNil(t, a)
+
+	body := server.Page(a.ID).Body
+	assert.Contains(t, body, "/x/", "the link must resolve within one run")
+	assert.NotContains(t, body, "./b-doc.md")
+}
+
+// TestSecondPassOnlyRepublishesWhatWaited: a document with nothing waiting must
+// not be written twice.
+func TestSecondPassOnlyRepublishesWhatWaited(t *testing.T) {
+	server := twoPassServer(t)
+	dir := t.TempDir()
+	header := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n"
+
+	writeFile(t, dir, "a-doc.md", header+"<!-- Title: A -->\n\nSee [B](./b-doc.md).\n")
+	writeFile(t, dir, "b-doc.md", header+"<!-- Title: B -->\n\nB, linking nowhere.\n")
+
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		Output: io.Discard,
+	}))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	a, err := api.FindPage("DOCS", "A", "page")
+	require.NoError(t, err)
+	b, err := api.FindPage("DOCS", "B", "page")
+	require.NoError(t, err)
+
+	assert.Greater(t, server.Page(a.ID).Version, server.Page(b.ID).Version,
+		"only the document that was waiting should have been published again")
+}
+
+// TestSecondRunDoesNothingExtra: once the pages exist there is nothing to wait
+// for, so a later run publishes each document once.
+func TestSecondRunDoesNothingExtra(t *testing.T) {
+	server := twoPassServer(t)
+	dir := t.TempDir()
+	header := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n"
+
+	writeFile(t, dir, "a-doc.md", header+"<!-- Title: A -->\n\nSee [B](./b-doc.md).\n")
+	writeFile(t, dir, "b-doc.md", header+"<!-- Title: B -->\n\nB.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	a, err := api.FindPage("DOCS", "A", "page")
+	require.NoError(t, err)
+	before := server.Page(a.ID).Version
+
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, before+1, server.Page(a.ID).Version,
+		"a run with nothing waiting should publish each document once")
+}
+
+// TestCheckLinksSeesResolvedLinksForPagesThisRunCreates covers the interaction
+// with --check-links, whose "not in the space yet" warning existed because of
+// the limitation this removes.
+//
+// Asserting only that the run succeeds would prove nothing -- that case was a
+// warning before as well -- so the link is checked to have actually resolved.
+func TestCheckLinksSeesResolvedLinksForPagesThisRunCreates(t *testing.T) {
+	server := twoPassServer(t)
+	dir := t.TempDir()
+	header := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n"
+
+	writeFile(t, dir, "a-doc.md", header+"<!-- Title: A -->\n\nSee [B](./b-doc.md).\n")
+	writeFile(t, dir, "b-doc.md", header+"<!-- Title: B -->\n\nB.\n")
+
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		CheckLinks: []string{"internal"}, Output: io.Discard,
+	}))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	a, err := api.FindPage("DOCS", "A", "page")
+	require.NoError(t, err)
+	require.NotNil(t, a)
+	assert.Contains(t, server.Page(a.ID).Body, "/x/",
+		"nothing should be left waiting for a page this run created")
+}
+
+// TestDryRunDoesNotWaitForPages: nothing is published on a dry run, so nothing
+// a link waits for will come to exist and the wait is worth reporting.
+func TestDryRunDoesNotWaitForPages(t *testing.T) {
+	server := twoPassServer(t)
+	dir := t.TempDir()
+	header := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n"
+
+	writeFile(t, dir, "a-doc.md", header+"<!-- Title: A -->\n\nSee [B](./b-doc.md).\n")
+	writeFile(t, dir, "b-doc.md", header+"<!-- Title: B -->\n\nB.\n")
+
+	var out strings.Builder
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		DryRun: true, Output: &out,
+	}))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	a, err := api.FindPage("DOCS", "A", "page")
+	require.NoError(t, err)
+	assert.Nil(t, a, "a dry run publishes nothing")
+}

--- a/page/link.go
+++ b/page/link.go
@@ -8,8 +8,10 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/kovetskiy/mark/v16/confluence"
 	"github.com/kovetskiy/mark/v16/metadata"
@@ -43,6 +45,15 @@ type LinkResolver struct {
 
 	// Checker decides how much is verified. Nil checks nothing.
 	Checker *LinkChecker
+
+	// SourceFile is the document being resolved for, so that a link waiting on
+	// a page this run has yet to create can name the file to publish again.
+	SourceFile string
+
+	// Deferrals collects those waits. Nil says nobody is going to publish
+	// anything a second time -- a dry run, or the second pass itself -- so a
+	// link to a page that is not there is reported rather than waited on.
+	Deferrals *Deferrals
 
 	// broken collects the links that failed a check, rather than the first one
 	// stopping the file. Reporting one at a time would mean fixing a link,
@@ -152,13 +163,23 @@ func (r *LinkResolver) Resolve(target, text string) (string, error) {
 		return "", fmt.Errorf("resolve link %q: %w", target, err)
 	}
 
-	if why != nil && r.checking() {
-		if why.transient {
-			// Never a failure: the ordinary state of a first run over files
-			// that link to each other.
+	if why != nil {
+		switch {
+		case !why.transient:
+			if r.checking() {
+				r.note("link %q does not resolve: %s", target, why.reason)
+			}
+
+		case r.Deferrals != nil:
+			// The page is not there yet, and this run is about to create it.
+			// Saying so now would be complaining about something that has not
+			// finished happening.
+			log.Debug().Msgf("link %q waits for %s", target, why.reason)
+			r.Deferrals.Note(r.SourceFile)
+
+		case r.checking():
+			// Nothing more is going to publish it.
 			log.Warn().Msgf("link %q does not resolve: %s", target, why.reason)
-		} else {
-			r.note("link %q does not resolve: %s", target, why.reason)
 		}
 	}
 
@@ -437,4 +458,51 @@ func encodeTinyLinkID(id uint64) string {
 	}
 
 	return result.String()
+}
+
+// Deferrals remembers which documents linked to pages that did not exist yet.
+//
+// mark resolves a link by finding the page it points at, so a document linking
+// to another that the same run is about to create has nothing to find. Rather
+// than leave the link dead until somebody runs mark again -- which is what the
+// documentation used to advise -- the documents that waited are published a
+// second time once everything exists.
+type Deferrals struct {
+	mu    sync.Mutex
+	files map[string]bool
+}
+
+// NewDeferrals returns an empty collector.
+func NewDeferrals() *Deferrals {
+	return &Deferrals{files: map[string]bool{}}
+}
+
+// Note records that a document has a link waiting on a page not yet published.
+func (d *Deferrals) Note(file string) {
+	if d == nil || file == "" {
+		return
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.files[file] = true
+}
+
+// Files returns the documents to publish again, in a stable order.
+func (d *Deferrals) Files() []string {
+	if d == nil {
+		return nil
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	files := make([]string, 0, len(d.files))
+	for file := range d.files {
+		files = append(files, file)
+	}
+	sort.Strings(files)
+
+	return files
 }


### PR DESCRIPTION
mark resolves a link by finding the page it points at, so a document linking to another that the same run is creating has nothing to find. The link stayed dead until somebody ran mark again — the README said so, and **every test in this repository works around it** with `// Twice, so the target exists by the time the link is resolved`.

```markdown
<!-- Title: A -->
See [B](./b-doc.md).
```

Publishing A and B together left A's link pointing at `./b-doc.md`.

## How it works

Documents that waited are noted while publishing, and published again once everything exists.

The property that keeps this cheap: **a wait only happens when the target does not exist yet**. So the second publish is a first-run cost, not a permanent doubling — once the pages are there, later runs find them the first time and nothing is republished. `TestSecondRunDoesNothingExtra` pins that.

Only the documents that actually waited are republished, not everything. `TestSecondPassOnlyRepublishesWhatWaited` pins that too, by asserting the document with nothing to wait for ends up on a lower version than the one that did.

Nothing is republished on `--dry-run` or `--compile-only`, where no page is being created for a link to wait for.

## The distinction is a nil collector

Whether a document is *waiting* or *being told* comes down to one thing: a nil deferral collector says nobody is going to publish anything again. That is true of a dry run and true of the second pass itself, so no separate "final pass" flag is needed — the second pass simply gets nil and reports whatever is still unresolved.

## It settles a wart in #895

`--check-links`' "not in the space yet" case existed precisely because of this limitation, and *had* to be a warning rather than a failure to avoid breaking a build that would have succeeded on a second run. It now means what it sounds like: a link to a page nothing is going to publish. README updated accordingly.

## Verification

Against master, the two substantive tests fail:

```
--- FAIL: TestLinksResolveOnTheFirstRun
--- FAIL: TestSecondPassOnlyRepublishesWhatWaited
--- PASS: TestSecondRunDoesNothingExtra
--- PASS: TestDryRunDoesNotWaitForPages
```

The two that pass on master are guards — that this does not publish twice when nothing is waiting, and does not publish at all on a dry run. Both would fail if the second pass fired indiscriminately.

`TestCheckLinksSeesResolvedLinksForPagesThisRunCreates` was weak when I first wrote it: it asserted only that the run succeeded, which was already true on master since that case was a warning. It now checks the link actually resolved, and fails on master.

The existing suite passes unchanged — including every test that runs mark twice, which now simply does the same work in one.

Full suite green under `-race`; `golangci-lint`: 0 issues.