### PR TITLE
fix: apply the orphan scope to everything it should, and name it to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -1331,7 +1331,7 @@ GLOBAL OPTIONS:
    --changes-only                           Avoids re-uploading pages that haven't changed since the last run. [$MARK_CHANGES_ONLY]
    --output-format string                   how to report what the run did: "url" prints the address of each published page (the default), "json" prints one object describing the whole run, "github" prints GitHub Actions workflow commands so that failures appear against the file that caused them. [$MARK_OUTPUT_FORMAT]
    --on-orphan string                       what to do about a page whose source file is gone: "report" says so and does nothing (the default), "archive" archives the page (Confluence Cloud only), "delete" moves it to the trash. Requires --track-pages. [$MARK_ON_ORPHAN]
-   --orphans-under string                   limit --on-orphan to pages below this page or folder, given by title or id. Without it, every tracked page the --files pattern would have published is in scope. [$MARK_ORPHANS_UNDER]
+   --orphan-under string                   limit --on-orphan to pages below this page or folder, given by title or id. Without it, every tracked page the --files pattern would have published is in scope. [$MARK_ORPHAN_UNDER]
    --check-links string [ --check-links string ]  fail on links that do not resolve. Repeat or comma-separate any of: "internal" (relative links to other files in the repository), "confluence" (ac: links naming a page by title), "external" (requests each URL to see whether it answers), or "all". [$MARK_CHECK_LINKS]
    --global-properties string               path to a YAML or JSON file of Confluence content properties to set on every page. A Property header or properties front matter in a document wins over the file for that page. [$MARK_GLOBAL_PROPERTIES]
    --append-labels                          add the labels a document asks for without removing any others, so that labels applied in Confluence survive a publish. Without it, a page ends up with exactly the labels its Label headers name. [$MARK_APPEND_LABELS]
@@ -1627,17 +1627,33 @@ Confluence accepts the request and archives afterwards, so Mark reports that it
 asked rather than that it finished; a failure after acceptance is not something
 Mark sees.
 
-`--orphans-under` narrows it further to the pages below one page or folder,
-named by title or by id:
+`--orphan-under` narrows it to the pages below one page or folder, named by
+title or by id:
 
 ```bash
-mark --track-pages --on-orphan delete --orphans-under "Team Handbook" \
+mark --track-pages --on-orphan delete --orphan-under "Team Handbook" \
      --files "docs/**/*.md"
 ```
 
 Without it, every tracked page the `--files` pattern would have published is in
 scope -- which is already narrower than the space, since a pattern is only
 evidence about where it was looking.
+
+The scope applies to everything Mark does about orphans, not only to removing
+them. A page outside it is not reported either, and is still remembered, so a
+later run with a wider scope knows about it.
+
+#### Flags that need other flags
+
+A combination that would leave you believing you are protected is refused
+outright rather than warned about, because the belief comes from silence:
+
+* `--on-orphan archive` or `delete` without `--track-pages`
+* `--no-overwrite` without `--track-pages`
+* `--check-links-warn-only` without `--check-links`
+
+A combination that merely does nothing -- `--track-pages` alongside a page ID,
+where the mapping cannot apply -- is a warning.
 
 #### What stops a page being removed
 

--- a/mark.go
+++ b/mark.go
@@ -79,7 +79,7 @@ type Config struct {
 	GlobalProperties   string
 	OnOrphan           string
 	OutputFormat       string
-	OrphansUnder       string
+	OrphanUnder        string
 
 	// Rendering
 	DropH1          bool
@@ -110,6 +110,13 @@ func Run(config Config) error {
 	// Settings are checked before anything else happens. A value that cannot be
 	// acted on should be said so plainly, not after a glob has been resolved
 	// and a connection opened -- and least of all part way through publishing.
+	//
+	// A combination that would leave somebody believing they are protected is
+	// refused rather than warned about. "I asked for links to be reported and
+	// saw none" and "I asked not to overwrite" are both conclusions people draw
+	// from silence, and silence is exactly what these produce on their own. A
+	// combination that merely does nothing, and that nobody would read anything
+	// into, is a warning.
 	outputFormat, err := report.ParseFormat(config.OutputFormat)
 	if err != nil {
 		return err
@@ -128,6 +135,13 @@ func Run(config Config) error {
 			"--on-orphan %s requires --track-pages: "+
 				"only the page manifest knows which pages mark published",
 			onOrphan,
+		)
+	}
+
+	if config.CheckLinksWarnOnly && len(config.CheckLinks) == 0 {
+		return fmt.Errorf(
+			"--check-links-warn-only requires --check-links: " +
+				"on its own no links are checked, so the silence means nothing",
 		)
 	}
 
@@ -179,13 +193,6 @@ func Run(config Config) error {
 	}
 
 	checker := page.NewLinkChecker(linkChecks)
-
-	if config.CheckLinksWarnOnly && !linkChecks.Any() {
-		log.Warn().Msg(
-			"--check-links-warn-only has no effect without --check-links: " +
-				"no links are being checked at all",
-		)
-	}
 
 	// The manifest is only consulted when asked for. It changes how an existing
 	// page is found, which is not something to switch on under anyone without
@@ -337,11 +344,9 @@ func Run(config Config) error {
 
 	var saveErr error
 	if tracker != nil {
-		reportOrphans(tracker, hasErrors)
-		if err := actOnOrphans(tracker, api, config, onOrphan, hasErrors, results); err != nil {
+		if err := handleOrphans(tracker, api, config, onOrphan, hasErrors, results); err != nil {
 			return err
 		}
-		pruneOrphans(tracker, hasErrors, config.DryRun)
 		if saveErr = tracker.Save(); saveErr != nil {
 			saveErr = fmt.Errorf("unable to save page manifest: %w", saveErr)
 		}
@@ -371,37 +376,6 @@ func Run(config Config) error {
 	}
 
 	return saveErr
-}
-
-// reportOrphans logs pages the manifest knows about that this run did not
-// publish to. It only reports; nothing here deletes anything.
-//
-// A path can be missing for two very different reasons -- the file was deleted,
-// or this run simply did not cover it -- and mark cannot tell them apart. A run
-// narrowed by --files leaves everything outside the glob unseen, and those files
-// are present and fine. The wording says candidates for that reason, and acting
-// on them is left to a human until there is a mechanism that can distinguish the
-// two cases.
-func reportOrphans(tracker *manifest.Store, hadErrors bool) {
-	for _, space := range tracker.Spaces() {
-		orphans := tracker.Orphans(space)
-		if len(orphans) == 0 {
-			continue
-		}
-		if hadErrors {
-			// Some files did not process, which is indistinguishable from those
-			// files being gone. Reporting them now would be actively misleading.
-			log.Debug().Msgf(
-				"space %q has %d unpublished tracked pages, not reported because this run had errors",
-				space, len(orphans),
-			)
-			continue
-		}
-		log.Info().Msgf(
-			"space %q: %d tracked page(s) had no matching source file in this run: %s",
-			space, len(orphans), strings.Join(orphans, ", "),
-		)
-	}
 }
 
 // ProcessFile processes a single markdown file and publishes it to Confluence.
@@ -989,30 +963,6 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	}
 
 	return target, placement, nil
-}
-
-// pruneOrphans forgets the entries reportOrphans just named.
-//
-// Left in place the mapping only ever grows, and a file deleted once is
-// reported as missing on every run from then on -- which teaches people to
-// ignore the one message worth reading. Reported once, then forgotten.
-//
-// Nothing is forgotten on a run that had errors, where a file that failed to
-// process is indistinguishable from one that is gone, nor on a dry run, which
-// does not get to change what the next run believes.
-func pruneOrphans(tracker *manifest.Store, hadErrors, dryRun bool) {
-	if hadErrors || dryRun {
-		return
-	}
-
-	for _, space := range tracker.Spaces() {
-		if pruned := tracker.PruneOrphans(space); len(pruned) > 0 {
-			log.Debug().Msgf(
-				"space %q: stopped tracking %d page(s) whose source files are gone",
-				space, len(pruned),
-			)
-		}
-	}
 }
 
 // previewTrackedResolution says what a real run would have done with a document
@@ -1786,91 +1736,6 @@ func pluraliseLinks(n int) string {
 	return fmt.Sprintf("%d links do not resolve", n)
 }
 
-// actOnOrphans archives or deletes the pages whose source files are gone.
-//
-// Nothing happens under the default, which only reports. Everything else is
-// hedged about, because this is the one thing mark does that a person cannot
-// simply run again to undo.
-func actOnOrphans(
-	tracker *manifest.Store,
-	api *confluence.API,
-	config Config,
-	action string,
-	hadErrors bool,
-	results *report.Report,
-) error {
-	if action == page.OnOrphanReport {
-		return nil
-	}
-
-	if hadErrors {
-		// A file that failed to process is indistinguishable from one that was
-		// deleted, and this is not a distinction to get wrong.
-		log.Warn().Msg("some files failed to process; orphaned pages are left alone")
-
-		return nil
-	}
-
-	for _, space := range tracker.Spaces() {
-		orphans := tracker.OrphanEntries(space)
-		if len(orphans) == 0 {
-			continue
-		}
-
-		// A run that published nothing in a space says nothing about that
-		// space: a failed checkout and every document having been deleted look
-		// exactly alike.
-		//
-		// A second line of defence rather than the first -- a pattern matching
-		// no files stops the run well before this -- and kept because the cost
-		// of it being needed once is a space emptied by a bad checkout.
-		if tracker.Published(space) == 0 {
-			log.Warn().Msgf(
-				"space %q: nothing was published in this run, so its %d orphaned page(s) are left alone",
-				space, len(orphans),
-			)
-
-			continue
-		}
-
-		scopeID, err := page.ResolveScope(api, space, config.OrphansUnder)
-		if err != nil {
-			return err
-		}
-
-		candidates := make([]page.Orphan, 0, len(orphans))
-		for _, orphan := range orphans {
-			candidates = append(candidates, page.Orphan{
-				Path:   orphan.Path,
-				PageID: orphan.Entry.PageID,
-				Title:  orphan.Entry.Title,
-			})
-		}
-
-		handled, err := page.HandleOrphans(api, action, scopeID, candidates, config.DryRun)
-		if err != nil {
-			return err
-		}
-
-		if config.DryRun {
-			continue
-		}
-
-		// Only what was actually dealt with is forgotten. A page left alone --
-		// out of scope, or holding children -- stays in the manifest so the
-		// next run finds it again instead of losing sight of it.
-		for _, path := range handled {
-			results.AddOrphan(report.Orphan{File: path, Action: action})
-
-			if err := tracker.Forget(space, path); err != nil {
-				return fmt.Errorf("unable to update page manifest for %q: %w", path, err)
-			}
-		}
-	}
-
-	return nil
-}
-
 func spaceOf(meta *metadata.Meta) string {
 	if meta == nil {
 		return ""
@@ -1885,4 +1750,124 @@ func titleOf(meta *metadata.Meta) string {
 	}
 
 	return meta.Title
+}
+
+// handleOrphans deals with the pages whose source files were not seen.
+//
+// Reporting, acting and forgetting are one thing because they have to agree
+// about which pages are being talked about. When they were separate, a scope
+// narrowed what was archived or deleted while leaving reporting to name
+// everything and forgetting to drop everything -- so a page deliberately put
+// out of scope was announced and then lost track of anyway.
+//
+// A page outside the scope is not mark's business on this run: not reported,
+// not touched, and still remembered, so that a later run with a wider scope
+// still knows about it.
+func handleOrphans(
+	tracker *manifest.Store,
+	api *confluence.API,
+	config Config,
+	action string,
+	hadErrors bool,
+	results *report.Report,
+) error {
+	for _, space := range tracker.Spaces() {
+		orphans := tracker.OrphanEntries(space)
+		if len(orphans) == 0 {
+			continue
+		}
+
+		if hadErrors {
+			// Some files did not process, which is indistinguishable from those
+			// files being gone. Saying anything now would be actively
+			// misleading, and acting on it worse.
+			log.Debug().Msgf(
+				"space %q has %d unpublished tracked pages, not reported because this run had errors",
+				space, len(orphans),
+			)
+
+			continue
+		}
+
+		scopeID, err := page.ResolveScope(api, space, config.OrphanUnder)
+		if err != nil {
+			return err
+		}
+
+		candidates := make([]page.Orphan, 0, len(orphans))
+		for _, orphan := range orphans {
+			candidate := page.Orphan{
+				Path:   orphan.Path,
+				PageID: orphan.Entry.PageID,
+				Title:  orphan.Entry.Title,
+			}
+
+			inScope, err := page.InScope(api, scopeID, candidate)
+			if err != nil {
+				return err
+			}
+
+			if inScope {
+				candidates = append(candidates, candidate)
+			}
+		}
+
+		if len(candidates) == 0 {
+			continue
+		}
+
+		paths := make([]string, 0, len(candidates))
+		for _, candidate := range candidates {
+			paths = append(paths, candidate.Path)
+		}
+
+		log.Info().Msgf(
+			"space %q: %d tracked page(s) had no matching source file in this run: %s",
+			space, len(paths), strings.Join(paths, ", "),
+		)
+
+		handled := paths
+		if action != page.OnOrphanReport {
+			// A run that published nothing in a space says nothing about that
+			// space: a failed checkout and every document having been deleted
+			// look exactly alike.
+			//
+			// A second line of defence rather than the first -- a pattern
+			// matching no files stops the run well before this -- and kept
+			// because the cost of it being needed once is a space emptied by a
+			// bad checkout.
+			if tracker.Published(space) == 0 {
+				log.Warn().Msgf(
+					"space %q: nothing was published in this run, so its %d orphaned page(s) are left alone",
+					space, len(candidates),
+				)
+
+				continue
+			}
+
+			handled, err = page.HandleOrphans(api, action, scopeID, candidates, config.DryRun)
+			if err != nil {
+				return err
+			}
+		}
+
+		if config.DryRun {
+			continue
+		}
+
+		// Only what was actually dealt with is forgotten. A page left alone --
+		// holding children, or out of scope -- stays in the manifest so a later
+		// run finds it again instead of losing sight of it.
+		for _, path := range handled {
+			if action != page.OnOrphanReport {
+				results.AddOrphan(report.Orphan{File: path, Action: action})
+			}
+
+			if err := tracker.Forget(space, path); err != nil {
+				return fmt.Errorf("unable to update page manifest for %q: %w", path, err)
+			}
+		}
+	}
+
+	return nil
 }

--- a/mark_checklinks_test.go
+++ b/mark_checklinks_test.go
@@ -247,3 +247,16 @@ func TestCheckLinksWarnOnly(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// TestCheckLinksWarnOnlyRequiresCheckLinks: on its own the flag checks nothing,
+// so somebody who set it and saw no warnings would conclude their links were
+// fine. That reading is what makes this a refusal rather than a warning.
+func TestCheckLinksWarnOnlyRequiresCheckLinks(t *testing.T) {
+	err := Run(Config{
+		BaseURL: "http://127.0.0.1:1", Username: "user", Password: "token",
+		Files: "none", CheckLinksWarnOnly: true, Output: io.Discard,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--check-links")
+}

--- a/mark_orphan_test.go
+++ b/mark_orphan_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kovetskiy/mark/v16/confluence"
 	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/kovetskiy/mark/v16/manifest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +31,7 @@ func orphanFixture(t *testing.T, onOrphan, under string) (*confluencetest.Server
 	config := Config{
 		BaseURL: server.URL, Username: "user", Password: "token",
 		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
-		TrackPages: true, OnOrphan: onOrphan, OrphansUnder: under,
+		TrackPages: true, OnOrphan: onOrphan, OrphanUnder: under,
 		Output: io.Discard,
 	}
 	require.NoError(t, Run(config))
@@ -217,8 +218,8 @@ func TestOnOrphanLeavesEverythingWhenNothingPublished(t *testing.T) {
 		"a run that published nothing must remove nothing")
 }
 
-// TestOrphansUnderLimitsScope: only pages below the named parent are in scope.
-func TestOrphansUnderLimitsScope(t *testing.T) {
+// TestOrphanUnderLimitsScope: only pages below the named parent are in scope.
+func TestOrphanUnderLimitsScope(t *testing.T) {
 	server := confluencetest.New(t)
 	home := server.AddPage("DOCS", "Home", "page", "")
 	server.SetHomepage("DOCS", home.ID)
@@ -236,7 +237,7 @@ func TestOrphansUnderLimitsScope(t *testing.T) {
 	config := Config{
 		BaseURL: server.URL, Username: "user", Password: "token",
 		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
-		TrackPages: true, OnOrphan: "delete", OrphansUnder: "Inside",
+		TrackPages: true, OnOrphan: "delete", OrphanUnder: "Inside",
 		Output: io.Discard,
 	}
 	require.NoError(t, Run(config))
@@ -256,4 +257,81 @@ func TestOrphansUnderLimitsScope(t *testing.T) {
 
 	assert.True(t, server.Page(in.ID).Trashed, "the page below Inside is in scope")
 	assert.False(t, server.Page(out.ID).Trashed, "the page below Outside is not")
+}
+
+// TestOrphanUnderScopesReportingToo is the inconsistency this fixes. The scope
+// narrowed what was archived or deleted, while reporting named everything and
+// forgetting dropped everything -- so a page deliberately put out of scope was
+// announced and then lost track of anyway.
+func TestOrphanUnderScopesReportingToo(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Inside", "page", home.ID)
+	server.AddPage("DOCS", "Outside", "page", home.ID)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "in.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Inside -->\n<!-- Title: In -->\n\nIn.\n")
+	writeFile(t, dir, "out.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Outside -->\n<!-- Title: Out -->\n\nOut.\n")
+	writeFile(t, dir, "keep.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Inside -->\n<!-- Title: Keep -->\n\nKeep.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		TrackPages: true, OnOrphan: "report", OrphanUnder: "Inside",
+		Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	out, err := api.FindPage("DOCS", "Out", "page")
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	// Both documents go. Only the one under "Inside" is mark's business.
+	require.NoError(t, os.Remove(filepath.Join(dir, "in.md")))
+	require.NoError(t, os.Remove(filepath.Join(dir, "out.md")))
+	require.NoError(t, Run(config))
+
+	store := manifest.NewStore(api)
+
+	_, inKnown, err := store.Lookup("DOCS", filepath.Join(dir, "in.md"))
+	require.NoError(t, err)
+	assert.False(t, inKnown, "an in-scope orphan is reported once and forgotten")
+
+	_, outKnown, err := store.Lookup("DOCS", filepath.Join(dir, "out.md"))
+	require.NoError(t, err)
+	assert.True(t, outKnown,
+		"a page put out of scope must still be remembered, not quietly dropped")
+}
+
+// TestOrphanUnderWithoutScopeIsUnchanged: with no scope every tracked page is
+// mark's business, which is what it has always been.
+func TestOrphanUnderWithoutScopeIsUnchanged(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	header := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n"
+	writeFile(t, dir, "keep.md", header+"<!-- Title: Keep -->\n\nKeep.\n")
+	writeFile(t, dir, "gone.md", header+"<!-- Title: Gone -->\n\nGone.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		TrackPages: true, Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+	require.NoError(t, os.Remove(filepath.Join(dir, "gone.md")))
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	_, known, err := manifest.NewStore(api).Lookup("DOCS", filepath.Join(dir, "gone.md"))
+	require.NoError(t, err)
+	assert.False(t, known, "reported once and then forgotten, as before")
 }

--- a/page/orphan.go
+++ b/page/orphan.go
@@ -53,7 +53,7 @@ type OrphanScope struct {
 	Under string
 }
 
-// ResolveScope finds the page or folder --orphans-under names.
+// ResolveScope finds the page or folder --orphan-under names.
 //
 // A title or an id, and a page or a folder, because the thing people want to
 // put a boundary around is a place in the tree and mark's tree has both in it.
@@ -87,7 +87,7 @@ func ResolveScope(api *confluence.API, spaceKey, under string) (string, error) {
 	}
 
 	return "", fmt.Errorf(
-		"--orphans-under names %q, which is not a page or folder in space %q",
+		"--orphan-under names %q, which is not a page or folder in space %q",
 		under, spaceKey,
 	)
 }

--- a/util/cli.go
+++ b/util/cli.go
@@ -123,7 +123,7 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 		GlobalProperties:   cmd.String("global-properties"),
 		OnOrphan:           cmd.String("on-orphan"),
 		OutputFormat:       cmd.String("output-format"),
-		OrphansUnder:       cmd.String("orphans-under"),
+		OrphanUnder:        cmd.String("orphan-under"),
 		PreserveComments:   cmd.Bool("preserve-comments"),
 
 		DropH1:          cmd.Bool("drop-h1"),

--- a/util/flags.go
+++ b/util/flags.go
@@ -213,11 +213,11 @@ var Flags = []cli.Flag{
 			altsrctoml.TOML("on-orphan", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.StringFlag{
-		Name:  "orphans-under",
+		Name:  "orphan-under",
 		Value: "",
-		Usage: "limit --on-orphan to pages below this page or folder, given by title or id. Without it, every tracked page the --files pattern would have published is in scope.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_ORPHANS_UNDER"),
-			altsrctoml.TOML("orphans-under", altsrc.NewStringPtrSourcer(&filename))),
+		Usage: "limit --on-orphan, and the reporting it does, to pages below this page or folder, given by title or id. Without it, every tracked page the --files pattern would have published is in scope.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_ORPHAN_UNDER"),
+			altsrctoml.TOML("orphan-under", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.StringSliceFlag{
 		Name:  "check-links",


### PR DESCRIPTION
Three inconsistencies found auditing the CLI, all of them mine and all from the same afternoon.

## 1. The scope was ignored by everything except removal

`--orphans-under` narrowed what was archived or deleted, while reporting went on naming every orphan and forgetting went on dropping every entry. So a page deliberately put **out of scope was announced and then lost track of anyway** — the one outcome the flag exists to prevent.

Reporting, acting and forgetting are now one function, because they have to agree about which pages are being talked about. A page outside the scope is not reported, not touched, and **still remembered**, so a later run with a wider scope still knows it is there.

On master the test fails with exactly that:

```
Error: Should be true
Messages: a page put out of scope must still be remembered, not quietly dropped
```

`TestOrphanUnderWithoutScopeIsUnchanged` passes on master too — it guards that with no scope set, behaviour is what it always was.

## 2. `--orphans-under` → `--orphan-under`

It broke the singular/plural convention this repository already keeps between `--parents` and `--parents-delimiter`, and it broke it against `--on-orphan`, a flag added in the same PR.

**Free to correct**: neither flag has appeared in a release, so nothing is being broken.

## 3. `--check-links-warn-only` now refuses rather than warns

I originally made this a warning on the grounds that it merely does nothing. That was wrong. On its own it checks no links at all, so somebody who sets it and sees no warnings concludes their links are fine — which is a false sense of safety, not a no-op.

That gives a rule, now written down where the checks are:

> A combination that would leave somebody believing they are protected is **refused**, because the belief comes from silence. A combination that merely does nothing, and that nobody would read anything into, is a **warning**.

| Combination | Reaction |
|---|---|
| `--on-orphan archive`/`delete` without `--track-pages` | error |
| `--no-overwrite` without `--track-pages` | error |
| `--check-links-warn-only` without `--check-links` | error — changed here |
| `--track-pages` alongside a page ID | warning |

The last one stays a warning: the mapping genuinely cannot apply, and nobody infers safety from it.

## Also checked, and clean

Auditing this range turned up no documentation gaps: every one of the 41 flags, 15 metadata headers and 11 `--features` values appears in the README, and every flag has both an env var and a config-file source. The only functions with no coverage anywhere are `UpdateAttachment` and `RestrictPageUpdates` (`--edit-lock`), both long-standing.

Full suite green under `-race`; `golangci-lint`: 0 issues.