### PR TITLE
feat: report a run as JSON or as GitHub Actions annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,6 +951,56 @@ cannot tell a `Label` header somebody deleted from a label somebody added in
 Confluence. That is visible on the page and can be undone by hand, which the
 deletion it prevents is not.
 
+### Reporting what a run did
+
+By default Mark prints the address of each page as it publishes, which is what
+it has always done. `--output-format` offers two other shapes.
+
+`json` describes the whole run as one object:
+
+```bash
+mark --output-format json --files "docs/**/*.md" | jq -r '.pages[] | select(.status=="published") | .url'
+```
+
+```json
+{
+  "pages": [
+    {
+      "file": "docs/architecture.md",
+      "status": "published",
+      "space": "DOCS",
+      "title": "Architecture",
+      "pageId": "1004",
+      "url": "https://example.atlassian.net/wiki/display/DOCS/Architecture"
+    },
+    {
+      "file": "docs/draft.md",
+      "status": "skipped",
+      "reason": "the document is not synchronized"
+    }
+  ],
+  "orphans": [{"file": "docs/old.md", "action": "delete"}]
+}
+```
+
+A page is `published`, `unchanged` (`--changes-only` found nothing to do),
+`skipped` (not synchronized, or edited in Confluence under `--no-overwrite`) or
+`failed`, with `reason` saying which in the last two cases.
+
+`github` prints [workflow
+commands](https://docs.github.com/actions/reference/workflow-commands-for-github-actions),
+so that a failure appears against the file that caused it in a pull request:
+
+```text
+::notice file=docs/architecture.md::published "Architecture" to https://...
+::warning file=docs/draft.md::the document is not synchronized
+::error file=docs/broken.md::unable to compile markdown: ...
+```
+
+```yaml
+- run: mark --output-format github --files "docs/**/*.md"
+```
+
 ### Links between pages published together
 
 A link is resolved by finding the page it points at, so a document linking to
@@ -1279,6 +1329,7 @@ GLOBAL OPTIONS:
    --mermaid-scale float                    defines the scaling factor for mermaid renderings. (default: 1) [$MARK_MERMAID_SCALE]
    --include-path string                    Path for shared includes, used as a fallback if the include doesn't exist in the current directory. [$MARK_INCLUDE_PATH]
    --changes-only                           Avoids re-uploading pages that haven't changed since the last run. [$MARK_CHANGES_ONLY]
+   --output-format string                   how to report what the run did: "url" prints the address of each published page (the default), "json" prints one object describing the whole run, "github" prints GitHub Actions workflow commands so that failures appear against the file that caused them. [$MARK_OUTPUT_FORMAT]
    --on-orphan string                       what to do about a page whose source file is gone: "report" says so and does nothing (the default), "archive" archives the page (Confluence Cloud only), "delete" moves it to the trash. Requires --track-pages. [$MARK_ON_ORPHAN]
    --orphans-under string                   limit --on-orphan to pages below this page or folder, given by title or id. Without it, every tracked page the --files pattern would have published is in scope. [$MARK_ORPHANS_UNDER]
    --check-links string [ --check-links string ]  fail on links that do not resolve. Repeat or comma-separate any of: "internal" (relative links to other files in the repository), "confluence" (ac: links naming a page by title), "external" (requests each URL to see whether it answers), or "all". [$MARK_CHECK_LINKS]

--- a/mark.go
+++ b/mark.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kovetskiy/mark/v16/mermaid"
 	"github.com/kovetskiy/mark/v16/metadata"
 	"github.com/kovetskiy/mark/v16/page"
+	"github.com/kovetskiy/mark/v16/report"
 	"github.com/kovetskiy/mark/v16/stdlib"
 	"github.com/kovetskiy/mark/v16/types"
 	"github.com/kovetskiy/mark/v16/vfs"
@@ -77,6 +78,7 @@ type Config struct {
 	AppendLabels       bool
 	GlobalProperties   string
 	OnOrphan           string
+	OutputFormat       string
 	OrphansUnder       string
 
 	// Rendering
@@ -108,6 +110,11 @@ func Run(config Config) error {
 	// Settings are checked before anything else happens. A value that cannot be
 	// acted on should be said so plainly, not after a glob has been resolved
 	// and a connection opened -- and least of all part way through publishing.
+	outputFormat, err := report.ParseFormat(config.OutputFormat)
+	if err != nil {
+		return err
+	}
+
 	onOrphan, err := page.ParseOnOrphan(config.OnOrphan)
 	if err != nil {
 		return err
@@ -228,6 +235,9 @@ func Run(config Config) error {
 		deferrals = page.NewDeferrals()
 	}
 
+	// What the run did, for whatever is reading the output rather than the log.
+	results := report.New()
+
 	// Pages that asked for a position among their siblings, collected as they
 	// publish and applied once at the end -- the order of one page only means
 	// anything alongside the others.
@@ -237,23 +247,37 @@ func Run(config Config) error {
 	for _, file := range files {
 		log.Info().Msgf("processing %s", file)
 
-		target, placement, err := processFile(file, api, config, std, tracker, folders, checker, globalProperties, deferrals)
+		target, placement, err := processFile(file, api, config, std, tracker, folders, checker, globalProperties, deferrals, results)
 		if placement != nil {
 			ordered = append(ordered, *placement)
 		}
 		if err != nil {
+			results.AddPage(report.Page{
+				File: file, Status: report.StatusFailed, Reason: err.Error(),
+			})
+
 			if config.ContinueOnError {
 				log.Error().Err(err).Msgf("processing %s", file)
 				hasErrors = true
 				continue
 			}
+
+			if writeErr := results.Write(config.output(), outputFormat); writeErr != nil {
+				log.Error().Err(writeErr).Msg("unable to write the run report")
+			}
+
 			return err
 		}
 
 		if target != nil {
 			log.Info().Msgf("page successfully updated: %s", api.BaseURL+target.Links.Full)
-			if _, err := fmt.Fprintln(config.output(), api.BaseURL+target.Links.Full); err != nil {
-				return err
+
+			// The other formats describe the whole run at the end, where a
+			// page published twice can be reported once.
+			if outputFormat == report.FormatURL {
+				if _, err := fmt.Fprintln(config.output(), api.BaseURL+target.Links.Full); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -272,7 +296,7 @@ func Run(config Config) error {
 			// Nil deferrals: this is the last look, so a link that still does
 			// not resolve is reported rather than waited on again.
 			if _, _, err := processFile(
-				file, api, config, std, tracker, folders, checker, globalProperties, nil,
+				file, api, config, std, tracker, folders, checker, globalProperties, nil, results,
 			); err != nil {
 				if config.ContinueOnError {
 					log.Error().Err(err).Msgf("processing %s", file)
@@ -314,7 +338,7 @@ func Run(config Config) error {
 	var saveErr error
 	if tracker != nil {
 		reportOrphans(tracker, hasErrors)
-		if err := actOnOrphans(tracker, api, config, onOrphan, hasErrors); err != nil {
+		if err := actOnOrphans(tracker, api, config, onOrphan, hasErrors, results); err != nil {
 			return err
 		}
 		pruneOrphans(tracker, hasErrors, config.DryRun)
@@ -331,6 +355,10 @@ func Run(config Config) error {
 			"%s:\n  %s",
 			pluraliseLinks(len(missingPages)), strings.Join(missingPages, "\n  "),
 		)
+	}
+
+	if err := results.Write(config.output(), outputFormat); err != nil {
+		return fmt.Errorf("unable to write the run report: %w", err)
 	}
 
 	if hasErrors {
@@ -399,7 +427,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 
 	checker := page.NewLinkChecker(linkChecks)
 
-	target, _, err := processFile(file, api, config, std, nil, nil, checker, globalProperties, nil)
+	target, _, err := processFile(file, api, config, std, nil, nil, checker, globalProperties, nil, nil)
 	if err != nil {
 		return target, err
 	}
@@ -418,7 +446,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 	return target, nil
 }
 
-func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, folders page.FolderTracker, checker *page.LinkChecker, globalProperties map[string]any, deferrals *page.Deferrals) (*confluence.PageInfo, *page.Ordered, error) {
+func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, folders page.FolderTracker, checker *page.LinkChecker, globalProperties map[string]any, deferrals *page.Deferrals, results *report.Report) (*confluence.PageInfo, *page.Ordered, error) {
 	markdown, err := os.ReadFile(file)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to read file %q: %w", file, err)
@@ -472,6 +500,11 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	// not use.
 	if !meta.Publish() {
 		log.Info().Msgf("%s is not synchronized; leaving it alone", file)
+		results.AddPage(report.Page{
+			File: file, Status: report.StatusSkipped,
+			Reason: "the document is not synchronized",
+			Space:  spaceOf(meta), Title: titleOf(meta),
+		})
 
 		// Looked up purely to mark the path as seen. A page somebody stopped
 		// synchronising is one they chose to keep, and a run that did not
@@ -697,6 +730,16 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 				target.Title, target.Version.Number, recorded,
 			)
 
+			results.AddPage(report.Page{
+				File: file, Status: report.StatusSkipped,
+				Reason: fmt.Sprintf(
+					"edited in Confluence since mark published it (version %d, mark wrote %d)",
+					target.Version.Number, recorded,
+				),
+				Space: spaceOf(meta), Title: target.Title,
+				PageID: target.ID, URL: api.BaseURL + target.Links.Full,
+			})
+
 			// Recorded, so the page still counts as seen and is not mistaken
 			// for an orphan and deleted. The version is deliberately not
 			// updated: until somebody resolves the difference, every run should
@@ -867,6 +910,16 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 			return nil, nil, fmt.Errorf("unable to record page mapping for %q: %w", file, err)
 		}
 	}
+
+	status := report.StatusPublished
+	if !shouldUpdatePage {
+		status = report.StatusUnchanged
+	}
+	results.AddPage(report.Page{
+		File: file, Status: status,
+		Space: spaceOf(meta), Title: target.Title,
+		PageID: target.ID, URL: api.BaseURL + target.Links.Full,
+	})
 
 	if shouldUpdatePage {
 		err = api.UpdatePage(
@@ -1744,6 +1797,7 @@ func actOnOrphans(
 	config Config,
 	action string,
 	hadErrors bool,
+	results *report.Report,
 ) error {
 	if action == page.OnOrphanReport {
 		return nil
@@ -1806,6 +1860,8 @@ func actOnOrphans(
 		// out of scope, or holding children -- stays in the manifest so the
 		// next run finds it again instead of losing sight of it.
 		for _, path := range handled {
+			results.AddOrphan(report.Orphan{File: path, Action: action})
+
 			if err := tracker.Forget(space, path); err != nil {
 				return fmt.Errorf("unable to update page manifest for %q: %w", path, err)
 			}
@@ -1813,4 +1869,20 @@ func actOnOrphans(
 	}
 
 	return nil
+}
+
+func spaceOf(meta *metadata.Meta) string {
+	if meta == nil {
+		return ""
+	}
+
+	return meta.Space
+}
+
+func titleOf(meta *metadata.Meta) string {
+	if meta == nil {
+		return ""
+	}
+
+	return meta.Title
 }

--- a/mark_output_test.go
+++ b/mark_output_test.go
@@ -1,0 +1,146 @@
+package mark
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func outputServer(t *testing.T) *confluencetest.Server {
+	t.Helper()
+	s := confluencetest.New(t)
+	home := s.AddPage("DOCS", "Home", "page", "")
+	s.SetHomepage("DOCS", home.ID)
+	s.AddPage("DOCS", "Parent", "page", home.ID)
+	return s
+}
+
+func runWithFormat(t *testing.T, format string, files map[string]string) (string, error) {
+	t.Helper()
+
+	server := outputServer(t)
+	dir := t.TempDir()
+	for name, content := range files {
+		writeFile(t, dir, name, content)
+	}
+
+	var out strings.Builder
+	err := Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		OutputFormat: format, ContinueOnError: true, Output: &out,
+	})
+
+	return out.String(), err
+}
+
+const outHeader = "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n"
+
+func TestOutputFormatURLIsUnchanged(t *testing.T) {
+	out, err := runWithFormat(t, "", map[string]string{
+		"a.md": outHeader + "<!-- Title: A -->\n\nA.\n",
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "/display/DOCS/")
+	assert.NotContains(t, out, "{", "the default output is not JSON")
+}
+
+func TestOutputFormatJSON(t *testing.T) {
+	out, err := runWithFormat(t, "json", map[string]string{
+		"a.md": outHeader + "<!-- Title: A -->\n\nA.\n",
+		"b.md": outHeader + "<!-- Title: B -->\n<!-- Synchronized: false -->\n\nB.\n",
+	})
+	require.NoError(t, err)
+
+	var got struct {
+		Pages []struct {
+			File, Status, Space, Title, PageID, URL, Reason string
+		} `json:"pages"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &got), "the output must parse as JSON")
+	require.Len(t, got.Pages, 2)
+
+	byStatus := map[string]string{}
+	for _, page := range got.Pages {
+		byStatus[page.Status] = page.File
+		assert.NotEmpty(t, page.File)
+	}
+
+	require.Contains(t, byStatus, "published")
+	require.Contains(t, byStatus, "skipped")
+	assert.True(t, strings.HasSuffix(byStatus["published"], "a.md"))
+	assert.True(t, strings.HasSuffix(byStatus["skipped"], "b.md"))
+
+	// The published page carries what a script would want to act on.
+	for _, page := range got.Pages {
+		if page.Status == "published" {
+			assert.Equal(t, "DOCS", page.Space)
+			assert.Equal(t, "A", page.Title)
+			assert.NotEmpty(t, page.PageID)
+			assert.Contains(t, page.URL, "/display/DOCS/")
+		}
+	}
+}
+
+// TestOutputFormatGitHubAnnotatesAFailingFile is why the format exists: the
+// failure has to name the file so it lands on it in a pull request.
+func TestOutputFormatGitHubAnnotatesAFailingFile(t *testing.T) {
+	out, err := runWithFormat(t, "github", map[string]string{
+		"good.md": outHeader + "<!-- Title: Good -->\n\nFine.\n",
+		"bad.md":  outHeader + "<!-- Title: Bad -->\n\n<!-- ac:ignore -->\nunclosed\n",
+	})
+	require.Error(t, err, "the unclosed region should fail its file")
+
+	var errorLine string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "::error") {
+			errorLine = line
+		}
+	}
+
+	require.NotEmpty(t, errorLine, "a failing file must produce an error annotation")
+	assert.Contains(t, errorLine, "file=")
+	assert.Contains(t, errorLine, "bad.md")
+	assert.Contains(t, out, "::notice", "the page that published should be noticed")
+	assert.NotContains(t, out, "\n\n::", "annotations are one per line")
+}
+
+func TestOutputFormatRejectsAnUnknownValue(t *testing.T) {
+	_, err := runWithFormat(t, "yaml", map[string]string{
+		"a.md": outHeader + "<!-- Title: A -->\n\nA.\n",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "output-format")
+}
+
+// TestOutputFormatGitHubReportsOrphanActions.
+func TestOutputFormatGitHubReportsOrphanActions(t *testing.T) {
+	server := outputServer(t)
+	dir := t.TempDir()
+	writeFile(t, dir, "keep.md", outHeader+"<!-- Title: Keep -->\n\nKeep.\n")
+	writeFile(t, dir, "gone.md", outHeader+"<!-- Title: Gone -->\n\nGone.\n")
+
+	var first strings.Builder
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		TrackPages: true, OnOrphan: "delete", OutputFormat: "github", Output: &first,
+	}
+	require.NoError(t, Run(config))
+
+	require.NoError(t, os.Remove(filepath.Join(dir, "gone.md")))
+
+	var second strings.Builder
+	config.Output = &second
+	require.NoError(t, Run(config))
+
+	assert.Contains(t, second.String(), "::warning")
+	assert.Contains(t, second.String(), "gone.md")
+}

--- a/report/report.go
+++ b/report/report.go
@@ -1,0 +1,243 @@
+// Package report collects what a run did, so that it can be said in whichever
+// way the thing reading it needs to hear.
+//
+// The log is for people. This is for everything else: a script deciding what
+// changed, or a CI system that wants a failure attached to the line of the file
+// that caused it.
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+)
+
+// The shapes a run's outcome can be written in.
+const (
+	// FormatURL prints the address of each published page and nothing else,
+	// which is what mark has always printed.
+	FormatURL = "url"
+
+	// FormatJSON prints one object describing the whole run.
+	FormatJSON = "json"
+
+	// FormatGitHub prints GitHub Actions workflow commands, which appear
+	// against the file they name in a pull request.
+	FormatGitHub = "github"
+)
+
+// ParseFormat reads the value given to --output-format.
+func ParseFormat(value string) (string, error) {
+	switch format := strings.ToLower(strings.TrimSpace(value)); format {
+	case "", FormatURL:
+		return FormatURL, nil
+	case FormatJSON:
+		return FormatJSON, nil
+	case FormatGitHub:
+		return FormatGitHub, nil
+	default:
+		return "", fmt.Errorf(
+			"unknown --output-format value %q: expected %s, %s or %s",
+			value, FormatURL, FormatJSON, FormatGitHub,
+		)
+	}
+}
+
+// What became of one document.
+const (
+	StatusPublished = "published"
+	StatusUnchanged = "unchanged"
+	StatusSkipped   = "skipped"
+	StatusFailed    = "failed"
+)
+
+// Page is one document's outcome.
+type Page struct {
+	File   string `json:"file"`
+	Status string `json:"status"`
+	Space  string `json:"space,omitempty"`
+	Title  string `json:"title,omitempty"`
+	PageID string `json:"pageId,omitempty"`
+	URL    string `json:"url,omitempty"`
+
+	// Reason says why a page was skipped or how it failed, in the words a
+	// person would want to read.
+	Reason string `json:"reason,omitempty"`
+}
+
+// Orphan is a tracked page whose document is gone, and what was done about it.
+type Orphan struct {
+	File   string `json:"file"`
+	PageID string `json:"pageId,omitempty"`
+	Title  string `json:"title,omitempty"`
+	Action string `json:"action"`
+}
+
+// Report is everything a run has to say.
+type Report struct {
+	mu sync.Mutex
+
+	Pages   []Page   `json:"pages"`
+	Orphans []Orphan `json:"orphans,omitempty"`
+	Errors  []string `json:"errors,omitempty"`
+}
+
+// New returns an empty report.
+func New() *Report {
+	return &Report{}
+}
+
+// AddPage records what became of a document.
+func (r *Report) AddPage(page Page) {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// A document published twice -- once waiting on a page this run created,
+	// then again once it existed -- is one document, and the later word is the
+	// true one.
+	for i := range r.Pages {
+		if r.Pages[i].File == page.File {
+			r.Pages[i] = page
+
+			return
+		}
+	}
+
+	r.Pages = append(r.Pages, page)
+}
+
+// AddOrphan records a tracked page whose document has gone.
+func (r *Report) AddOrphan(orphan Orphan) {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.Orphans = append(r.Orphans, orphan)
+}
+
+// AddError records something that went wrong and was not about one document.
+func (r *Report) AddError(message string) {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.Errors = append(r.Errors, message)
+}
+
+// Write says what happened, in the requested shape.
+//
+// The url form writes as each page publishes rather than at the end, so it is
+// not written again here: repeating it would double every line of the output
+// mark has always produced.
+func (r *Report) Write(w io.Writer, format string) error {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	switch format {
+	case FormatJSON:
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+
+		return encoder.Encode(r)
+
+	case FormatGitHub:
+		return r.writeGitHub(w)
+
+	default:
+		return nil
+	}
+}
+
+func (r *Report) writeGitHub(w io.Writer) error {
+	for _, page := range r.Pages {
+		switch page.Status {
+		case StatusFailed:
+			if err := command(w, "error", page.File, page.Reason); err != nil {
+				return err
+			}
+
+		case StatusSkipped:
+			if err := command(w, "warning", page.File, page.Reason); err != nil {
+				return err
+			}
+
+		case StatusPublished:
+			if err := command(w, "notice", page.File,
+				fmt.Sprintf("published %q to %s", page.Title, page.URL)); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, orphan := range r.Orphans {
+		message := fmt.Sprintf("page %q has no source file", orphan.Title)
+		if orphan.Action != "report" {
+			message = fmt.Sprintf("page %q was %sd: its source file is gone", orphan.Title, orphan.Action)
+		}
+
+		if err := command(w, "warning", orphan.File, message); err != nil {
+			return err
+		}
+	}
+
+	for _, message := range r.Errors {
+		if err := command(w, "error", "", message); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// command writes one GitHub Actions workflow command.
+//
+// The file is given as a property so that the annotation appears against that
+// file in a pull request, which is the whole reason for this format.
+func command(w io.Writer, level, file, message string) error {
+	var properties string
+	if file != "" {
+		properties = " file=" + escapeProperty(file)
+	}
+
+	_, err := fmt.Fprintf(w, "::%s%s::%s\n", level, properties, escapeMessage(message))
+
+	return err
+}
+
+// escapeMessage encodes the characters that would otherwise end the command or
+// start a new one.
+func escapeMessage(s string) string {
+	return strings.NewReplacer(
+		"%", "%25",
+		"\r", "%0D",
+		"\n", "%0A",
+	).Replace(s)
+}
+
+// escapeProperty encodes what escapeMessage does and the two characters that
+// separate properties from each other and from the message.
+func escapeProperty(s string) string {
+	return strings.NewReplacer(
+		"%", "%25",
+		"\r", "%0D",
+		"\n", "%0A",
+		":", "%3A",
+		",", "%2C",
+	).Replace(s)
+}

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -1,0 +1,103 @@
+package report
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFormat(t *testing.T) {
+	for value, expected := range map[string]string{
+		"": FormatURL, "url": FormatURL, "json": FormatJSON,
+		"github": FormatGitHub, " GitHub ": FormatGitHub,
+	} {
+		got, err := ParseFormat(value)
+		assert.NoError(t, err, "value %q", value)
+		assert.Equal(t, expected, got, "value %q", value)
+	}
+
+	_, err := ParseFormat("yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "github")
+}
+
+func TestJSONDescribesTheRun(t *testing.T) {
+	r := New()
+	r.AddPage(Page{
+		File: "docs/a.md", Status: StatusPublished, Space: "DOCS",
+		Title: "A", PageID: "1004", URL: "https://example/x/1004",
+	})
+	r.AddOrphan(Orphan{File: "docs/old.md", Title: "Old", Action: "delete"})
+	r.AddError("something went wrong")
+
+	var out strings.Builder
+	require.NoError(t, r.Write(&out, FormatJSON))
+
+	got := out.String()
+	assert.Contains(t, got, `"file": "docs/a.md"`)
+	assert.Contains(t, got, `"status": "published"`)
+	assert.Contains(t, got, `"pageId": "1004"`)
+	assert.Contains(t, got, `"action": "delete"`)
+	assert.Contains(t, got, `"something went wrong"`)
+}
+
+// TestGitHubAnnotatesTheFile is the point of that format: a failure has to name
+// the file so it appears against it in a pull request.
+func TestGitHubAnnotatesTheFile(t *testing.T) {
+	r := New()
+	r.AddPage(Page{File: "docs/a.md", Status: StatusPublished, Title: "A", URL: "https://example/x/1"})
+	r.AddPage(Page{File: "docs/b.md", Status: StatusFailed, Reason: "unable to compile markdown"})
+	r.AddPage(Page{File: "docs/c.md", Status: StatusSkipped, Reason: "the document is not synchronized"})
+
+	var out strings.Builder
+	require.NoError(t, r.Write(&out, FormatGitHub))
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.Len(t, lines, 3)
+	assert.Equal(t, `::notice file=docs/a.md::published "A" to https://example/x/1`, lines[0])
+	assert.Equal(t, "::error file=docs/b.md::unable to compile markdown", lines[1])
+	assert.Equal(t, "::warning file=docs/c.md::the document is not synchronized", lines[2])
+}
+
+// TestGitHubEscapes covers the characters that would otherwise end a command
+// early or start another one.
+func TestGitHubEscapes(t *testing.T) {
+	r := New()
+	r.AddPage(Page{
+		File:   "docs/a,b:c.md",
+		Status: StatusFailed,
+		Reason: "100% wrong\nand on two lines",
+	})
+
+	var out strings.Builder
+	require.NoError(t, r.Write(&out, FormatGitHub))
+
+	got := strings.TrimSpace(out.String())
+	assert.Equal(t, "::error file=docs/a%2Cb%3Ac.md::100%25 wrong%0Aand on two lines", got)
+	assert.Equal(t, 1, len(strings.Split(got, "\n")),
+		"a newline in a message must not become a second command")
+}
+
+// TestURLFormatWritesNothingAtTheEnd: those lines are printed as each page
+// publishes, and repeating them would double mark's usual output.
+func TestURLFormatWritesNothingAtTheEnd(t *testing.T) {
+	r := New()
+	r.AddPage(Page{File: "docs/a.md", Status: StatusPublished, URL: "https://example/x/1"})
+
+	var out strings.Builder
+	require.NoError(t, r.Write(&out, FormatURL))
+	assert.Empty(t, out.String())
+}
+
+// TestAPageIsReportedOnce: a document published twice -- once waiting on a page
+// this run created, then again once it existed -- is one document.
+func TestAPageIsReportedOnce(t *testing.T) {
+	r := New()
+	r.AddPage(Page{File: "docs/a.md", Status: StatusPublished, URL: "first"})
+	r.AddPage(Page{File: "docs/a.md", Status: StatusPublished, URL: "second"})
+
+	require.Len(t, r.Pages, 1)
+	assert.Equal(t, "second", r.Pages[0].URL, "the later word is the true one")
+}

--- a/util/cli.go
+++ b/util/cli.go
@@ -122,6 +122,7 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 		AppendLabels:       cmd.Bool("append-labels"),
 		GlobalProperties:   cmd.String("global-properties"),
 		OnOrphan:           cmd.String("on-orphan"),
+		OutputFormat:       cmd.String("output-format"),
 		OrphansUnder:       cmd.String("orphans-under"),
 		PreserveComments:   cmd.Bool("preserve-comments"),
 

--- a/util/flags.go
+++ b/util/flags.go
@@ -199,6 +199,13 @@ var Flags = []cli.Flag{
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHANGES_ONLY"), altsrctoml.TOML("changes-only", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.StringFlag{
+		Name:  "output-format",
+		Value: "url",
+		Usage: "how to report what the run did: \"url\" prints the address of each published page (the default), \"json\" prints one object describing the whole run, \"github\" prints GitHub Actions workflow commands so that failures appear against the file that caused them.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_OUTPUT_FORMAT"),
+			altsrctoml.TOML("output-format", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
 		Name:  "on-orphan",
 		Value: "report",
 		Usage: "what to do about a page whose source file is gone: \"report\" says so and does nothing (the default), \"archive\" archives the page (Confluence Cloud only), \"delete\" moves it to the trash. Requires --track-pages.",


### PR DESCRIPTION
mark printed the address of each page it published and nothing else — all a person needs, and not enough for anything else. A script deciding what changed had to parse the log, and CI had no way to put a failure next to the file that caused it.

## `--output-format json`

```bash
mark --output-format json --files "docs/**/*.md" | jq -r '.pages[] | select(.status=="published") | .url'
```

```json
{
  "pages": [
    {"file": "docs/architecture.md", "status": "published", "space": "DOCS",
     "title": "Architecture", "pageId": "1004", "url": "https://.../display/DOCS/Architecture"},
    {"file": "docs/draft.md", "status": "skipped",
     "reason": "the document is not synchronized"}
  ],
  "orphans": [{"file": "docs/old.md", "action": "delete"}]
}
```

`published`, `unchanged` (`--changes-only` found nothing to do), `skipped` or `failed`, with `reason` distinguishing the last two.

**Outcomes are recorded where they are known**, not inferred from what `processFile` returns. A page skipped for not being synchronized and a page skipped because somebody edited it under `--no-overwrite` are both "skipped", and only the code doing the skipping knows which — so that is where it is recorded.

## `--output-format github`

```text
::notice file=docs/architecture.md::published "Architecture" to https://...
::warning file=docs/draft.md::the document is not synchronized
::error file=docs/broken.md::unable to compile markdown: ...
```

A failing document is annotated **against that file in the pull request** rather than buried in a log somebody has to open.

The escaping is the substance here: a newline in a message would otherwise end the command and begin another, and a colon or comma in a path would end the `file=` property early. `TestGitHubEscapes` covers exactly that, including asserting a multi-line message stays one command.

## The default is untouched

`url` still prints as each page publishes rather than at the end, because that is what anyone watching a long run wants. The other two describe the run once it is over — which is also what lets a document published twice (once waiting on a page the run was creating, then again once it existed, per #904) be reported as the one document it is. `TestAPageIsReportedOnce` pins that.

## Verification

Six unit tests on the report itself and five end-to-end. The end-to-end ones are the substantive check, since they prove the wiring rather than the formatting:

- `TestOutputFormatJSON` parses the output as JSON and asserts a published and a skipped document are each described correctly, with space, title, page id and URL on the published one.
- `TestOutputFormatGitHubAnnotatesAFailingFile` uses a genuinely failing document (an unclosed `ac:ignore` region) and asserts the `::error` names that file, while the page that did publish gets a `::notice`.
- `TestOutputFormatGitHubReportsOrphanActions` covers a deleted orphan appearing as a warning.
- `TestOutputFormatURLIsUnchanged` guards the default.

Full suite green under `-race`; `golangci-lint`: 0 issues.