### PR TITLE
build(deps): bump mermaid.go to v0.3.0 and act on its failure classes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/chromedp/chromedp v0.16.0
 	github.com/d2lang/d2 v0.8.1
 	github.com/d2lang/util-go v0.2.0
-	github.com/dreampuf/mermaid.go v0.2.3
+	github.com/dreampuf/mermaid.go v0.3.0
 	github.com/kovetskiy/gopencils v0.0.0-20250404051442-0b776066936a
 	github.com/rs/zerolog v1.35.1
 	github.com/stefanfritsch/goldmark-admonitions v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yA
 github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dop251/goja v0.0.0-20240927123429-241b342198c2 h1:Ux9RXuPQmTB4C1MKagNLme0krvq8ulewfor+ORO/QL4=
 github.com/dop251/goja v0.0.0-20240927123429-241b342198c2/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
-github.com/dreampuf/mermaid.go v0.2.3 h1:CkSum5f5CsaMNP4UX2jMl4wZ0Z4N7G76kzWJM7wQS5U=
-github.com/dreampuf/mermaid.go v0.2.3/go.mod h1:I/re/aAkBgC6N+rl+fsOtxsZrihL2h2b0gH9wH5Ew1Q=
+github.com/dreampuf/mermaid.go v0.3.0 h1:y0W04Nlb1BPdyyWNlr+lDTm3PaOyh2b7huGbnzbf4zw=
+github.com/dreampuf/mermaid.go v0.3.0/go.mod h1:I/re/aAkBgC6N+rl+fsOtxsZrihL2h2b0gH9wH5Ew1Q=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 h1:KZaTBSyshWX3MP5jukJcNSuXDQTO+rNpt0J564dX/eg=

--- a/mermaid/mermaid.go
+++ b/mermaid/mermaid.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -21,6 +22,19 @@ var (
 	mermaidMutex  sync.Mutex
 )
 
+// renderTimeout bounds a single diagram: the wait for any render already
+// occupying the engine's one page, plus the render itself.
+//
+// It replaces mermaid.go's own DefaultRenderTimeout of 30 seconds, which is too
+// tight for the CPU-starved CI containers mark runs in -- the same contention
+// the chrome package raises WSURLReadTimeout for.
+var renderTimeout = 120 * time.Second
+
+// renderAttempts is how many times one diagram is rendered before giving up.
+// A crashed browser is the only failure worth retrying, and only because the
+// second attempt runs on a new one: see the crash case in renderPNG.
+const renderAttempts = 2
+
 func getMermaidEngine() (*mermaid.RenderEngine, error) {
 	mermaidMutex.Lock()
 	defer mermaidMutex.Unlock()
@@ -34,61 +48,107 @@ func getMermaidEngine() (*mermaid.RenderEngine, error) {
 	// only the additional options are passed here. Without them Chrome fails to
 	// start wherever the sandbox is unavailable -- the same failure the d2
 	// renderer hits, since both drive Chrome through chromedp.
+	//
+	// The context governs the engine's whole lifetime rather than just its
+	// startup, so it deliberately carries no deadline: mermaid.go bounds loading
+	// the embedded bundle with DefaultStartupTimeout by itself, whereas a
+	// deadline here would close the browser mid-run.
 	engine, err := mermaid.NewRenderEngine(context.Background(), nil, chrome.AllocatorOptions()...)
 	if err != nil {
 		return nil, err
 	}
+
+	engine.SetRenderTimeout(renderTimeout)
+
+	// Without this a crash is only ever seen as whatever the in-flight render
+	// happened to fail with, and one that happens between diagrams is invisible
+	// until the next diagram fails. The handler runs on chromedp's event
+	// goroutine, so it may only log: calling back into the engine from there
+	// deadlocks.
+	engine.SetTargetCrashedHandler(func(err error) {
+		log.Error().Err(err).Msg("Chrome crashed while rendering Mermaid diagrams")
+	})
+
 	mermaidEngine = engine
 	return mermaidEngine, nil
 }
 
-var renderTimeout = 120 * time.Second
-
-func resetEngine() {
+// discardEngine drops engine from the global slot and closes it, so that the
+// next diagram launches a new browser. It is a no-op when the slot has already
+// moved on, so that a second diagram failing against the same dead engine
+// cannot tear down the replacement the first one built.
+func discardEngine(engine *mermaid.RenderEngine) {
 	mermaidMutex.Lock()
-	defer mermaidMutex.Unlock()
-
-	if mermaidEngine != nil {
-		mermaidEngine.Cancel()
+	if mermaidEngine == engine {
 		mermaidEngine = nil
+	}
+	mermaidMutex.Unlock()
+
+	engine.Cancel()
+}
+
+// renderPNG renders one diagram, deciding from mermaid.go's sentinel errors
+// whether the engine survived the failure and whether another attempt is worth
+// making.
+func renderPNG(title, diagram string, scale float64) ([]byte, *mermaid.BoxModel, error) {
+	for attempt := 1; ; attempt++ {
+		engine, err := getMermaidEngine()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// The context bounds the wait for a turn on the engine's page as well as
+		// the render, which the engine's own timeout does not: that clock only
+		// starts once the render begins.
+		ctx, cancel := context.WithTimeout(context.Background(), renderTimeout)
+		pngBytes, boxModel, err := engine.RenderAsScaledPngContext(ctx, diagram, scale)
+		cancel()
+
+		switch {
+		case err == nil:
+			return pngBytes, boxModel, nil
+
+		case errors.Is(err, mermaid.ErrTargetCrashed), errors.Is(err, mermaid.ErrEngineClosed):
+			// Every later render on this engine fails the same way, so it is
+			// closed here and the next attempt gets a fresh browser. This is the
+			// one failure a retry can fix.
+			discardEngine(engine)
+			if attempt < renderAttempts {
+				log.Warn().Err(err).Msgf("Mermaid render engine died on %q, retrying with a new browser", title)
+				continue
+			}
+			return nil, nil, err
+
+		case errors.Is(err, mermaid.ErrRenderException):
+			// The diagram is what failed, so the engine is still good and a
+			// retry would fail identically. mermaid.go keeps chrome's
+			// *runtime.ExceptionDetails in the chain, so the message already
+			// names the mermaid parse error.
+			return nil, nil, fmt.Errorf("invalid mermaid diagram: %w", err)
+
+		case errors.Is(err, context.DeadlineExceeded):
+			// Cancelling a render only aborts its in-flight commands, so the
+			// engine stays usable and is kept for the next diagram. Retrying is
+			// not worth another renderTimeout on a diagram that has already
+			// shown it does not settle.
+			return nil, nil, fmt.Errorf("mermaid rendering timed out after %v: %w", renderTimeout, err)
+
+		default:
+			// An unclassified failure says nothing about whether the browser
+			// survived it, so it is discarded: starting the next diagram over is
+			// cheap next to producing a page with a diagram missing from it.
+			discardEngine(engine)
+			return nil, nil, err
+		}
 	}
 }
 
 func ProcessMermaidLocally(title string, mermaidDiagram []byte, scale float64) (attachment.Attachment, error) {
-	renderer, err := getMermaidEngine()
-	if err != nil {
-		return attachment.Attachment{}, err
-	}
-
 	log.Debug().Msgf("Rendering: %q", title)
 
-	type renderResult struct {
-		pngBytes []byte
-		boxModel *mermaid.BoxModel
-		err      error
-	}
-
-	ch := make(chan renderResult, 1)
-	go func() {
-		pngBytes, boxModel, err := renderer.RenderAsScaledPng(string(mermaidDiagram), scale)
-		ch <- renderResult{pngBytes, boxModel, err}
-	}()
-
-	var pngBytes []byte
-	var boxModel *mermaid.BoxModel
-
-	select {
-	case res := <-ch:
-		if res.err != nil {
-			resetEngine()
-			return attachment.Attachment{}, res.err
-		}
-		pngBytes = res.pngBytes
-		boxModel = res.boxModel
-	case <-time.After(renderTimeout):
-		log.Error().Msgf("Mermaid rendering timed out after %v, resetting engine", renderTimeout)
-		resetEngine()
-		return attachment.Attachment{}, fmt.Errorf("mermaid rendering timed out after %v", renderTimeout)
+	pngBytes, boxModel, err := renderPNG(title, string(mermaidDiagram), scale)
+	if err != nil {
+		return attachment.Attachment{}, err
 	}
 
 	scaleAsBytes := make([]byte, 8)

--- a/mermaid/mermaid_test.go
+++ b/mermaid/mermaid_test.go
@@ -1,12 +1,16 @@
 package mermaid
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
+	"time"
 
+	mermaid "github.com/dreampuf/mermaid.go"
 	"github.com/kovetskiy/mark/v16/attachment"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractMermaidImage(t *testing.T) {
@@ -50,4 +54,53 @@ func TestExtractMermaidImage(t *testing.T) {
 			assert.Greater(t, gotHeight, int64(0), "processMermaidLocally(%v, %v)", tt.name, string(tt.markdown))
 		})
 	}
+}
+
+// A diagram mermaid.js refuses is reported as ErrRenderException, which says the
+// page raised an exception rather than that the browser died. The engine is
+// therefore kept: before mermaid.go classified its failures, every bad diagram
+// in a run tore Chrome down and made the next one pay a relaunch.
+func TestInvalidDiagramKeepsEngine(t *testing.T) {
+	before, err := getMermaidEngine()
+	require.NoError(t, err)
+
+	_, err = ProcessMermaidLocally("invalid", []byte("this is not a mermaid diagram"), 1.0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, mermaid.ErrRenderException)
+
+	after, err := getMermaidEngine()
+	require.NoError(t, err)
+	assert.Same(t, before, after)
+}
+
+// A render that outruns renderTimeout also leaves the engine usable, because
+// cancelling it aborts only the commands in flight. Both timeouts are shortened
+// here: the context one bounds the wait for a turn on the page, the engine one
+// bounds the render itself.
+func TestRenderTimeoutKeepsEngine(t *testing.T) {
+	before, err := getMermaidEngine()
+	require.NoError(t, err)
+
+	original := renderTimeout
+	t.Cleanup(func() {
+		renderTimeout = original
+		before.SetRenderTimeout(original)
+	})
+	renderTimeout = time.Nanosecond
+	before.SetRenderTimeout(time.Nanosecond)
+
+	_, err = ProcessMermaidLocally("timeout", []byte("graph TD;\n A-->B;"), 1.0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+
+	renderTimeout = original
+	before.SetRenderTimeout(original)
+
+	after, err := getMermaidEngine()
+	require.NoError(t, err)
+	assert.Same(t, before, after)
+
+	got, err := ProcessMermaidLocally("after-timeout", []byte("graph TD;\n A-->B;"), 1.0)
+	require.NoError(t, err)
+	assert.NotEmpty(t, got.FileBytes)
 }


### PR DESCRIPTION
Bumps `github.com/dreampuf/mermaid.go` to v0.3.0 and uses what it adds: sentinel errors for the failure classes, a real per-render deadline, context-aware render methods, and a crash callback.

mark had approximated the timeout with a goroutine and a `select`, and treated every failure identically — tear the browser down and let the next diagram start over.

## Timeouts

`RenderAsScaledPng` + goroutine/`time.After` becomes `RenderAsScaledPngContext` under a 120s context, with `SetRenderTimeout(renderTimeout)` so the library's 30s `DefaultRenderTimeout` doesn't cut a render short first. Two things the old wrapper couldn't do:

- an abandoned render is actually cancelled, instead of being left running behind a returned error;
- the deadline covers the wait for a turn on the engine's single page, which the engine's own clock does not — it only starts once a render begins.

## Errors and crashes

Failures now branch on the sentinels:

| failure | response |
| --- | --- |
| `ErrTargetCrashed` / `ErrEngineClosed` | discard the engine, retry once on a new browser |
| `ErrRenderException` | keep the engine, fail as `invalid mermaid diagram: …` — chrome's `ExceptionDetails` stays in the chain, so the message names the mermaid parse error |
| `context.DeadlineExceeded` | keep the engine (cancelling a render aborts only the commands in flight), no retry |
| anything else | discard the engine, as before |

So an invalid diagram no longer costs a browser relaunch for every diagram after it, and a crash is the one case that gets a second attempt.

`SetTargetCrashedHandler` logs `Inspector.targetCrashed` and unexpected detaches, so a browser that dies between diagrams is reported as a crash rather than surfacing later as an unexplained timeout. It only logs — it runs on chromedp's event goroutine and must not re-enter the engine.

`resetEngine` becomes `discardEngine(engine)`, which clears the global slot only if it still holds the engine that failed, so a second diagram failing against the same dead engine cannot close the replacement the first one built.

## Note

The engine context stays `context.Background()`: it governs the engine's whole lifetime, not just startup, so a deadline there would close the browser mid-run. Startup is therefore bounded by the library's `DefaultStartupTimeout` (60s), which isn't adjustable without capping the engine's lifetime. mark's own `WSURLReadTimeout(60s)` from `chrome.AllocatorOptions()` still applies on top.

## Tests

Two new tests in `mermaid/mermaid_test.go`: an invalid diagram yields `ErrRenderException` and leaves the engine instance intact; a shortened timeout yields `context.DeadlineExceeded`, keeps the same engine, and the engine still renders afterwards.

`go test ./... -count=1` passes, `mermaid` also under `-race`; `golangci-lint run ./mermaid/...` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)