### PR TITLE
fix: send a numeric page id when archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1621,6 +1621,12 @@ mark --track-pages --on-orphan delete --files "docs/**/*.md"
 `delete` means the trash, which Confluence keeps recoverable. Mark never purges
 a page: that second step is left to a person.
 
+`archive` exists only on Confluence Cloud, and Server and Data Center report
+that they have no such thing rather than appearing to have archived anything.
+Confluence accepts the request and archives afterwards, so Mark reports that it
+asked rather than that it finished; a failure after acceptance is not something
+Mark sees.
+
 `--orphans-under` narrows it further to the pages below one page or folder,
 named by title or by id:
 

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -1549,15 +1549,30 @@ func (api *API) DeletePage(contentID string) error {
 	}
 }
 
-// ArchivePage archives a page, which is gentler than the trash: it leaves the
-// page findable and restorable without an administrator.
+// ArchivePage asks for a page to be archived, which is gentler than the trash:
+// it leaves the page findable and restorable without an administrator.
 //
-// Cloud only. Server and Data Center have no archive, and say so with a 404,
-// which is reported rather than swallowed so that a run asking to archive is
-// not silently doing nothing.
+// The identifier goes in as a number. Confluence documents the body as
+// {"pages":[{"id":<number>}]} and rejects a quoted one with 400, which is easy
+// to miss because every other endpoint here takes an id as a string.
+//
+// The answer is 202: the request has been accepted and the archiving happens
+// afterwards, reported through the long-running task the response names. mark
+// does not wait for it. A page that fails to archive after acceptance is not
+// noticed here, which is worth knowing before relying on this in a place where
+// it matters.
+//
+// Cloud only. Server and Data Center have no archive and say so, which is
+// reported rather than swallowed so that a run asking to archive is not
+// silently doing nothing.
 func (api *API) ArchivePage(contentID string) error {
+	id, err := strconv.ParseInt(contentID, 10, 64)
+	if err != nil {
+		return fmt.Errorf("cannot archive content %q: not a page id: %w", contentID, err)
+	}
+
 	payload := map[string]any{
-		"pages": []map[string]string{{"id": contentID}},
+		"pages": []map[string]any{{"id": id}},
 	}
 
 	request, err := api.rest.Res("content").Res("archive", &struct{}{}).Post(payload)

--- a/confluence/archive_test.go
+++ b/confluence/archive_test.go
@@ -1,0 +1,75 @@
+package confluence_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestArchivePageSendsANumericID pins the request Confluence documents:
+// POST /rest/api/content/archive with {"pages":[{"id":<number>}]}.
+//
+// The id is the part worth pinning. Every other endpoint here takes one as a
+// string, this one rejects a quoted id with 400, and nothing in the call site
+// hints at the difference.
+func TestArchivePageSendsANumericID(t *testing.T) {
+	var (
+		method string
+		path   string
+		body   []byte
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method, path = r.Method, r.URL.Path
+		body, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"id":"task-1","links":{"status":"/rest/api/longtask/task-1"}}`))
+	}))
+	defer server.Close()
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	require.NoError(t, api.ArchivePage("1004"))
+
+	assert.Equal(t, http.MethodPost, method)
+	assert.Equal(t, "/rest/api/content/archive", path)
+
+	var payload struct {
+		Pages []struct {
+			ID json.RawMessage `json:"id"`
+		} `json:"pages"`
+	}
+	require.NoError(t, json.Unmarshal(body, &payload))
+	require.Len(t, payload.Pages, 1)
+	assert.JSONEq(t, `1004`, string(payload.Pages[0].ID),
+		"the id must be sent as a number, not a quoted string")
+}
+
+func TestArchivePageRejectsSomethingThatIsNotAnID(t *testing.T) {
+	api := confluence.NewAPI("http://127.0.0.1:1", "user", "token", false)
+
+	err := api.ArchivePage("not-a-page")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a page id")
+}
+
+// TestArchivePageReportsRefusal covers Server and Data Center, which have no
+// archive at all: a run asking for one must not appear to have got it.
+func TestArchivePageReportsRefusal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"no such endpoint"}`))
+	}))
+	defer server.Close()
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	err := api.ArchivePage("1004")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -276,9 +276,11 @@ func (s *Server) archiveContent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The documented schema is a number, and Confluence rejects a quoted one.
+	// Decoding into int64 makes the fake as strict as the real thing.
 	var payload struct {
 		Pages []struct {
-			ID string `json:"id"`
+			ID int64 `json:"id"`
 		} `json:"pages"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -290,12 +292,16 @@ func (s *Server) archiveContent(w http.ResponseWriter, r *http.Request) {
 	defer s.mu.Unlock()
 
 	for _, item := range payload.Pages {
-		if p, ok := s.pages[item.ID]; ok {
+		if p, ok := s.pages[strconv.FormatInt(item.ID, 10)]; ok {
 			p.Archived = true
 		}
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{"id": "archive-task"})
+	// 202 with a task to watch: the archiving itself happens afterwards.
+	writeJSON(w, http.StatusAccepted, map[string]any{
+		"id":    "archive-task",
+		"links": map[string]any{"status": "/rest/api/longtask/archive-task"},
+	})
 }
 
 // SetHomepage marks a page as the space homepage.


### PR DESCRIPTION
Follow-up to #903, where I flagged `archive` as the one path I could not verify. Checking it found a real bug.

## The bug

Atlassian documents the archive request as:

```
POST /wiki/rest/api/content/archive
{"pages": [{"id": <number>}]}
```

mark sent `{"pages":[{"id":"1004"}]}` — a **quoted** id, which Confluence answers with `400`. Every other endpoint in `confluence/api.go` takes an id as a string, and nothing at the call site hints that this one differs, which is exactly why it slipped through.

So `--on-orphan archive` would have failed against a real Cloud instance, while passing every test here.

## How it is verifiable now

I could not try this against a real Cloud instance, and archiving pages on somebody's production wiki is not something to do to find out. What I could do was read [the reference](https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-content/) and make the fake as strict as the real thing: it now decodes the id as a number, so a quoted one is a `400` here too.

That turns an unverifiable claim into a failing test. On master:

```
Error: Not equal:
  expected: float64(1004)
  actual  : string("1004")
Messages: the id must be sent as a number, not a quoted string
```

The request shape is also pinned directly in `confluence/archive_test.go` — method, path and body — so the next person to touch it does not have to find the reference again.

## Two things the same reading turned up

**It is asynchronous.** The answer is `202 Accepted` with a long-running task to watch; the archiving happens afterwards. mark does not wait, so it now reports having *asked* rather than having finished, and the README says a failure after acceptance is not something mark sees. Polling the task would be a reasonable follow-up; it did not seem proportionate to add now.

**Server and Data Center have no archive**, which they say and mark reports, rather than a run appearing to have archived something. There is a test for that too.

The fake also now answers `202` with a task link rather than `200`, matching what Cloud actually returns.

## What is still unverified

The live path. This is a documentation-conformance fix, not a live one — the request now matches what Atlassian publishes, but nobody has watched a real page become archived. That is worth one manual run on a throwaway page before relying on it.

Full suite green under `-race`; `golangci-lint`: 0 issues.