### PR TITLE
feat: derive a page's parents from the directory its file is in

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,19 @@ Directory names are titled the way filenames are, so `getting-started` becomes
 "Getting Started".
 
 An `index.md` or `README.md` **is** its directory's page rather than a page
-inside it, and takes the directory's name as its title unless it gives itself
-one. So `docs/guides/README.md` is the "Guides" page that `setup.md` sits under.
+inside it. So `docs/guides/README.md` is the page that `setup.md` sits under.
+
+What that page is called is decided once, and the documents beneath it look for
+the same name, so the two cannot disagree:
+
+1. the `Title` header or front matter of the directory's own document
+2. its leading heading, with `--title-from-h1`
+3. a `title:` in a `.pages` file beside the documents, for a directory that has
+   no document of its own
+4. the directory's name
+
+The filename is never used. It is `README` in every directory that has one,
+which names a file rather than a page.
 
 The root is everything in `--files` before the first wildcard, and
 `--parents-from-path-root` overrides that where the guess is wrong. A document

--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ holds one page of a title: rename one of them, or use
 appends a short hash of the page's parents, space and title, which differs
 between two documents in different directories.
 
+### Directories are remembered too
+
+Mark creates the page standing for a directory, so it remembers doing so. When
+the last document under a directory goes away, that page turns up as a page with
+no source file like any other, and `--on-orphan` decides what becomes of it:
+
+```bash
+mark --parents-from-path --track-pages --on-orphan delete --files "docs/**/*.md"
+```
+
+A directory's page is only removable once it holds nothing, since a page with
+children is always left alone. So a directory and everything in it takes two
+runs to disappear: the documents first, then the page that held them.
+
+A directory holding its own `index.md` or `README.md` is not remembered this
+way, that document's own entry having the page already.
+
 ### Turning it on for pages that already exist
 
 Every page not already where its path implies will be moved on the next run.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,59 @@ appended to the values from front matter.
 There can be any number of `Parent` headers, if Mark can't find specified
 parent by title, Mark creates it.
 
+## Parents from the directory a file is in
+
+`--parents-from-path` puts each page under a page named after every directory
+between the file pattern's root and the file itself, so the page tree comes out
+looking like the repository:
+
+```bash
+mark --parents-from-path --files "docs/**/*.md"
+```
+
+```text
+docs/guides/setup.md        ->  Guides > Setup
+docs/guides/deep/tuning.md  ->  Guides > Deep > Tuning
+```
+
+Directory names are titled the way filenames are, so `getting-started` becomes
+"Getting Started".
+
+An `index.md` or `README.md` **is** its directory's page rather than a page
+inside it, and takes the directory's name as its title unless it gives itself
+one. So `docs/guides/README.md` is the "Guides" page that `setup.md` sits under.
+
+The root is everything in `--files` before the first wildcard, and
+`--parents-from-path-root` overrides that where the guess is wrong. A document
+that names its own `Parent` is left where it asks to be, and `--parents` still
+prefixes everything.
+
+### One page per title
+
+A space holds one page of a given title, so two documents wanting the same title
+want the same page: the second would overwrite the first and drag it under its
+own parents. Deriving parents from the path makes that likely rather than
+unlucky -- every directory tends to hold a README, and several will want an
+"Overview".
+
+Mark refuses before publishing the second one:
+
+```text
+docs/api/overview.md already publishes "Overview" in space "DOCS", and a space
+holds one page of a title: rename one of them, or use
+--title-append-generated-hash
+```
+
+`--title-append-generated-hash` is the way to keep both titles as they are: it
+appends a short hash of the page's parents, space and title, which differs
+between two documents in different directories.
+
+### Turning it on for pages that already exist
+
+Every page not already where its path implies will be moved on the next run.
+`--dry-run` reports the moves without making them, and is worth reading first on
+a space anybody else works in.
+
 Changing a `Parent` header on a page that has already been published moves that
 page to the new parent. Mark treats your repository as the source of truth for
 where a page lives, as it already does for the page's title and content, so a
@@ -1311,6 +1364,8 @@ GLOBAL OPTIONS:
    --strip-linebreaks, -L                   remove linebreaks inside of tags, to accommodate non-standard Confluence behavior [$MARK_STRIP_LINEBREAKS]
    --title-from-h1                          extract page title from a leading H1 heading. If no H1 heading on a page exists, then title must be set in the page metadata. Mutually exclusive with --title-from-filename. [$MARK_TITLE_FROM_H1]
    --title-from-filename                    use the filename (without extension) as the Confluence page title if no explicit page title is set in the metadata. Mutually exclusive with --title-from-h1. [$MARK_TITLE_FROM_FILENAME]
+   --parents-from-path                      place each page under a page named after every directory between the file pattern's root and the file itself. An index.md or README.md is the page for its own directory rather than a page inside it. A document that names its own Parent is left alone. [$MARK_PARENTS_FROM_PATH]
+   --parents-from-path-root string          the directory --parents-from-path measures from. Taken from the --files pattern when not given, which is everything before its first wildcard. [$MARK_PARENTS_FROM_PATH_ROOT]
    --title-append-generated-hash            appends a short hash generated from the path of the page (space, parents, and title) to the title [$MARK_TITLE_APPEND_GENERATED_HASH]
    --minor-edit                             don't send notifications while updating Confluence page. [$MARK_MINOR_EDIT]
    --version-message string                 add a message to the page version, to explain the edit (default: "") [$MARK_VERSION_MESSAGE]

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -908,6 +908,11 @@ func (s *Server) searchContent(w http.ResponseWriter, r *http.Request) {
 
 	var matches []*Page
 	for _, p := range s.pages {
+		// A page in the trash is not found by a search, the way it is not in
+		// the space any more as far as anything else is concerned.
+		if p.Trashed {
+			continue
+		}
 		if spaceKey != "" && p.SpaceKey != spaceKey {
 			continue
 		}
@@ -1190,7 +1195,8 @@ func (s *Server) childPages(w http.ResponseWriter, r *http.Request, parentID str
 
 	results := []map[string]any{}
 	for _, id := range s.childOrder[parentID] {
-		if p, ok := s.pages[id]; ok && p.ParentID == parentID {
+		// Trashing a page takes it out of its parent's children.
+		if p, ok := s.pages[id]; ok && p.ParentID == parentID && !p.Trashed {
 			results = append(results, s.pageJSON(p))
 		}
 	}

--- a/mark.go
+++ b/mark.go
@@ -472,11 +472,13 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 
 	// Where the file sits says where the page goes, unless the document says
 	// otherwise. An author who wrote a Parent header meant it.
+	pathRoot := config.ParentsFromPathRoot
+	if config.ParentsFromPath && pathRoot == "" {
+		pathRoot = page.GlobRoot(config.Files)
+	}
+
 	if config.ParentsFromPath && meta != nil {
-		root := config.ParentsFromPathRoot
-		if root == "" {
-			root = page.GlobRoot(config.Files)
-		}
+		root := pathRoot
 
 		derived, title := page.PathHierarchy(root, file)
 
@@ -922,6 +924,12 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	if tracker != nil && meta != nil {
 		if err := tracker.Record(meta.Space, file, target.ID, meta.Title, sourceHash); err != nil {
 			return nil, nil, fmt.Errorf("unable to record page mapping for %q: %w", file, err)
+		}
+
+		if config.ParentsFromPath && !meta.DeclaredParents {
+			if err := recordDirectoryPages(tracker, target, pathRoot, file, meta.Space); err != nil {
+				return nil, nil, err
+			}
 		}
 	}
 
@@ -1910,4 +1918,54 @@ func handleOrphans(
 	}
 
 	return nil
+}
+
+// recordDirectoryPages remembers the pages standing for the directories a
+// document sits under.
+//
+// mark creates them and nothing has been keeping track of them, so the last
+// document under a directory going away used to leave its page behind with
+// nobody aware it was ever mark's doing. Recorded, it turns up as a page with
+// no source file like any other, and --on-orphan can be told what to do about
+// it.
+//
+// The ids come from the published page's own ancestors rather than from the
+// code that creates them: a document's ancestors end with exactly the pages its
+// path asked for, and reading them costs nothing extra.
+func recordDirectoryPages(
+	tracker *manifest.Store,
+	target *confluence.PageInfo,
+	root, file, space string,
+) error {
+	keys := page.DirectoryKeys(root, file)
+	if len(keys) == 0 || len(target.Ancestors) < len(keys) {
+		return nil
+	}
+
+	tail := target.Ancestors[len(target.Ancestors)-len(keys):]
+
+	for i, key := range keys {
+		// A directory holding a document of its own has that document's entry
+		// for its page already, and two entries claiming one page is the thing
+		// the manifest complains about.
+		if page.HasIndexFile(key) {
+			continue
+		}
+
+		if err := tracker.Record(
+			space, key, tail[i].ID, tail[i].Title, directoryHash(key),
+		); err != nil {
+			return fmt.Errorf("unable to record directory page for %q: %w", key, err)
+		}
+	}
+
+	return nil
+}
+
+// directoryHash gives a directory entry a fingerprint of its own.
+//
+// A directory has no content to fingerprint, and an entry sharing a hash with a
+// document could be mistaken for that document under a previous name.
+func directoryHash(key string) string {
+	return sha1Hash("mark:directory:" + key)
 }

--- a/mark.go
+++ b/mark.go
@@ -63,6 +63,8 @@ type Config struct {
 	TitleFromH1              bool
 	TitleFromFilename        bool
 	TitleAppendGeneratedHash bool
+	ParentsFromPath          bool
+	ParentsFromPathRoot      string
 	ContentAppearance        string
 
 	// Page updates
@@ -245,6 +247,13 @@ func Run(config Config) error {
 	// What the run did, for whatever is reading the output rather than the log.
 	results := report.New()
 
+	// Only when the path decides where pages go: that is what turns a title
+	// two documents share from bad luck into the ordinary case.
+	var titles *page.TitleClaims
+	if config.ParentsFromPath {
+		titles = page.NewTitleClaims()
+	}
+
 	// Pages that asked for a position among their siblings, collected as they
 	// publish and applied once at the end -- the order of one page only means
 	// anything alongside the others.
@@ -254,7 +263,7 @@ func Run(config Config) error {
 	for _, file := range files {
 		log.Info().Msgf("processing %s", file)
 
-		target, placement, err := processFile(file, api, config, std, tracker, folders, checker, globalProperties, deferrals, results)
+		target, placement, err := processFile(file, api, config, std, tracker, folders, checker, globalProperties, deferrals, results, titles)
 		if placement != nil {
 			ordered = append(ordered, *placement)
 		}
@@ -303,7 +312,7 @@ func Run(config Config) error {
 			// Nil deferrals: this is the last look, so a link that still does
 			// not resolve is reported rather than waited on again.
 			if _, _, err := processFile(
-				file, api, config, std, tracker, folders, checker, globalProperties, nil, results,
+				file, api, config, std, tracker, folders, checker, globalProperties, nil, results, titles,
 			); err != nil {
 				if config.ContinueOnError {
 					log.Error().Err(err).Msgf("processing %s", file)
@@ -401,7 +410,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 
 	checker := page.NewLinkChecker(linkChecks)
 
-	target, _, err := processFile(file, api, config, std, nil, nil, checker, globalProperties, nil, nil)
+	target, _, err := processFile(file, api, config, std, nil, nil, checker, globalProperties, nil, nil, nil)
 	if err != nil {
 		return target, err
 	}
@@ -420,7 +429,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 	return target, nil
 }
 
-func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, folders page.FolderTracker, checker *page.LinkChecker, globalProperties map[string]any, deferrals *page.Deferrals, results *report.Report) (*confluence.PageInfo, *page.Ordered, error) {
+func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, folders page.FolderTracker, checker *page.LinkChecker, globalProperties map[string]any, deferrals *page.Deferrals, results *report.Report, titles *page.TitleClaims) (*confluence.PageInfo, *page.Ordered, error) {
 	markdown, err := os.ReadFile(file)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to read file %q: %w", file, err)
@@ -459,6 +468,37 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to extract metadata from file %q: %w", file, err)
+	}
+
+	// Where the file sits says where the page goes, unless the document says
+	// otherwise. An author who wrote a Parent header meant it.
+	if config.ParentsFromPath && meta != nil {
+		root := config.ParentsFromPathRoot
+		if root == "" {
+			root = page.GlobRoot(config.Files)
+		}
+
+		derived, title := page.PathHierarchy(root, file)
+
+		if !meta.DeclaredParents {
+			meta.Parents = append(meta.Parents, derived...)
+		}
+
+		// An index file has no title of its own to speak of: taken from the
+		// filename it would be "Readme" on every page that has one.
+		if title != "" && !meta.DeclaredTitle {
+			meta.Title = title
+		}
+	}
+
+	if meta != nil {
+		if previous, taken := titles.Claim(meta.Space, meta.Title, file); taken {
+			return nil, nil, fmt.Errorf(
+				"%s already publishes %q in space %q, and a space holds one page of a title: "+
+					"rename one of them, or use --title-append-generated-hash",
+				previous, meta.Title, meta.Space,
+			)
+		}
 	}
 
 	if config.PageID != "" && meta != nil {

--- a/mark.go
+++ b/mark.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kovetskiy/mark/v16/types"
 	"github.com/kovetskiy/mark/v16/vfs"
 	"github.com/rs/zerolog/log"
+	"go.yaml.in/yaml/v3"
 )
 
 var markerRegex = regexp.MustCompile(`(?s)<ac:inline-comment-marker ac:ref="([^"]+)">(.*?)</ac:inline-comment-marker>`)
@@ -249,9 +250,13 @@ func Run(config Config) error {
 
 	// Only when the path decides where pages go: that is what turns a title
 	// two documents share from bad luck into the ordinary case.
-	var titles *page.TitleClaims
+	var (
+		titles          *page.TitleClaims
+		directoryTitles *page.DirectoryTitles
+	)
 	if config.ParentsFromPath {
 		titles = page.NewTitleClaims()
+		directoryTitles = page.NewDirectoryTitles(directoryTitleReader(config))
 	}
 
 	// Pages that asked for a position among their siblings, collected as they
@@ -263,7 +268,7 @@ func Run(config Config) error {
 	for _, file := range files {
 		log.Info().Msgf("processing %s", file)
 
-		target, placement, err := processFile(file, api, config, std, tracker, folders, checker, globalProperties, deferrals, results, titles)
+		target, placement, err := processFile(file, api, config, std, tracker, folders, checker, globalProperties, deferrals, results, titles, directoryTitles)
 		if placement != nil {
 			ordered = append(ordered, *placement)
 		}
@@ -312,7 +317,7 @@ func Run(config Config) error {
 			// Nil deferrals: this is the last look, so a link that still does
 			// not resolve is reported rather than waited on again.
 			if _, _, err := processFile(
-				file, api, config, std, tracker, folders, checker, globalProperties, nil, results, titles,
+				file, api, config, std, tracker, folders, checker, globalProperties, nil, results, titles, directoryTitles,
 			); err != nil {
 				if config.ContinueOnError {
 					log.Error().Err(err).Msgf("processing %s", file)
@@ -410,7 +415,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 
 	checker := page.NewLinkChecker(linkChecks)
 
-	target, _, err := processFile(file, api, config, std, nil, nil, checker, globalProperties, nil, nil, nil)
+	target, _, err := processFile(file, api, config, std, nil, nil, checker, globalProperties, nil, nil, nil, nil)
 	if err != nil {
 		return target, err
 	}
@@ -429,7 +434,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 	return target, nil
 }
 
-func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, folders page.FolderTracker, checker *page.LinkChecker, globalProperties map[string]any, deferrals *page.Deferrals, results *report.Report, titles *page.TitleClaims) (*confluence.PageInfo, *page.Ordered, error) {
+func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, folders page.FolderTracker, checker *page.LinkChecker, globalProperties map[string]any, deferrals *page.Deferrals, results *report.Report, titles *page.TitleClaims, directoryTitles *page.DirectoryTitles) (*confluence.PageInfo, *page.Ordered, error) {
 	markdown, err := os.ReadFile(file)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to read file %q: %w", file, err)
@@ -478,17 +483,20 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	}
 
 	if config.ParentsFromPath && meta != nil {
-		root := pathRoot
-
-		derived, title := page.PathHierarchy(root, file)
+		derived, title, err := page.PathHierarchy(pathRoot, file, directoryTitles)
+		if err != nil {
+			return nil, nil, err
+		}
 
 		if !meta.DeclaredParents {
 			meta.Parents = append(meta.Parents, derived...)
 		}
 
-		// An index file has no title of its own to speak of: taken from the
-		// filename it would be "Readme" on every page that has one.
-		if title != "" && !meta.DeclaredTitle {
+		// A directory's own document is titled by the directory, whatever the
+		// filename would have said -- "Readme" on every page that has one. The
+		// title comes from the same place its children's parent does, so the
+		// two cannot disagree.
+		if title != "" {
 			meta.Title = title
 		}
 	}
@@ -1968,4 +1976,61 @@ func recordDirectoryPages(
 // document could be mistaken for that document under a previous name.
 func directoryHash(key string) string {
 	return sha1Hash("mark:directory:" + key)
+}
+
+// directoryTitleReader works out what a directory's page should be called.
+//
+// A directory's own document says so first, in the same order publishing would
+// read it: a Title header or front matter, then a leading heading when
+// --title-from-h1 asked for that. A .pages file beside the documents says so
+// for a directory that has no document of its own. Failing both, the directory
+// is named after itself.
+//
+// The filename is deliberately not consulted. It is "README" in every directory
+// that has one, which is a name for a file rather than for a page.
+func directoryTitleReader(config Config) func(string) (string, error) {
+	return func(directory string) (string, error) {
+		for _, name := range []string{"index.md", "README.md", "readme.md", "Index.md"} {
+			path := filepath.Join(directory, name)
+
+			source, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+
+			meta, _, err := metadata.ExtractMeta(
+				source, "", config.TitleFromH1, false, path, nil, false, "",
+				slices.Contains(config.Features, "frontmatter"),
+			)
+			if err != nil {
+				return "", fmt.Errorf("unable to read the title of %q: %w", path, err)
+			}
+
+			if meta != nil && meta.Title != "" {
+				return meta.Title, nil
+			}
+
+			break
+		}
+
+		return directoryTitleFromPagesFile(directory)
+	}
+}
+
+// directoryTitleFromPagesFile reads a .pages file, the convention MkDocs and
+// others already use for naming a directory.
+func directoryTitleFromPagesFile(directory string) (string, error) {
+	source, err := os.ReadFile(filepath.Join(directory, ".pages"))
+	if err != nil {
+		return "", nil //nolint:nilerr // absence is the ordinary case
+	}
+
+	var pages struct {
+		Title string `yaml:"title"`
+	}
+	if err := yaml.Unmarshal(source, &pages); err != nil {
+		return "", fmt.Errorf("unable to parse %s: %w", filepath.Join(directory, ".pages"), err)
+	}
+
+	return strings.TrimSpace(pages.Title), nil
 }

--- a/mark_hierarchy_test.go
+++ b/mark_hierarchy_test.go
@@ -298,3 +298,78 @@ func TestDirectoryPagesAreNotRecordedWithoutTheFlag(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ok, "a parent mark did not derive from the path is not its to track")
 }
+
+// TestIndexTitleIsTheDirectoryTitle is a bug phase one left behind. A README
+// that titled itself published under that title, while the documents beside it
+// went on looking for a page named after the directory -- so mark made a second,
+// empty one and put them under that, leaving the README's page childless.
+func TestIndexTitleIsTheDirectoryTitle(t *testing.T) {
+	dir := t.TempDir()
+	writeAt(t, dir, "guides/README.md", space+"<!-- Title: Developer Handbook -->\n\nIntro.\n")
+	writeAt(t, dir, "guides/setup.md", space+"<!-- Title: Setup -->\n\nSetup.\n")
+
+	api := runHierarchy(t, dir, nil)
+
+	assert.Equal(t, []string{"Home", "Developer Handbook"}, ancestryOf(t, api, "Setup"),
+		"the children belong to the page their directory's document published")
+
+	empty, err := api.FindPage("DOCS", "Guides", "page")
+	require.NoError(t, err)
+	assert.Nil(t, empty, "no second page named after the directory")
+}
+
+// TestIndexH1BecomesTheDirectoryTitle: with --title-from-h1 the heading is what
+// the document calls itself, and phase one threw it away.
+func TestIndexH1BecomesTheDirectoryTitle(t *testing.T) {
+	dir := t.TempDir()
+	writeAt(t, dir, "guides/README.md", space+"\n# Developer Handbook\n\nIntro.\n")
+	writeAt(t, dir, "guides/setup.md", space+"<!-- Title: Setup -->\n\nSetup.\n")
+
+	api := runHierarchy(t, dir, func(c *Config) { c.TitleFromH1 = true })
+
+	assert.Equal(t, []string{"Home", "Developer Handbook"}, ancestryOf(t, api, "Setup"))
+
+	empty, err := api.FindPage("DOCS", "Guides", "page")
+	require.NoError(t, err)
+	assert.Nil(t, empty)
+}
+
+// TestPagesFileNamesADirectory covers a directory with no document of its own.
+func TestPagesFileNamesADirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeAt(t, dir, "guides/.pages", "title: Developer Handbook\n")
+	writeAt(t, dir, "guides/setup.md", space+"<!-- Title: Setup -->\n\nSetup.\n")
+
+	api := runHierarchy(t, dir, nil)
+
+	assert.Equal(t, []string{"Home", "Developer Handbook"}, ancestryOf(t, api, "Setup"))
+}
+
+// TestDocumentBeatsPagesFile: a directory's own document is the more particular
+// statement about what its page is called.
+func TestDocumentBeatsPagesFile(t *testing.T) {
+	dir := t.TempDir()
+	writeAt(t, dir, "guides/.pages", "title: From The Pages File\n")
+	writeAt(t, dir, "guides/README.md", space+"<!-- Title: From The Document -->\n\nx.\n")
+	writeAt(t, dir, "guides/setup.md", space+"<!-- Title: Setup -->\n\nSetup.\n")
+
+	api := runHierarchy(t, dir, nil)
+
+	assert.Equal(t, []string{"Home", "From The Document"}, ancestryOf(t, api, "Setup"))
+}
+
+// TestFilenameNeverNamesADirectory: --title-from-filename would call every
+// directory's page "Readme", which is a name for a file rather than a page.
+func TestFilenameNeverNamesADirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeAt(t, dir, "guides/README.md", space+"\nIntro.\n")
+	writeAt(t, dir, "guides/setup.md", space+"<!-- Title: Setup -->\n\nSetup.\n")
+
+	api := runHierarchy(t, dir, func(c *Config) { c.TitleFromFilename = true })
+
+	assert.Equal(t, []string{"Home", "Guides"}, ancestryOf(t, api, "Setup"))
+
+	readme, err := api.FindPage("DOCS", "Readme", "page")
+	require.NoError(t, err)
+	assert.Nil(t, readme, "no page should be called Readme")
+}

--- a/mark_hierarchy_test.go
+++ b/mark_hierarchy_test.go
@@ -1,0 +1,206 @@
+package mark
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func hierarchyServer(t *testing.T) *confluencetest.Server {
+	t.Helper()
+	s := confluencetest.New(t)
+	home := s.AddPage("DOCS", "Home", "page", "")
+	s.SetHomepage("DOCS", home.ID)
+	return s
+}
+
+// writeAt writes a file, creating the directories leading to it.
+func writeAt(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+// ancestryOf reports the titles a page sits under, outermost first.
+func ancestryOf(t *testing.T, api *confluence.API, title string) []string {
+	t.Helper()
+
+	page, err := api.FindPage("DOCS", title, "page")
+	require.NoError(t, err)
+	require.NotNil(t, page, "page %q should exist", title)
+
+	found, err := api.GetPageByIDExpanded(page.ID, "ancestors")
+	require.NoError(t, err)
+
+	var titles []string
+	for _, ancestor := range found.Ancestors {
+		titles = append(titles, ancestor.Title)
+	}
+
+	return titles
+}
+
+func runHierarchy(t *testing.T, dir string, extra func(*Config)) *confluence.API {
+	t.Helper()
+
+	server := hierarchyServer(t)
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "**", "*.md"), Features: []string{"mention"},
+		ParentsFromPath: true, ParentsFromPathRoot: dir, Output: io.Discard,
+	}
+	if extra != nil {
+		extra(&config)
+	}
+	require.NoError(t, Run(config))
+
+	return confluence.NewAPI(server.URL, "user", "token", false)
+}
+
+const space = "<!-- Space: DOCS -->\n"
+
+// TestPathBecomesTheParentChain is the feature: where a file sits is where its
+// page goes.
+func TestPathBecomesTheParentChain(t *testing.T) {
+	dir := t.TempDir()
+	writeAt(t, dir, "guides/deep/setup.md", space+"<!-- Title: Setup -->\n\nSetup.\n")
+
+	api := runHierarchy(t, dir, nil)
+
+	assert.Equal(t, []string{"Home", "Guides", "Deep"}, ancestryOf(t, api, "Setup"))
+}
+
+// TestIndexIsItsDirectorysPage: a directory's own document is its landing page,
+// not a child of an empty one.
+func TestIndexIsItsDirectorysPage(t *testing.T) {
+	dir := t.TempDir()
+	writeAt(t, dir, "guides/README.md", space+"\nWhat the guides are.\n")
+	writeAt(t, dir, "guides/setup.md", space+"<!-- Title: Setup -->\n\nSetup.\n")
+
+	api := runHierarchy(t, dir, nil)
+
+	// The README took its title from the directory and sits at the top.
+	assert.Equal(t, []string{"Home"}, ancestryOf(t, api, "Guides"))
+	assert.Equal(t, []string{"Home", "Guides"}, ancestryOf(t, api, "Setup"))
+
+	page, err := api.FindPage("DOCS", "Guides", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+}
+
+// TestDeclaredParentWins: an author who wrote a Parent header meant it.
+func TestDeclaredParentWins(t *testing.T) {
+	dir := t.TempDir()
+	writeAt(t, dir, "guides/setup.md",
+		space+"<!-- Title: Setup -->\n<!-- Parent: Elsewhere -->\n\nSetup.\n")
+
+	api := runHierarchy(t, dir, nil)
+
+	assert.Equal(t, []string{"Home", "Elsewhere"}, ancestryOf(t, api, "Setup"),
+		"the document's own Parent must not be joined by the path's")
+}
+
+// TestDeclaredTitleWinsForAnIndex: only a title it does not have is supplied.
+func TestDeclaredTitleWinsForAnIndex(t *testing.T) {
+	dir := t.TempDir()
+	writeAt(t, dir, "guides/README.md", space+"<!-- Title: Handbook -->\n\nx.\n")
+
+	api := runHierarchy(t, dir, nil)
+
+	page, err := api.FindPage("DOCS", "Handbook", "page")
+	require.NoError(t, err)
+	assert.NotNil(t, page, "the title the document gave itself is kept")
+}
+
+// TestParentsFlagStillPrefixes: --parents remains the root of everything.
+func TestParentsFlagStillPrefixes(t *testing.T) {
+	dir := t.TempDir()
+	writeAt(t, dir, "guides/setup.md", space+"<!-- Title: Setup -->\n\nSetup.\n")
+
+	api := runHierarchy(t, dir, func(c *Config) { c.Parents = []string{"Docs Root"} })
+
+	assert.Equal(t, []string{"Home", "Docs Root", "Guides"}, ancestryOf(t, api, "Setup"))
+}
+
+// TestWithoutTheFlagNothingChanges guards the default.
+func TestWithoutTheFlagNothingChanges(t *testing.T) {
+	dir := t.TempDir()
+	writeAt(t, dir, "guides/setup.md", space+"<!-- Title: Setup -->\n\nSetup.\n")
+
+	api := runHierarchy(t, dir, func(c *Config) { c.ParentsFromPath = false })
+
+	assert.Equal(t, []string{"Home"}, ancestryOf(t, api, "Setup"),
+		"without the flag the path says nothing")
+}
+
+// TestRootIsTakenFromThePattern: the root need not be given.
+func TestRootIsTakenFromThePattern(t *testing.T) {
+	dir := t.TempDir()
+	writeAt(t, dir, "guides/setup.md", space+"<!-- Title: Setup -->\n\nSetup.\n")
+
+	api := runHierarchy(t, dir, func(c *Config) { c.ParentsFromPathRoot = "" })
+
+	assert.Equal(t, []string{"Home", "Guides"}, ancestryOf(t, api, "Setup"))
+}
+
+// TestTitleCollisionIsRefused is what makes this safe to turn on. A space holds
+// one page of a given title, so two documents wanting the same one want the
+// same page: without this the second overwrites the first and drags it under
+// its own parents, leaving one page where two were meant and nothing to say so.
+//
+// Deriving parents from the path makes that likely rather than unlucky, since
+// every directory tends to hold a README and several will want an "Overview".
+func TestTitleCollisionIsRefused(t *testing.T) {
+	server := hierarchyServer(t)
+	dir := t.TempDir()
+	writeAt(t, dir, "api/overview.md", space+"<!-- Title: Overview -->\n\nAPI overview.\n")
+	writeAt(t, dir, "sdk/overview.md", space+"<!-- Title: Overview -->\n\nSDK overview.\n")
+
+	err := Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "**", "*.md"), Features: []string{"mention"},
+		ParentsFromPath: true, ParentsFromPathRoot: dir, Output: io.Discard,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already publishes")
+	assert.Contains(t, err.Error(), "--title-append-generated-hash")
+
+	// The document that got there first keeps the page it published, with its
+	// own content and under its own parents.
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	assert.Equal(t, []string{"Home", "Api"}, ancestryOf(t, api, "Overview"))
+
+	page, err := api.FindPage("DOCS", "Overview", "page")
+	require.NoError(t, err)
+	found, err := api.GetPageByIDExpanded(page.ID, "ancestors,body.storage")
+	require.NoError(t, err)
+	assert.Contains(t, found.Body.Storage.Value, "API overview",
+		"the first document's page must not have been taken over")
+}
+
+// TestSameTitleInDifferentSpacesIsFine: the constraint is per space.
+func TestSameTitleInDifferentSpacesIsFine(t *testing.T) {
+	server := hierarchyServer(t)
+	server.AddSpace("OTHER")
+	other := server.AddPage("OTHER", "Other Home", "page", "")
+	server.SetHomepage("OTHER", other.ID)
+
+	dir := t.TempDir()
+	writeAt(t, dir, "api/overview.md", space+"<!-- Title: Overview -->\n\nOne.\n")
+	writeAt(t, dir, "sdk/overview.md",
+		"<!-- Space: OTHER -->\n<!-- Title: Overview -->\n\nTwo.\n")
+
+	assert.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "**", "*.md"), Features: []string{"mention"},
+		ParentsFromPath: true, ParentsFromPathRoot: dir, Output: io.Discard,
+	}))
+}

--- a/mark_hierarchy_test.go
+++ b/mark_hierarchy_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kovetskiy/mark/v16/confluence"
 	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/kovetskiy/mark/v16/manifest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -203,4 +204,97 @@ func TestSameTitleInDifferentSpacesIsFine(t *testing.T) {
 		Files: filepath.Join(dir, "**", "*.md"), Features: []string{"mention"},
 		ParentsFromPath: true, ParentsFromPathRoot: dir, Output: io.Discard,
 	}))
+}
+
+// TestEmptiedDirectoryBecomesAnOrphan is what phase two is for. mark creates
+// the page standing for a directory, and nothing used to remember that, so when
+// the last document under it went away the page stayed behind with nobody aware
+// it had ever been mark's doing.
+func TestEmptiedDirectoryBecomesAnOrphan(t *testing.T) {
+	server := hierarchyServer(t)
+	dir := t.TempDir()
+	writeAt(t, dir, "guides/setup.md", space+"<!-- Title: Setup -->\n\nSetup.\n")
+	writeAt(t, dir, "keep.md", space+"<!-- Title: Keep -->\n\nKeep.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "**", "*.md"), Features: []string{"mention"},
+		ParentsFromPath: true, ParentsFromPathRoot: dir,
+		TrackPages: true, OnOrphan: "delete", Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	guides, err := api.FindPage("DOCS", "Guides", "page")
+	require.NoError(t, err)
+	require.NotNil(t, guides, "mark created a page for the directory")
+
+	setup, err := api.FindPage("DOCS", "Setup", "page")
+	require.NoError(t, err)
+	require.NotNil(t, setup)
+
+	// The whole directory goes.
+	require.NoError(t, os.RemoveAll(filepath.Join(dir, "guides")))
+	require.NoError(t, Run(config))
+
+	// Setup goes first, then Guides, which is only removable once empty.
+	assert.True(t, server.Page(setup.ID).Trashed, "the document's page is an orphan")
+	require.NoError(t, Run(config))
+	assert.True(t, server.Page(guides.ID).Trashed,
+		"the page standing for the directory is an orphan too")
+}
+
+// TestDirectoryWithAnIndexIsNotRecordedTwice: a directory holding its own
+// document has that document's entry for its page already, and two entries
+// claiming one page is what the manifest complains about.
+func TestDirectoryWithAnIndexIsNotRecordedTwice(t *testing.T) {
+	server := hierarchyServer(t)
+	dir := t.TempDir()
+	writeAt(t, dir, "guides/README.md", space+"\nWhat the guides are.\n")
+	writeAt(t, dir, "guides/setup.md", space+"<!-- Title: Setup -->\n\nSetup.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "**", "*.md"), Features: []string{"mention"},
+		ParentsFromPath: true, ParentsFromPathRoot: dir,
+		TrackPages: true, Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	guides, err := api.FindPage("DOCS", "Guides", "page")
+	require.NoError(t, err)
+	require.NotNil(t, guides)
+
+	store := manifest.NewStore(api)
+
+	// The README owns the page, under its own path.
+	entry, ok, err := store.Lookup("DOCS", filepath.Join(dir, "guides", "README.md"))
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, guides.ID, entry.PageID)
+
+	// The directory itself is not a second claim on it.
+	_, ok, err = store.Lookup("DOCS", filepath.Join(dir, "guides"))
+	require.NoError(t, err)
+	assert.False(t, ok, "the directory must not claim a page its own document owns")
+}
+
+// TestDirectoryPagesAreNotRecordedWithoutTheFlag guards the default.
+func TestDirectoryPagesAreNotRecordedWithoutTheFlag(t *testing.T) {
+	server := hierarchyServer(t)
+	dir := t.TempDir()
+	writeAt(t, dir, "guides/setup.md",
+		space+"<!-- Title: Setup -->\n<!-- Parent: Guides -->\n\nSetup.\n")
+
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "**", "*.md"), Features: []string{"mention"},
+		TrackPages: true, Output: io.Discard,
+	}))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	_, ok, err := manifest.NewStore(api).Lookup("DOCS", filepath.Join(dir, "guides"))
+	require.NoError(t, err)
+	assert.False(t, ok, "a parent mark did not derive from the path is not its to track")
 }

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -50,6 +50,13 @@ type Meta struct {
 	Labels            []string
 	ContentAppearance string
 
+	// DeclaredParents and DeclaredTitle record what the document said about
+	// itself, as against what a command line flag supplied. Deriving either
+	// from the file's path has to give way to an author who wrote it down, and
+	// by the time Parents and Title are assembled the two are indistinguishable.
+	DeclaredParents bool
+	DeclaredTitle   bool
+
 	// Synchronized is whether the document is published at all. Nil means it
 	// said nothing, which is not the same as false: a pointer keeps the
 	// difference between a document opting out and a Meta that simply never
@@ -202,6 +209,7 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 			switch normKey {
 			case "parents":
 				meta.Parents = append(meta.Parents, toStringSlice(v)...)
+				meta.DeclaredParents = true
 			case "folders":
 				meta.Folders = append(meta.Folders, toStringSlice(v)...)
 			case "space":
@@ -210,6 +218,7 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 				meta.Type = toString(v)
 			case "title":
 				meta.Title = toString(v)
+				meta.DeclaredTitle = true
 			case "layout":
 				meta.Layout = toString(v)
 			case "sidebar":
@@ -311,6 +320,7 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 				switch header {
 				case HeaderParent:
 					meta.Parents = append(meta.Parents, value)
+					meta.DeclaredParents = true
 
 				case HeaderFolder:
 					meta.Folders = append(meta.Folders, value)
@@ -323,6 +333,7 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 
 				case HeaderTitle:
 					meta.Title = strings.TrimSpace(value)
+					meta.DeclaredTitle = true
 
 				case HeaderLayout:
 					meta.Layout = strings.TrimSpace(value)
@@ -467,10 +478,16 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 
 func setTitleFromFilename(meta *Meta, filename string) {
 	base := filepath.Base(filename)
-	title := strings.TrimSuffix(base, filepath.Ext(base))
-	title = strings.ReplaceAll(title, "_", " ")
-	title = strings.ReplaceAll(title, "-", " ")
-	meta.Title = cases.Title(language.English).String(title)
+	meta.Title = TitleFromName(strings.TrimSuffix(base, filepath.Ext(base)))
+}
+
+// TitleFromName turns a file or directory name into a page title, so that
+// "getting-started" reads as "Getting Started".
+func TitleFromName(name string) string {
+	name = strings.ReplaceAll(name, "_", " ")
+	name = strings.ReplaceAll(name, "-", " ")
+
+	return cases.Title(language.English).String(name)
 }
 
 // ExtractDocumentLeadingH1 will extract leading H1 heading

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -181,7 +181,7 @@ image-align: center
 		Labels:            []string{"alpha", "beta"},
 		ContentAppearance: DefaultContentAppearance,
 		ImageAlign:        "center",
-	}, meta)
+		DeclaredTitle:     true, DeclaredParents: true}, meta)
 	assert.Equal(t, "# Content\n", string(body))
 }
 
@@ -342,7 +342,7 @@ func TestExtractMeta_FolderHeaders(t *testing.T) {
 				Title:             "Authentication",
 				Type:              "page",
 				ContentAppearance: "full-width",
-			},
+				DeclaredTitle:     true},
 		},
 		{
 			name: "multiple folder headers",
@@ -359,7 +359,7 @@ func TestExtractMeta_FolderHeaders(t *testing.T) {
 				Title:             "Password Reset",
 				Type:              "page",
 				ContentAppearance: "full-width",
-			},
+				DeclaredTitle:     true},
 		},
 		{
 			name: "folder and parent headers mixed",
@@ -377,7 +377,7 @@ func TestExtractMeta_FolderHeaders(t *testing.T) {
 				Title:             "Password Reset",
 				Type:              "page",
 				ContentAppearance: "full-width",
-			},
+				DeclaredTitle:     true, DeclaredParents: true},
 		},
 		{
 			name: "no folder headers",
@@ -392,7 +392,7 @@ func TestExtractMeta_FolderHeaders(t *testing.T) {
 				Title:             "Password Reset",
 				Type:              "page",
 				ContentAppearance: "full-width",
-			},
+				DeclaredTitle:     true, DeclaredParents: true},
 		},
 		{
 			name: "folder headers with spaces and special characters",
@@ -408,7 +408,7 @@ func TestExtractMeta_FolderHeaders(t *testing.T) {
 				Title:             "Getting Started",
 				Type:              "page",
 				ContentAppearance: "full-width",
-			},
+				DeclaredTitle:     true},
 		},
 	}
 

--- a/page/hierarchy.go
+++ b/page/hierarchy.go
@@ -56,7 +56,7 @@ func GlobRoot(pattern string) string {
 //
 // The returned title is only a suggestion, and only for an index file: every
 // other document keeps whatever title it would have had.
-func PathHierarchy(root, file string) (parents []string, title string) {
+func PathHierarchy(root, file string, titles *DirectoryTitles) (parents []string, title string, err error) {
 	file = filepath.ToSlash(file)
 	root = strings.TrimSuffix(filepath.ToSlash(root), "/")
 
@@ -65,7 +65,7 @@ func PathHierarchy(root, file string) (parents []string, title string) {
 		trimmed, ok := strings.CutPrefix(file, root+"/")
 		if !ok {
 			// Outside the root the path says nothing about where the page goes.
-			return nil, ""
+			return nil, "", nil
 		}
 		relative = trimmed
 	}
@@ -87,28 +87,52 @@ func PathHierarchy(root, file string) (parents []string, title string) {
 		// The document is its directory's page, so its parents are the
 		// directories above it and its title is the directory's own.
 		if len(segments) == 0 {
-			return nil, ""
+			return nil, "", nil
 		}
 
-		parents = titles(segments[:len(segments)-1])
+		parents, err = resolveTitles(root, segments[:len(segments)-1], titles)
+		if err != nil {
+			return nil, "", err
+		}
 
-		return parents, metadata.TitleFromName(segments[len(segments)-1])
+		own, err := titles.Title(joinPath(root, segments))
+		if err != nil {
+			return nil, "", err
+		}
+
+		return parents, own, nil
 	}
 
-	return titles(segments), ""
+	parents, err = resolveTitles(root, segments, titles)
+
+	return parents, "", err
 }
 
-func titles(segments []string) []string {
+func joinPath(root string, segments []string) string {
+	path := strings.Join(segments, "/")
+	if root != "" {
+		return root + "/" + path
+	}
+
+	return path
+}
+
+// resolveTitles names each directory on the way down.
+func resolveTitles(root string, segments []string, titles *DirectoryTitles) ([]string, error) {
 	if len(segments) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	out := make([]string, 0, len(segments))
-	for _, segment := range segments {
-		out = append(out, metadata.TitleFromName(segment))
+	for i := range segments {
+		title, err := titles.Title(joinPath(root, segments[:i+1]))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, title)
 	}
 
-	return out
+	return out, nil
 }
 
 // TitleClaims remembers which document laid claim to which page title.
@@ -212,4 +236,54 @@ func HasIndexFile(directory string) bool {
 	}
 
 	return false
+}
+
+// DirectoryTitles answers what the page standing for a directory is called.
+//
+// One answer, asked for in two places: by the document that is the directory's
+// page, and by every document underneath it that has to name its parent. Worked
+// out separately they disagreed, and a README that titled itself ended up beside
+// an empty page named after its directory rather than being it.
+type DirectoryTitles struct {
+	resolve func(directory string) (string, error)
+
+	mu     sync.Mutex
+	cached map[string]string
+}
+
+// NewDirectoryTitles returns a register that asks resolve once per directory.
+func NewDirectoryTitles(resolve func(directory string) (string, error)) *DirectoryTitles {
+	return &DirectoryTitles{resolve: resolve, cached: map[string]string{}}
+}
+
+// Title reports what the directory's page is called, falling back to the
+// directory's own name.
+func (d *DirectoryTitles) Title(directory string) (string, error) {
+	name := metadata.TitleFromName(filepath.Base(directory))
+
+	if d == nil || d.resolve == nil {
+		return name, nil
+	}
+
+	d.mu.Lock()
+	if title, ok := d.cached[directory]; ok {
+		d.mu.Unlock()
+
+		return title, nil
+	}
+	d.mu.Unlock()
+
+	title, err := d.resolve(directory)
+	if err != nil {
+		return "", err
+	}
+	if title == "" {
+		title = name
+	}
+
+	d.mu.Lock()
+	d.cached[directory] = title
+	d.mu.Unlock()
+
+	return title, nil
 }

--- a/page/hierarchy.go
+++ b/page/hierarchy.go
@@ -1,0 +1,152 @@
+package page
+
+import (
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/kovetskiy/mark/v16/metadata"
+)
+
+// indexNames are the files that stand for the directory they are in rather than
+// sitting inside it, which is the convention every static site generator and
+// code host already uses.
+var indexNames = map[string]bool{
+	"index":  true,
+	"readme": true,
+}
+
+// GlobRoot reports the directory a --files pattern starts from.
+//
+// Everything up to the first segment holding a wildcard: "docs/**/*.md" begins
+// at "docs", and so does "docs/*.md". A pattern with a wildcard in its first
+// segment has no fixed root and answers "", which leaves the paths beneath it
+// as they are.
+func GlobRoot(pattern string) string {
+	if pattern == "" {
+		return ""
+	}
+
+	segments := strings.Split(filepath.ToSlash(pattern), "/")
+
+	fixed := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		if strings.ContainsAny(segment, "*?[{") {
+			break
+		}
+		fixed = append(fixed, segment)
+	}
+
+	// The last fixed segment is the file itself when the pattern names one.
+	if len(fixed) == len(segments) && len(fixed) > 0 {
+		fixed = fixed[:len(fixed)-1]
+	}
+
+	return strings.Join(fixed, "/")
+}
+
+// PathHierarchy reports the parent titles a document's location implies, and
+// the title to give it if it has none of its own.
+//
+// A document is placed under a page for each directory between the root and
+// itself. An index file is not placed under a page named after its own
+// directory -- it is that page, which is what makes a directory's own document
+// its landing page rather than a child of an empty one.
+//
+// The returned title is only a suggestion, and only for an index file: every
+// other document keeps whatever title it would have had.
+func PathHierarchy(root, file string) (parents []string, title string) {
+	file = filepath.ToSlash(file)
+	root = strings.TrimSuffix(filepath.ToSlash(root), "/")
+
+	relative := file
+	if root != "" {
+		trimmed, ok := strings.CutPrefix(file, root+"/")
+		if !ok {
+			// Outside the root the path says nothing about where the page goes.
+			return nil, ""
+		}
+		relative = trimmed
+	}
+
+	directory := filepath.ToSlash(filepath.Dir(relative))
+	if directory == "." {
+		directory = ""
+	}
+
+	var segments []string
+	if directory != "" {
+		segments = strings.Split(directory, "/")
+	}
+
+	base := filepath.Base(relative)
+	name := strings.TrimSuffix(base, filepath.Ext(base))
+
+	if indexNames[strings.ToLower(name)] {
+		// The document is its directory's page, so its parents are the
+		// directories above it and its title is the directory's own.
+		if len(segments) == 0 {
+			return nil, ""
+		}
+
+		parents = titles(segments[:len(segments)-1])
+
+		return parents, metadata.TitleFromName(segments[len(segments)-1])
+	}
+
+	return titles(segments), ""
+}
+
+func titles(segments []string) []string {
+	if len(segments) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		out = append(out, metadata.TitleFromName(segment))
+	}
+
+	return out
+}
+
+// TitleClaims remembers which document laid claim to which page title.
+//
+// Confluence allows one page of a given title per space, so two documents
+// wanting the same title want the same page: the second overwrites the first
+// and moves it under its own parents, leaving one page where two were meant and
+// no sign that anything was lost.
+//
+// Deriving parents from the path makes that likely rather than unlucky. Every
+// directory tends to hold a README, and "Overview" is a thing several of them
+// will call a page. The claim is taken before anything is published, so the
+// second document fails and the first keeps the page it already had.
+type TitleClaims struct {
+	mu     sync.Mutex
+	claims map[string]string
+}
+
+// NewTitleClaims returns an empty register.
+func NewTitleClaims() *TitleClaims {
+	return &TitleClaims{claims: map[string]string{}}
+}
+
+// Claim records that file publishes title in space, and reports the document
+// that got there first, if any.
+func (c *TitleClaims) Claim(space, title, file string) (string, bool) {
+	if c == nil || title == "" {
+		return "", false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := space + "\x00" + title
+	if previous, taken := c.claims[key]; taken && previous != file {
+		return previous, true
+	}
+
+	c.claims[key] = file
+
+	return "", false
+}

--- a/page/hierarchy.go
+++ b/page/hierarchy.go
@@ -1,6 +1,7 @@
 package page
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -149,4 +150,66 @@ func (c *TitleClaims) Claim(space, title, file string) (string, bool) {
 	c.claims[key] = file
 
 	return "", false
+}
+
+// DirectoryKeys reports the directories a document's derived parents stand for,
+// outermost first, as paths rather than titles.
+//
+// "docs/guides/deep/setup.md" under root "docs" gives docs/guides and
+// docs/guides/deep, which are the pages mark creates on the way to it. They are
+// worth remembering: nothing else does, so when the last document under a
+// directory goes, the page standing for that directory would otherwise be left
+// behind with no one aware it was ever mark's.
+//
+// An index file is not counted as its own directory, having a page of its own
+// under its own name already.
+func DirectoryKeys(root, file string) []string {
+	file = filepath.ToSlash(file)
+	root = strings.TrimSuffix(filepath.ToSlash(root), "/")
+
+	relative := file
+	if root != "" {
+		trimmed, ok := strings.CutPrefix(file, root+"/")
+		if !ok {
+			return nil
+		}
+		relative = trimmed
+	}
+
+	directory := filepath.ToSlash(filepath.Dir(relative))
+	if directory == "." {
+		return nil
+	}
+
+	segments := strings.Split(directory, "/")
+
+	base := filepath.Base(relative)
+	if indexNames[strings.ToLower(strings.TrimSuffix(base, filepath.Ext(base)))] {
+		segments = segments[:len(segments)-1]
+	}
+
+	keys := make([]string, 0, len(segments))
+	for i := range segments {
+		path := strings.Join(segments[:i+1], "/")
+		if root != "" {
+			path = root + "/" + path
+		}
+		keys = append(keys, path)
+	}
+
+	return keys
+}
+
+// HasIndexFile reports whether a directory holds a document of its own.
+//
+// One that does owns the directory's page under its own path, and recording the
+// directory as well would leave two entries claiming a single page.
+func HasIndexFile(directory string) bool {
+	for _, name := range []string{"index.md", "README.md", "readme.md", "Index.md"} {
+		if _, err := os.Stat(filepath.Join(directory, name)); err == nil {
+			return true
+		}
+	}
+
+	return false
 }

--- a/page/hierarchy_test.go
+++ b/page/hierarchy_test.go
@@ -1,0 +1,71 @@
+package page
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGlobRoot(t *testing.T) {
+	for pattern, expected := range map[string]string{
+		"docs/**/*.md":      "docs",
+		"docs/*.md":         "docs",
+		"docs/guides/*.md":  "docs/guides",
+		"docs/README.md":    "docs",
+		"*.md":              "",
+		"**/*.md":           "",
+		"/abs/docs/**/*.md": "/abs/docs",
+		"docs/{a,b}/*.md":   "docs",
+		"":                  "",
+	} {
+		assert.Equal(t, expected, GlobRoot(pattern), "pattern %q", pattern)
+	}
+}
+
+func TestPathHierarchy(t *testing.T) {
+	for name, tt := range map[string]struct {
+		root, file string
+		parents    []string
+		title      string
+	}{
+		"a document in a subdirectory": {
+			"docs", "docs/guides/setup.md", []string{"Guides"}, "",
+		},
+		"nested directories": {
+			"docs", "docs/guides/deep/setup.md", []string{"Guides", "Deep"}, "",
+		},
+		"directory names are titled": {
+			"docs", "docs/getting-started/x.md", []string{"Getting Started"}, "",
+		},
+		"underscores too": {
+			"docs", "docs/on_call/x.md", []string{"On Call"}, "",
+		},
+		"a document at the root": {
+			"docs", "docs/setup.md", nil, "",
+		},
+		"README is its directory's page": {
+			"docs", "docs/guides/README.md", nil, "Guides",
+		},
+		"index is its directory's page": {
+			"docs", "docs/guides/index.md", nil, "Guides",
+		},
+		"a nested index sits under the directories above it": {
+			"docs", "docs/guides/deep/README.md", []string{"Guides"}, "Deep",
+		},
+		"README at the root has no directory to be named after": {
+			"docs", "docs/README.md", nil, "",
+		},
+		"no root at all": {
+			"", "guides/setup.md", []string{"Guides"}, "",
+		},
+		"a file outside the root says nothing": {
+			"docs", "other/setup.md", nil, "",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			parents, title := PathHierarchy(tt.root, tt.file)
+			assert.Equal(t, tt.parents, parents)
+			assert.Equal(t, tt.title, title)
+		})
+	}
+}

--- a/page/hierarchy_test.go
+++ b/page/hierarchy_test.go
@@ -63,9 +63,60 @@ func TestPathHierarchy(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			parents, title := PathHierarchy(tt.root, tt.file)
+			parents, title, err := PathHierarchy(tt.root, tt.file, nil)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.parents, parents)
 			assert.Equal(t, tt.title, title)
 		})
 	}
+}
+
+// TestDirectoryTitlesAreAskedOnce: a directory's title is worked out by reading
+// a file, and a repository has many documents in each directory.
+func TestDirectoryTitlesAreAskedOnce(t *testing.T) {
+	asked := map[string]int{}
+	titles := NewDirectoryTitles(func(directory string) (string, error) {
+		asked[directory]++
+
+		return "Handbook", nil
+	})
+
+	for range 3 {
+		title, err := titles.Title("docs/guides")
+		assert.NoError(t, err)
+		assert.Equal(t, "Handbook", title)
+	}
+
+	assert.Equal(t, 1, asked["docs/guides"])
+}
+
+// TestDirectoryTitleFallsBackToTheName: saying nothing leaves the directory
+// named after itself.
+func TestDirectoryTitleFallsBackToTheName(t *testing.T) {
+	titles := NewDirectoryTitles(func(string) (string, error) { return "", nil })
+
+	title, err := titles.Title("docs/getting-started")
+	assert.NoError(t, err)
+	assert.Equal(t, "Getting Started", title)
+}
+
+// TestDirectoryTitleUsedForParentsAndForTheIndex is the agreement that matters:
+// the name a directory's own document publishes under, and the name its
+// children look for, are the same string.
+func TestDirectoryTitleUsedForParentsAndForTheIndex(t *testing.T) {
+	titles := NewDirectoryTitles(func(directory string) (string, error) {
+		if directory == "docs/guides" {
+			return "Developer Handbook", nil
+		}
+
+		return "", nil
+	})
+
+	parents, _, err := PathHierarchy("docs", "docs/guides/setup.md", titles)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"Developer Handbook"}, parents)
+
+	_, own, err := PathHierarchy("docs", "docs/guides/README.md", titles)
+	assert.NoError(t, err)
+	assert.Equal(t, "Developer Handbook", own)
 }

--- a/util/cli.go
+++ b/util/cli.go
@@ -109,6 +109,8 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 		TitleFromH1:              cmd.Bool("title-from-h1"),
 		TitleFromFilename:        cmd.Bool("title-from-filename"),
 		TitleAppendGeneratedHash: cmd.Bool("title-append-generated-hash"),
+		ParentsFromPath:          cmd.Bool("parents-from-path"),
+		ParentsFromPathRoot:      cmd.String("parents-from-path-root"),
 		ContentAppearance:        cmd.String("content-appearance"),
 
 		MinorEdit:          cmd.Bool("minor-edit"),

--- a/util/flags.go
+++ b/util/flags.go
@@ -77,6 +77,18 @@ var Flags = []cli.Flag{
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_FROM_FILENAME"), altsrctoml.TOML("title-from-filename", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.BoolFlag{
+		Name:    "parents-from-path",
+		Value:   false,
+		Usage:   "place each page under a page named after every directory between the file pattern's root and the file itself. An index.md or README.md is the page for its own directory rather than a page inside it. A document that names its own Parent is left alone.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PARENTS_FROM_PATH"), altsrctoml.TOML("parents-from-path", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:    "parents-from-path-root",
+		Value:   "",
+		Usage:   "the directory --parents-from-path measures from. Taken from the --files pattern when not given, which is everything before its first wildcard.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PARENTS_FROM_PATH_ROOT"), altsrctoml.TOML("parents-from-path-root", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
 		Name:    "title-append-generated-hash",
 		Value:   false,
 		Usage:   "appends a short hash generated from the path of the page (space, parents, and title) to the title",


### PR DESCRIPTION
Phase 1 of the directory-hierarchy plan. `--parents-from-path` makes a repository's shape into the page tree, without a `Parent` header on every document.

```bash
mark --parents-from-path --files "docs/**/*.md"
```

```text
docs/guides/setup.md        ->  Guides > Setup
docs/guides/deep/tuning.md  ->  Guides > Deep > Tuning
```

- Directory names are titled the way filenames already are, so `getting-started` becomes "Getting Started" — reusing the existing helper rather than a second convention.
- **`index.md` / `README.md` *is* its directory's page**, not a page inside it, and takes the directory's name as its title. A directory's own document is what people expect to land on.
- The root is everything in `--files` before the first wildcard; `--parents-from-path-root` overrides it.
- `--parents` still prefixes everything.

## What a document says about itself wins

A `Parent` header is left alone, and so is a `Title`. That needed `Meta` to start recording **whether `Parents` and `Title` came from the document or from a command-line flag** — by the time they are assembled the two are indistinguishable, since `--parents` is prepended and `--title-from-filename` fills the title in.

Two new fields, `DeclaredParents` and `DeclaredTitle`, set where the headers and front matter are parsed. This avoided adding parameters to `ExtractMeta`, which has 28 call sites.

## The part that makes it safe to turn on

**I claimed in the plan that title collisions would fail loudly. That was wrong, and I checked.** Two `overview.md` files in different directories produced **one** page, under `Sdk`, holding the SDK content — the API page silently taken over and moved.

A space holds one page of a given title, so two documents wanting the same title want the same page. Deriving parents from the path makes that likely rather than unlucky: every directory tends to hold a README, and several will want an "Overview".

So a title is claimed **before anything is published**, and a second document wanting it fails before touching Confluence:

```text
docs/api/overview.md already publishes "Overview" in space "DOCS", and a space
holds one page of a title: rename one of them, or use --title-append-generated-hash
```

The first document keeps the page it already had, with its own content and parents — asserted, not assumed. `--title-append-generated-hash` already hashes parents+space+title, so it is the existing way to keep both titles.

The check is scoped to `--parents-from-path`, since making it general would start failing runs that work today.

## Verification

With derivation stubbed out, the four feature tests fail and the three guards pass — the guards being "a declared Parent wins", "a declared Title wins", and "without the flag nothing changes", all of which assert the feature *not* applying.

Twenty-three unit cases on the path arithmetic (roots, nesting, index files, files outside the root, a README at the root with no directory to be named after) plus nine end-to-end.

Six existing `metadata` expectations were updated for the two new fields; each declares the header it now records.

## Phase 2: directories are remembered

mark creates the page standing for a directory, so it now remembers doing so. When the last document under a directory goes, that page turns up as a page with no source file like any other, and `--on-orphan` decides what becomes of it.

**The ids come from the published page's own ancestors**, not from the code that creates them — a document's ancestors end with exactly the pages its path asked for, so this needed no change to how ancestry is built.

A directory holding its own `index.md`/`README.md` is deliberately left out: that document's entry has the page already, and two entries claiming one page is what the manifest complains about. Directory entries also carry a fingerprint of their own, so one can never be mistaken for a document published under a previous name.

A directory and its contents take **two runs** to disappear — the documents first, then the page that held them — because the existing refusal to remove a page with children applies here too. That is the desired behaviour and the test asserts it.

### The fake was wrong about trashed pages

Writing this turned up two things Confluence does that the fake did not: a trashed page is **not returned by a search**, and is **not among its parent's children**. Both now hold. That gap is what kept a directory whose only document had just been trashed looking as though it still had one — a fidelity bug that would have hidden real behaviour, not just this test.

## Not in this phase

`.pages`-style directory titles, collapsing single-page directories, and mapping directories to Confluence folders on Cloud.

**Adoption note, in the README**: turning this on moves every page not already where its path implies. `--dry-run` reports the moves first.