### PR TITLE
fix: publish a macro parameter holding an element without whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,36 +191,33 @@ If the template cannot be found relative to the current directory, a fallback di
 
 ## Whitespace inside `ac:parameter`
 
-A template's output is published exactly as written, whitespace included, and
-there is one place where that matters. A storage-format element inside an
-`<ac:parameter>` must not have anything around it:
-
-```xml
-<ac:parameter ac:name="name"><ri:attachment ri:filename="diagram.drawio"/></ac:parameter>
-```
-
-Written across several lines, the newlines become part of the parameter, and
-Confluence resolves a parameter holding both text and an element by writing the
-element out as a string. The page then contains something like
-`AttachmentResourceIdentifier[...,filename=diagram.drawio]` where the attachment
-should be, and nothing is reported: Mark uploaded what it was given, and the
-change happened on the server.
-
-Go's trim markers keep the template readable and the output tight:
+A macro parameter holding a storage-format element must hold nothing else, so
+Mark publishes such a parameter with the whitespace taken out of it. A template
+can be written to be read:
 
 ```text
 <ac:structured-macro ac:name="inc-drawio">
-  {{- "" -}}
   <ac:parameter ac:name="name">
-    {{- "" -}}
     <ri:attachment ri:filename="{{ .Name }}"/>
-    {{- "" -}}
   </ac:parameter>
-  {{- "" -}}
 </ac:structured-macro>
 ```
 
-The built-in templates are written on one line for the same reason.
+and reaches Confluence as
+`<ac:parameter ac:name="name"><ri:attachment ri:filename="..."/></ac:parameter>`.
+
+Left as written, the newlines would make the parameter hold text as well as an
+element, and Confluence resolves that by writing the element out as a string:
+the page ends up carrying `AttachmentResourceIdentifier[...,filename=...]` where
+the attachment should be, with nothing reported, since Mark published what it
+was given.
+
+Only a parameter whose value is an element is tightened, which is decided by its
+content beginning with `<` and ending with `>`. A parameter holding a string
+keeps its spacing, because there the spacing is the value. Whitespace anywhere
+else is left alone and has to be: the blank lines inside `<ac:rich-text-body>`
+are what let a macro's body be read as Markdown, and a body ending in a list
+would otherwise swallow the closing tags.
 
 Optionally the delimiters can be defined:
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,39 @@ to the template relative to current working dir, e.g.:
 
 If the template cannot be found relative to the current directory, a fallback directory can be defined via `--include-path`. This way it is possible to have global include files while local ones will still take precedence.
 
+## Whitespace inside `ac:parameter`
+
+A template's output is published exactly as written, whitespace included, and
+there is one place where that matters. A storage-format element inside an
+`<ac:parameter>` must not have anything around it:
+
+```xml
+<ac:parameter ac:name="name"><ri:attachment ri:filename="diagram.drawio"/></ac:parameter>
+```
+
+Written across several lines, the newlines become part of the parameter, and
+Confluence resolves a parameter holding both text and an element by writing the
+element out as a string. The page then contains something like
+`AttachmentResourceIdentifier[...,filename=diagram.drawio]` where the attachment
+should be, and nothing is reported: Mark uploaded what it was given, and the
+change happened on the server.
+
+Go's trim markers keep the template readable and the output tight:
+
+```text
+<ac:structured-macro ac:name="inc-drawio">
+  {{- "" -}}
+  <ac:parameter ac:name="name">
+    {{- "" -}}
+    <ri:attachment ri:filename="{{ .Name }}"/>
+    {{- "" -}}
+  </ac:parameter>
+  {{- "" -}}
+</ac:structured-macro>
+```
+
+The built-in templates are written on one line for the same reason.
+
 Optionally the delimiters can be defined:
 
 ```markdown

--- a/includes/parameter.go
+++ b/includes/parameter.go
@@ -1,0 +1,87 @@
+package includes
+
+import "bytes"
+
+const (
+	parameterOpen  = "<ac:parameter"
+	parameterClose = "</ac:parameter>"
+)
+
+// TrimElementParameters removes the whitespace a template put inside an
+// <ac:parameter> whose value is a storage-format element.
+//
+// A template is written to be read, so a macro parameter holding an attachment
+// tends to be written across lines and indented:
+//
+//	<ac:parameter ac:name="name">
+//	  <ri:attachment ri:filename="diagram.drawio"/>
+//	</ac:parameter>
+//
+// Those newlines are published along with the element, which leaves the
+// parameter holding text as well as an element. Confluence resolves that by
+// writing the element out as a string, so the page ends up carrying
+// AttachmentResourceIdentifier[...,filename=diagram.drawio] where the
+// attachment should be -- and nothing is reported, because as far as mark is
+// concerned it published exactly what it was given.
+//
+// Only a parameter whose content is an element is touched, which is decided by
+// the trimmed content beginning with < and ending with >. A parameter holding a
+// string is left exactly as written, spaces and all, because there the spacing
+// is the value.
+//
+// Whitespace elsewhere is left alone, and has to be: the blank lines inside
+// <ac:rich-text-body> are what let a macro's body be read as Markdown blocks,
+// and a body ending in a list would otherwise swallow the closing tags.
+func TrimElementParameters(content []byte) []byte {
+	if !bytes.Contains(content, []byte(parameterOpen)) {
+		return content
+	}
+
+	var out bytes.Buffer
+	rest := content
+
+	for {
+		start := bytes.Index(rest, []byte(parameterOpen))
+		if start == -1 {
+			break
+		}
+
+		// The end of the opening tag, after any attributes.
+		tagEnd := bytes.IndexByte(rest[start:], '>')
+		if tagEnd == -1 {
+			break
+		}
+		tagEnd += start + 1
+
+		// A parameter that closes itself holds nothing to trim.
+		if rest[tagEnd-2] == '/' {
+			out.Write(rest[:tagEnd])
+			rest = rest[tagEnd:]
+
+			continue
+		}
+
+		closeAt := bytes.Index(rest[tagEnd:], []byte(parameterClose))
+		if closeAt == -1 {
+			break
+		}
+		closeAt += tagEnd
+
+		inner := rest[tagEnd:closeAt]
+		trimmed := bytes.TrimSpace(inner)
+
+		out.Write(rest[:tagEnd])
+		if len(trimmed) > 1 && trimmed[0] == '<' && trimmed[len(trimmed)-1] == '>' {
+			out.Write(trimmed)
+		} else {
+			out.Write(inner)
+		}
+		out.WriteString(parameterClose)
+
+		rest = rest[closeAt+len(parameterClose):]
+	}
+
+	out.Write(rest)
+
+	return out.Bytes()
+}

--- a/includes/parameter_test.go
+++ b/includes/parameter_test.go
@@ -1,0 +1,59 @@
+package includes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrimElementParameters(t *testing.T) {
+	for name, tt := range map[string]struct{ in, expected string }{
+		"element across lines": {
+			"<ac:parameter ac:name=\"name\">\n  <ri:attachment ri:filename=\"a.drawio\"/>\n</ac:parameter>",
+			`<ac:parameter ac:name="name"><ri:attachment ri:filename="a.drawio"/></ac:parameter>`,
+		},
+		"element already tight": {
+			`<ac:parameter ac:name="name"><ri:attachment ri:filename="a.drawio"/></ac:parameter>`,
+			`<ac:parameter ac:name="name"><ri:attachment ri:filename="a.drawio"/></ac:parameter>`,
+		},
+		"element with children": {
+			"<ac:parameter ac:name=\"n\">\n<ac:link><ri:page ri:content-title=\"T\"/></ac:link>\n</ac:parameter>",
+			`<ac:parameter ac:name="n"><ac:link><ri:page ri:content-title="T"/></ac:link></ac:parameter>`,
+		},
+		"string keeps its spacing": {
+			`<ac:parameter ac:name="title">  spaced  </ac:parameter>`,
+			`<ac:parameter ac:name="title">  spaced  </ac:parameter>`,
+		},
+		"string that mentions a tag is still a string": {
+			"<ac:parameter ac:name=\"t\">\n  see <ri:attachment/> here\n</ac:parameter>",
+			"<ac:parameter ac:name=\"t\">\n  see <ri:attachment/> here\n</ac:parameter>",
+		},
+		"empty parameter": {
+			`<ac:parameter ac:name="t"></ac:parameter>`,
+			`<ac:parameter ac:name="t"></ac:parameter>`,
+		},
+		"self-closing parameter": {
+			`<ac:parameter ac:name="t"/>`,
+			`<ac:parameter ac:name="t"/>`,
+		},
+		"several parameters": {
+			"<ac:parameter ac:name=\"a\">\n<ri:x/>\n</ac:parameter><ac:parameter ac:name=\"b\">  text  </ac:parameter>",
+			`<ac:parameter ac:name="a"><ri:x/></ac:parameter><ac:parameter ac:name="b">  text  </ac:parameter>`,
+		},
+		"body whitespace is not a parameter": {
+			"<ac:rich-text-body>\n\n- one\n\n</ac:rich-text-body>",
+			"<ac:rich-text-body>\n\n- one\n\n</ac:rich-text-body>",
+		},
+		"nothing to do": {
+			"just some text", "just some text",
+		},
+		"unclosed parameter is left alone": {
+			`<ac:parameter ac:name="t">   <ri:x/>`,
+			`<ac:parameter ac:name="t">   <ri:x/>`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, string(TrimElementParameters([]byte(tt.in))))
+		})
+	}
+}

--- a/includes/templates.go
+++ b/includes/templates.go
@@ -253,9 +253,13 @@ func ProcessIncludesWithStack(
 		return templates, contents, false, fmt.Errorf("unable to execute template %q (vars: %s): %w", dir.Template, formatVardump(dir.Data), err)
 	}
 
+	// A parameter holding an element must hold nothing else, and a template is
+	// written to be read rather than to be careful about that.
+	expanded := TrimElementParameters(buffer.Bytes())
+
 	// Recursively process nested includes with updated stack
 	newStack := append(stack, dir.Template)
-	subTemplates, subBytes, _, subErr := ProcessIncludesWithStack(base, includePath, buffer.Bytes(), templates, newStack)
+	subTemplates, subBytes, _, subErr := ProcessIncludesWithStack(base, includePath, expanded, templates, newStack)
 	if subErr != nil {
 		return templates, contents, false, subErr
 	}

--- a/macro/macro.go
+++ b/macro/macro.go
@@ -127,7 +127,10 @@ func (macro *Macro) Apply(
 				return match
 			}
 
-			return buf.Bytes()
+			// Same reason as for an include: a parameter holding an element
+			// must hold nothing else, and a readable template does not
+			// naturally produce that.
+			return includes.TrimElementParameters(buf.Bytes())
 		},
 	)
 

--- a/markdown/template_whitespace_test.go
+++ b/markdown/template_whitespace_test.go
@@ -35,16 +35,13 @@ const drawioDocument = "<!-- Macro: %%drawio%%\n" +
 	"     Template: inc-drawio\n" +
 	"     Name: diagram.drawio -->\n\n%%drawio%%\n"
 
-// TestCustomTemplateOutputIsPreservedVerbatim pins mark's side of issue #908: a
-// template's output is injected exactly as written, whitespace included.
+// TestParameterHoldingAnElementIsTightened is issue #908, written the way the
+// reporter wrote it: across lines, indented, readable.
 //
-// That is the contract, and it is also the trap. A storage-format element
-// surrounded by newlines inside <ac:parameter> makes the parameter mixed
-// content, and Confluence resolves that by writing the element out as a string
-// -- which is where AttachmentResourceIdentifier[...] comes from. It is worth a
-// test because the mangling happens on the server, so nothing here would ever
-// show it.
-func TestCustomTemplateOutputIsPreservedVerbatim(t *testing.T) {
+// The newlines would otherwise be published inside the parameter, leaving it
+// holding text as well as an element, which Confluence resolves by writing the
+// element out as a string.
+func TestParameterHoldingAnElementIsTightened(t *testing.T) {
 	out := compileWithTemplate(t, "inc-drawio",
 		"<ac:structured-macro ac:name=\"inc-drawio\">\n"+
 			"  <ac:parameter ac:name=\"name\">\n"+
@@ -53,39 +50,46 @@ func TestCustomTemplateOutputIsPreservedVerbatim(t *testing.T) {
 			"</ac:structured-macro>\n",
 		drawioDocument)
 
-	assert.Contains(t, out, `<ri:attachment ri:filename="diagram.drawio" />`,
-		"mark must not alter what a template produced")
-	assert.Regexp(t, `(?s)<ac:parameter ac:name="name">\s*\n`, out,
-		"the newlines the template asked for are still there")
-}
-
-// TestCustomTemplateCanEmitWhitespaceFreeParameters is the way out. Go's trim
-// markers let a template stay readable while emitting nothing between the
-// parameter and the element inside it, which is what the built-in templates do
-// by being joined without separators.
-func TestCustomTemplateCanEmitWhitespaceFreeParameters(t *testing.T) {
-	out := compileWithTemplate(t, "inc-drawio",
-		"<ac:structured-macro ac:name=\"inc-drawio\">\n"+
-			"  {{- \"\" -}}\n"+
-			"  <ac:parameter ac:name=\"name\">\n"+
-			"    {{- \"\" -}}\n"+
-			"    <ri:attachment ri:filename=\"{{ .Name }}\"/>\n"+
-			"    {{- \"\" -}}\n"+
-			"  </ac:parameter>\n"+
-			"  {{- \"\" -}}\n"+
-			"</ac:structured-macro>\n",
-		drawioDocument)
-
 	assert.Contains(t, out,
-		`<ac:parameter ac:name="name"><ri:attachment ri:filename="diagram.drawio"/></ac:parameter>`,
+		`<ac:parameter ac:name="name"><ri:attachment ri:filename="diagram.drawio" /></ac:parameter>`,
 		"nothing may sit between the parameter and the element inside it")
 }
 
-// TestBuiltinTemplateHasNoWhitespaceInItsParameter is the comparison the issue
-// rests on. The built-in works where the custom one did not, and this is the
-// whole of the difference: the built-in emits no whitespace, because its lines
-// are joined with nothing between them.
-func TestBuiltinTemplateHasNoWhitespaceInItsParameter(t *testing.T) {
+// TestParameterHoldingAStringIsUntouched: there the spacing is the value, and
+// mark has no business deciding what somebody meant by it.
+func TestParameterHoldingAStringIsUntouched(t *testing.T) {
+	out := compileWithTemplate(t, "inc-title",
+		"<ac:structured-macro ac:name=\"inc-title\">"+
+			"<ac:parameter ac:name=\"title\">  {{ .Name }}  </ac:parameter>"+
+			"</ac:structured-macro>\n",
+		"<!-- Macro: %%t%%\n     Template: inc-title\n     Name: spaced -->\n\n%%t%%\n")
+
+	assert.Contains(t, out, `<ac:parameter ac:name="title">  spaced  </ac:parameter>`,
+		"a string parameter keeps the spacing it was given")
+}
+
+// TestBodyWhitespaceIsPreserved is the property that rules out doing this more
+// widely. The blank lines inside a rich text body are what let a macro's body
+// be read as Markdown blocks; a body ending in a list would otherwise swallow
+// the closing tags.
+func TestBodyWhitespaceIsPreserved(t *testing.T) {
+	lib, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	out, _, err := mark.CompileMarkdown([]byte(
+		"<!-- Macro: :m:\n     Template: ac:box\n     Name: info\n"+
+			"     Body: \"- one\\n- two\" -->\n\n:m:\n"),
+		lib, "testdata/x.md", types.MarkConfig{MermaidScale: 1, D2Scale: 1})
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "<li>one</li>", "the body must still be read as Markdown")
+	assert.Contains(t, out, "</ul>\n</ac:rich-text-body>",
+		"the closing tags must still sit outside the list")
+}
+
+// TestBuiltinTemplateStillMatches: the built-in was already tight, being joined
+// with nothing between its lines, and must stay that way.
+func TestBuiltinTemplateStillMatches(t *testing.T) {
 	lib, err := stdlib.New(nil)
 	require.NoError(t, err)
 
@@ -96,6 +100,5 @@ func TestBuiltinTemplateHasNoWhitespaceInItsParameter(t *testing.T) {
 
 	assert.Contains(t, out,
 		`<ac:parameter ac:name="name"><ri:attachment ri:filename="diagram.drawio"/></ac:parameter>`)
-	assert.NotContains(t, strings.SplitN(out, "</ac:parameter>", 2)[0], "\n",
-		"the built-in parameter holds no newline, which is why it survives")
+	assert.NotContains(t, strings.SplitN(out, "</ac:parameter>", 2)[0], "\n")
 }

--- a/markdown/template_whitespace_test.go
+++ b/markdown/template_whitespace_test.go
@@ -1,0 +1,101 @@
+package mark_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	mark "github.com/kovetskiy/mark/v16/markdown"
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// compileWithTemplate renders a document against a template of the given name
+// placed on the include path.
+func compileWithTemplate(t *testing.T, name, template, document string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(template), 0o600))
+
+	lib, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	out, _, err := mark.CompileMarkdown([]byte(document), lib, "testdata/x.md",
+		types.MarkConfig{MermaidScale: 1, D2Scale: 1, IncludePath: dir})
+	require.NoError(t, err)
+
+	return out
+}
+
+const drawioDocument = "<!-- Macro: %%drawio%%\n" +
+	"     Template: inc-drawio\n" +
+	"     Name: diagram.drawio -->\n\n%%drawio%%\n"
+
+// TestCustomTemplateOutputIsPreservedVerbatim pins mark's side of issue #908: a
+// template's output is injected exactly as written, whitespace included.
+//
+// That is the contract, and it is also the trap. A storage-format element
+// surrounded by newlines inside <ac:parameter> makes the parameter mixed
+// content, and Confluence resolves that by writing the element out as a string
+// -- which is where AttachmentResourceIdentifier[...] comes from. It is worth a
+// test because the mangling happens on the server, so nothing here would ever
+// show it.
+func TestCustomTemplateOutputIsPreservedVerbatim(t *testing.T) {
+	out := compileWithTemplate(t, "inc-drawio",
+		"<ac:structured-macro ac:name=\"inc-drawio\">\n"+
+			"  <ac:parameter ac:name=\"name\">\n"+
+			"    <ri:attachment ri:filename=\"{{ .Name }}\" />\n"+
+			"  </ac:parameter>\n"+
+			"</ac:structured-macro>\n",
+		drawioDocument)
+
+	assert.Contains(t, out, `<ri:attachment ri:filename="diagram.drawio" />`,
+		"mark must not alter what a template produced")
+	assert.Regexp(t, `(?s)<ac:parameter ac:name="name">\s*\n`, out,
+		"the newlines the template asked for are still there")
+}
+
+// TestCustomTemplateCanEmitWhitespaceFreeParameters is the way out. Go's trim
+// markers let a template stay readable while emitting nothing between the
+// parameter and the element inside it, which is what the built-in templates do
+// by being joined without separators.
+func TestCustomTemplateCanEmitWhitespaceFreeParameters(t *testing.T) {
+	out := compileWithTemplate(t, "inc-drawio",
+		"<ac:structured-macro ac:name=\"inc-drawio\">\n"+
+			"  {{- \"\" -}}\n"+
+			"  <ac:parameter ac:name=\"name\">\n"+
+			"    {{- \"\" -}}\n"+
+			"    <ri:attachment ri:filename=\"{{ .Name }}\"/>\n"+
+			"    {{- \"\" -}}\n"+
+			"  </ac:parameter>\n"+
+			"  {{- \"\" -}}\n"+
+			"</ac:structured-macro>\n",
+		drawioDocument)
+
+	assert.Contains(t, out,
+		`<ac:parameter ac:name="name"><ri:attachment ri:filename="diagram.drawio"/></ac:parameter>`,
+		"nothing may sit between the parameter and the element inside it")
+}
+
+// TestBuiltinTemplateHasNoWhitespaceInItsParameter is the comparison the issue
+// rests on. The built-in works where the custom one did not, and this is the
+// whole of the difference: the built-in emits no whitespace, because its lines
+// are joined with nothing between them.
+func TestBuiltinTemplateHasNoWhitespaceInItsParameter(t *testing.T) {
+	lib, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	out, _, err := mark.CompileMarkdown(
+		[]byte("<!-- Include: ac:view-file\n     Name: diagram.drawio -->\n"),
+		lib, "testdata/x.md", types.MarkConfig{MermaidScale: 1, D2Scale: 1})
+	require.NoError(t, err)
+
+	assert.Contains(t, out,
+		`<ac:parameter ac:name="name"><ri:attachment ri:filename="diagram.drawio"/></ac:parameter>`)
+	assert.NotContains(t, strings.SplitN(out, "</ac:parameter>", 2)[0], "\n",
+		"the built-in parameter holds no newline, which is why it survives")
+}


### PR DESCRIPTION
Fixes #908.

## What was happening

A template producing

```xml
<ac:parameter ac:name="name">
  <ri:attachment ri:filename="diagram.drawio" />
</ac:parameter>
```

published as `AttachmentResourceIdentifier[...,filename=diagram.drawio]`.

**mark was not mangling it.** Capturing what mark uploads shows the XML intact; the mangled string is a Java `toString()` and appears nowhere in this repository. Confluence writes it, resolving a parameter that holds *text as well as an element* by turning the element into a string. The text is the template's own newlines and indentation.

That is also why the built-in templates worked where a custom one did not: `stdlib.go:32` joins their lines with an empty string, so their parameters hold an element and nothing else. **The difference was never built-in versus custom — it was whitespace.**

## The fix

A parameter whose value is an element is now published without the whitespace around it, done where each template's output is produced.

Expecting people to know this of a template they wrote to be readable is not much of an answer, which is why this went from a documentation change to a code one.

**Only that case is touched:**

- a parameter holding a **string** keeps its spacing, since there the spacing is the value
- whitespace **anywhere else** is untouched — and has to be: the blank lines inside `<ac:rich-text-body>` are what let a macro's body be read as Markdown, and **five built-in templates depend on them**. `ac:box` even carries a comment explaining that a body ending in a list would otherwise swallow the closing tags.

Whether a parameter holds an element is decided by its trimmed content beginning with `<` and ending with `>` — so `see <ri:attachment/> here` is still a string and is left alone.

## Why at expansion time, not on the finished page

A page may perfectly well contain a code block showing this markup, and rewriting the finished output would eat it. That is precisely the mistake #887, #888 and #893 were about; doing it on each template's own output makes it impossible by construction.

## Tests

Eleven cases on the rule itself, covering both what must change and what must not: element across lines, already-tight, element with children, string spacing preserved, a string that merely mentions a tag, empty and self-closing parameters, several parameters in one output, rich-text-body untouched, and an unclosed parameter left alone.

Four through the full pipeline: the reporter's exact template tightened; a string parameter untouched; `ac:box`'s body still parsing as Markdown with its closing tags outside the list; and the built-in still matching.

## One thing still unconfirmed

That Confluence's coercion is *caused* by the whitespace. I have no instance to test against and the fake cannot emulate it. Established: mark sent valid XML, the built-in and custom templates differed only in whitespace, and the built-in is the one that worked. The reporter has been asked to confirm — worth waiting for that before releasing, since if the cause lies elsewhere this is harmless but not a fix.