### PR TITLE
feat(util): add --password-command to resolve the token at run time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1591,7 +1591,7 @@ GLOBAL OPTIONS:
    --log-level string                       set the log level. Possible values: TRACE, DEBUG, INFO, WARNING, ERROR, FATAL. (default: "info") [$MARK_LOG_LEVEL]
    --username string, -u string             use specified username for updating Confluence page. [$MARK_USERNAME]
    --password string, -p string             use specified token for updating Confluence page. Specify - as password to read password from stdin, or your Personal access token. Username is not mandatory if personal access token is provided. For more info please see: https://developer.atlassian.com/server/confluence/confluence-server-rest-api/#authentication. [$MARK_PASSWORD]
-   --password-command string                run the specified command and use its trimmed stdout as the token for updating Confluence page. Runs without a shell, and is ignored when a password is set. [$MARK_PASSWORD_COMMAND]
+   --password-command string                run the specified command and use the first line of its stdout as the token for updating Confluence page. Runs without a shell. A password set from the same or a stronger source (command line, then environment, then configuration file) takes precedence. [$MARK_PASSWORD_COMMAND]
    --target-url string, -l string           edit specified Confluence page. If -l is not specified, file should contain metadata (see above). [$MARK_TARGET_URL]
    --base-url string, -b string             base URL for Confluence. Alternative option for base_url config field. [$MARK_BASE_URL]
    --config string, -c string               use the specified configuration file. (default: "${HOME}/.config/mark.toml") [$MARK_CONFIG]
@@ -1648,8 +1648,20 @@ and name the script instead. The command also gets no standard input, so a
 helper that prompts on stdin cannot be used -- one that opens the terminal
 itself, as `pinentry` does, is fine.
 
-A compile resolves the command like any other run, so a helper that cannot
-produce a token fails the run rather than being skipped.
+Only the first line of what the command prints becomes the token, so a helper
+that prints a whole entry with the password on top -- `pass show` does -- needs
+no wrapper to trim it.
+
+Where both a `password` and a `password-command` are set, the one from the
+stronger source wins: the command line beats the environment, which beats the
+configuration file. Only when both come from the same place does the `password`
+win, and mark says so.
+
+A compile resolves the command like any other run, since a relative link is
+followed by looking that page up. A helper that cannot produce a token there is
+a warning and not an error, because `--compile-only` has to keep validating
+documents on a machine -- a CI image, typically -- that has no password manager
+on it.
 
 **NOTE**: Labels aren't supported when using `minor-edit`!
 

--- a/README.md
+++ b/README.md
@@ -1591,6 +1591,7 @@ GLOBAL OPTIONS:
    --log-level string                       set the log level. Possible values: TRACE, DEBUG, INFO, WARNING, ERROR, FATAL. (default: "info") [$MARK_LOG_LEVEL]
    --username string, -u string             use specified username for updating Confluence page. [$MARK_USERNAME]
    --password string, -p string             use specified token for updating Confluence page. Specify - as password to read password from stdin, or your Personal access token. Username is not mandatory if personal access token is provided. For more info please see: https://developer.atlassian.com/server/confluence/confluence-server-rest-api/#authentication. [$MARK_PASSWORD]
+   --password-command string                run the specified command and use its trimmed stdout as the token for updating Confluence page. Runs without a shell, and is ignored when a password is set. [$MARK_PASSWORD_COMMAND]
    --target-url string, -l string           edit specified Confluence page. If -l is not specified, file should contain metadata (see above). [$MARK_TARGET_URL]
    --base-url string, -b string             base URL for Confluence. Alternative option for base_url config field. [$MARK_BASE_URL]
    --config string, -c string               use the specified configuration file. (default: "${HOME}/.config/mark.toml") [$MARK_CONFIG]
@@ -1628,12 +1629,17 @@ located in a system specific directory (or specified via `-c --config <path>`) w
 ```toml
 username = "your-email"
 password = "password-or-api-key-for-confluence-cloud"
+# Or name a command that prints the token, instead of storing it here:
+# password-command = "pass show confluence/api-token"
 # If you are using Confluence Cloud add the /wiki suffix to base_url
 base-url = "http://confluence.local"
 title-from-h1 = true
 drop-h1 = true
 image-align = "center"
 ```
+
+**NOTE**: `password-command` keeps the token out of both the configuration file and the environment.
+A password manager or keychain helper supplies it per run.
 
 **NOTE**: Labels aren't supported when using `minor-edit`!
 

--- a/README.md
+++ b/README.md
@@ -1652,6 +1652,11 @@ Only the first line of what the command prints becomes the token, so a helper
 that prints a whole entry with the password on top -- `pass show` does -- needs
 no wrapper to trim it.
 
+The command has to fetch the secret rather than contain it. It is handed to the
+operating system as written, so anyone who can list processes can read it for as
+long as it runs -- which is the exposure `password-command` exists to avoid, and
+writing a token into the command itself puts it straight back.
+
 Where both a `password` and a `password-command` are set, the one set in the
 stronger layer wins: the command line beats the environment, which beats the
 configuration file. Only when both come from the same layer does the `password`

--- a/README.md
+++ b/README.md
@@ -1591,7 +1591,7 @@ GLOBAL OPTIONS:
    --log-level string                       set the log level. Possible values: TRACE, DEBUG, INFO, WARNING, ERROR, FATAL. (default: "info") [$MARK_LOG_LEVEL]
    --username string, -u string             use specified username for updating Confluence page. [$MARK_USERNAME]
    --password string, -p string             use specified token for updating Confluence page. Specify - as password to read password from stdin, or your Personal access token. Username is not mandatory if personal access token is provided. For more info please see: https://developer.atlassian.com/server/confluence/confluence-server-rest-api/#authentication. [$MARK_PASSWORD]
-   --password-command string                run the specified command and use the first line of its stdout as the token for updating Confluence page. Runs without a shell. A password set on the command line, in the environment or in the configuration file takes precedence over one set further down that list. [$MARK_PASSWORD_COMMAND]
+   --password-command string                run the specified command and use the first line of its stdout as the token for updating Confluence page. Runs without a shell. Mutually exclusive with password. [$MARK_PASSWORD_COMMAND]
    --target-url string, -l string           edit specified Confluence page. If -l is not specified, file should contain metadata (see above). [$MARK_TARGET_URL]
    --base-url string, -b string             base URL for Confluence. Alternative option for base_url config field. [$MARK_BASE_URL]
    --config string, -c string               use the specified configuration file. (default: "${HOME}/.config/mark.toml") [$MARK_CONFIG]
@@ -1657,10 +1657,11 @@ operating system as written, so anyone who can list processes can read it for as
 long as it runs -- which is the exposure `password-command` exists to avoid, and
 writing a token into the command itself puts it straight back.
 
-Where both a `password` and a `password-command` are set, the one set in the
-stronger layer wins: the command line beats the environment, which beats the
-configuration file. Only when both come from the same layer does the `password`
-win, and mark says so.
+`password` and `password-command` are mutually exclusive, and setting both --
+in any combination of flag, environment variable and configuration file -- is an
+error rather than a choice mark makes for you. Moving to a command therefore
+means taking the `password` out of the configuration file, not leaving it there
+beside the new setting.
 
 A compile resolves the command like any other run, since a relative link is
 followed by looking that page up. A helper that cannot produce a token there is

--- a/README.md
+++ b/README.md
@@ -1641,6 +1641,13 @@ image-align = "center"
 **NOTE**: `password-command` keeps the token out of both the configuration file and the environment.
 A password manager or keychain helper supplies it per run.
 
+The command runs without a shell, so the string is split on whitespace and
+nothing is expanded: there is no quoting, and a program path or argument
+containing a space cannot be written here. Wrap such a helper in a small script
+and name the script instead. The command also gets no standard input, so a
+helper that prompts on stdin cannot be used -- one that opens the terminal
+itself, as `pinentry` does, is fine.
+
 **NOTE**: Labels aren't supported when using `minor-edit`!
 
 **NOTE**: See [Preserving Inline Comments](#preserving-inline-comments) for a detailed description of the `--preserve-comments` flag.

--- a/README.md
+++ b/README.md
@@ -1648,6 +1648,9 @@ and name the script instead. The command also gets no standard input, so a
 helper that prompts on stdin cannot be used -- one that opens the terminal
 itself, as `pinentry` does, is fine.
 
+A compile resolves the command like any other run, so a helper that cannot
+produce a token fails the run rather than being skipped.
+
 **NOTE**: Labels aren't supported when using `minor-edit`!
 
 **NOTE**: See [Preserving Inline Comments](#preserving-inline-comments) for a detailed description of the `--preserve-comments` flag.

--- a/README.md
+++ b/README.md
@@ -1591,7 +1591,7 @@ GLOBAL OPTIONS:
    --log-level string                       set the log level. Possible values: TRACE, DEBUG, INFO, WARNING, ERROR, FATAL. (default: "info") [$MARK_LOG_LEVEL]
    --username string, -u string             use specified username for updating Confluence page. [$MARK_USERNAME]
    --password string, -p string             use specified token for updating Confluence page. Specify - as password to read password from stdin, or your Personal access token. Username is not mandatory if personal access token is provided. For more info please see: https://developer.atlassian.com/server/confluence/confluence-server-rest-api/#authentication. [$MARK_PASSWORD]
-   --password-command string                run the specified command and use the first line of its stdout as the token for updating Confluence page. Runs without a shell. A password set from the same or a stronger source (command line, then environment, then configuration file) takes precedence. [$MARK_PASSWORD_COMMAND]
+   --password-command string                run the specified command and use the first line of its stdout as the token for updating Confluence page. Runs without a shell. A password set on the command line, in the environment or in the configuration file takes precedence over one set further down that list. [$MARK_PASSWORD_COMMAND]
    --target-url string, -l string           edit specified Confluence page. If -l is not specified, file should contain metadata (see above). [$MARK_TARGET_URL]
    --base-url string, -b string             base URL for Confluence. Alternative option for base_url config field. [$MARK_BASE_URL]
    --config string, -c string               use the specified configuration file. (default: "${HOME}/.config/mark.toml") [$MARK_CONFIG]
@@ -1652,9 +1652,9 @@ Only the first line of what the command prints becomes the token, so a helper
 that prints a whole entry with the password on top -- `pass show` does -- needs
 no wrapper to trim it.
 
-Where both a `password` and a `password-command` are set, the one from the
-stronger source wins: the command line beats the environment, which beats the
-configuration file. Only when both come from the same place does the `password`
+Where both a `password` and a `password-command` are set, the one set in the
+stronger layer wins: the command line beats the environment, which beats the
+configuration file. Only when both come from the same layer does the `password`
 win, and mark says so.
 
 A compile resolves the command like any other run, since a relative link is

--- a/util/auth.go
+++ b/util/auth.go
@@ -42,6 +42,21 @@ func GetCredentials(
 	compileOnly bool,
 
 ) (*Credentials, error) {
+	// Two answers to one question, and no way to tell which is meant: a
+	// password left in the configuration file from before the command was set
+	// up looks exactly like one somebody wants used. Either resolves through
+	// its own chain -- command line, then environment, then configuration file
+	// -- so preferring one of them by value cannot tell a token typed just now
+	// from one that has sat in a file for a year, and preferring one by layer
+	// only moves the guess. Say so instead, the way mark says it about every
+	// other pair of settings that contradict each other.
+	if password != "" && passwordCommand != "" {
+		return nil, errors.New(
+			"password and password-command are mutually exclusive. Please specify only one, " +
+				"whether by flag, environment variable or configuration file",
+		)
+	}
+
 	// Ahead of everything to do with the password. A run that cannot go
 	// anywhere for want of a base URL has no business asking a keyring for a
 	// token it will never send: putting somebody through a pinentry dialog and
@@ -83,16 +98,7 @@ func GetCredentials(
 		password = strings.TrimSpace(string(stdin))
 	}
 
-	// Both still carrying a value means they came from the same layer, since
-	// passwordPrecedence has already dropped the weaker of two layers. Warn
-	// rather than settle it in silence: a password left beside a command is
-	// usually the older of the two.
-	if password != "" && passwordCommand != "" {
-		log.Warn().Msg("both password and password-command are set; using password and ignoring password-command")
-	}
-
 	// Ahead of the empty-password check below, otherwise supplying only a command errors out before the command ever runs.
-	// Behind the "-" branch above, so that whatever the command prints is the token itself and cannot be taken for the flag that says to read one from standard input.
 	//
 	// A compile-only run is not exempt. It looks like one that never
 	// authenticates, and it is not: a relative link to another document is
@@ -225,110 +231,4 @@ func firstLine(out string) string {
 	line, _, _ := strings.Cut(strings.TrimSpace(out), "\n")
 
 	return strings.TrimSpace(line)
-}
-
-// passwordPrecedence returns the password and the password command a run should
-// go on with, decided by where each of them was set.
-//
-// Each of the two resolves through its own chain -- command line, then
-// environment, then configuration file -- so a rule stated over the two
-// resolved values alone cannot tell a token typed on the command line from one
-// that has been sitting in the configuration file for a year. Preferring the
-// password whenever it is non-empty therefore made --password-command the one
-// flag in mark that the configuration file overrides, and left editing that
-// file the only way to use it. The setting from the stronger layer wins
-// instead. A tie -- both from the same layer -- is left to GetCredentials,
-// which keeps the password.
-//
-// args is the command line mark was run with, os.Args in a real run.
-func passwordPrecedence(password string, passwordCommand string, args []string) (string, string) {
-	if password == "" || passwordCommand == "" {
-		return password, passwordCommand
-	}
-
-	byPassword := layerOf(args, "MARK_PASSWORD", "password", "p")
-	byCommand := layerOf(args, "MARK_PASSWORD_COMMAND", "password-command")
-
-	switch {
-	case byCommand > byPassword:
-		log.Warn().Msgf(
-			"both password and password-command are set; using password-command from %s and ignoring password from %s",
-			byCommand, byPassword,
-		)
-
-		return "", passwordCommand
-
-	case byPassword > byCommand:
-		log.Warn().Msgf(
-			"both password and password-command are set; using password from %s and ignoring password-command from %s",
-			byPassword, byCommand,
-		)
-
-		return password, ""
-	}
-
-	return password, passwordCommand
-}
-
-// layer is where a setting was given, ordered the way every flag in mark is
-// resolved: the command line beats the environment, which beats the
-// configuration file. urfave applies that order to each flag on its own and
-// keeps no record of which layer answered, so a rule spanning two flags has to
-// work it out again.
-type layer int
-
-const (
-	fromConfigFile layer = iota
-	fromEnvironment
-	fromCommandLine
-)
-
-func (l layer) String() string {
-	switch l {
-	case fromCommandLine:
-		return "the command line"
-
-	case fromEnvironment:
-		return "the environment"
-
-	default:
-		return "the configuration file"
-	}
-}
-
-// layerOf reports where a setting that has a value was given. A value named
-// nowhere on the command line and absent from the environment can only have
-// come from the configuration file, which is the last place urfave looks.
-func layerOf(args []string, env string, names ...string) layer {
-	switch {
-	case namedIn(args, names):
-		return fromCommandLine
-
-	case os.Getenv(env) != "":
-		return fromEnvironment
-
-	default:
-		return fromConfigFile
-	}
-}
-
-// namedIn reports whether any of names appears in args as a flag, in the forms
-// urfave accepts: one dash or two, with the value either attached or following.
-func namedIn(args []string, names []string) bool {
-	for _, arg := range args {
-		// Nothing past this is a flag, whatever it looks like.
-		if arg == "--" {
-			return false
-		}
-
-		for _, name := range names {
-			for _, dashed := range []string{"-" + name, "--" + name} {
-				if arg == dashed || strings.HasPrefix(arg, dashed+"=") {
-					return true
-				}
-			}
-		}
-	}
-
-	return false
 }

--- a/util/auth.go
+++ b/util/auth.go
@@ -1,13 +1,22 @@
 package util
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
+	"os/exec"
 	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
 )
+
+// passwordCommandTimeout bounds how long a password command may run.
+// A helper that prompts for input or hangs on a locked keyring then fails the run instead of stalling it.
+const passwordCommandTimeout = 30 * time.Second
 
 type Credentials struct {
 	Username string
@@ -17,8 +26,10 @@ type Credentials struct {
 }
 
 func GetCredentials(
+	ctx context.Context,
 	username string,
 	password string,
+	passwordCommand string,
 	targetURL string,
 	baseURL string,
 	compileOnly bool,
@@ -39,6 +50,21 @@ func GetCredentials(
 		}
 
 		password = strings.TrimSpace(string(stdin))
+	}
+
+	// Either can arrive from the flag, the environment or the config file, so a password left in one layer would otherwise shadow the command in silence.
+	if password != "" && passwordCommand != "" {
+		log.Warn().Msg("both password and password-command are set; using password and ignoring password-command")
+	}
+
+	// Ahead of the empty-password check below, otherwise supplying only a command errors out before the command ever runs.
+	// Behind the "-" branch above, so that whatever the command prints is the token itself and cannot be taken for the flag that says to read one from standard input.
+	// A compile-only run never authenticates, so running the command there would prompt for a passphrase or wait on a hardware key to produce a token nothing uses.
+	if password == "" && passwordCommand != "" && !compileOnly {
+		password, err = runPasswordCommand(ctx, passwordCommand)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read password from command: %w", err)
+		}
 	}
 
 	if password == "" {
@@ -83,4 +109,38 @@ func GetCredentials(
 	}
 
 	return creds, nil
+}
+
+// runPasswordCommand runs command and returns its trimmed stdout.
+// No shell is involved, so the string undergoes no expansion and quoted arguments are not honoured.
+func runPasswordCommand(ctx context.Context, command string) (string, error) {
+	argv := strings.Fields(command)
+	if len(argv) == 0 {
+		return "", errors.New("command is empty")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, passwordCommandTimeout)
+	defer cancel()
+
+	// Running this through a shell would let a config value expand into a command nobody wrote.
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...) //nolint:gosec // G204: operator-supplied command
+
+	// Output() captures stdout only, and its ExitError does not reliably carry stderr.
+	// Without this the helper's own diagnostics are lost.
+	cmd.Stderr = os.Stderr
+
+	out, err := cmd.Output()
+	if ctx.Err() != nil {
+		return "", fmt.Errorf("command did not complete: %w", ctx.Err())
+	}
+	if err != nil {
+		return "", fmt.Errorf("command failed: %w", err)
+	}
+
+	password := strings.TrimSpace(string(out))
+	if password == "" {
+		return "", errors.New("command produced no output")
+	}
+
+	return password, nil
 }

--- a/util/auth.go
+++ b/util/auth.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
-	"github.com/urfave/cli/v3"
 )
 
 // passwordCommandTimeout bounds how long a password command may run.
@@ -147,7 +146,7 @@ func GetCredentials(
 	return creds, nil
 }
 
-// runPasswordCommand runs command and returns its trimmed stdout.
+// runPasswordCommand runs command and returns the first line of what it printed.
 // No shell is involved, so the string undergoes no expansion and quoted arguments are not honoured.
 func runPasswordCommand(ctx context.Context, command string) (string, error) {
 	argv := strings.Fields(command)
@@ -223,7 +222,7 @@ func firstLine(out string) string {
 }
 
 // passwordPrecedence returns the password and the password command a run should
-// go on with, decided by where each of them came from.
+// go on with, decided by where each of them was set.
 //
 // Each of the two resolves through its own chain -- command line, then
 // environment, then configuration file -- so a rule stated over the two
@@ -231,77 +230,99 @@ func firstLine(out string) string {
 // that has been sitting in the configuration file for a year. Preferring the
 // password whenever it is non-empty therefore made --password-command the one
 // flag in mark that the configuration file overrides, and left editing that
-// file the only way to use it. The value from the stronger source wins instead.
-// A tie -- both from the same source -- is left to GetCredentials, which keeps
-// the password.
-func passwordPrecedence(cmd *cli.Command) (string, string) {
-	password := cmd.String("password")
-	command := cmd.String("password-command")
-
-	if password == "" || command == "" {
-		return password, command
+// file the only way to use it. The setting from the stronger layer wins
+// instead. A tie -- both from the same layer -- is left to GetCredentials,
+// which keeps the password.
+//
+// args is the command line mark was run with, os.Args in a real run.
+func passwordPrecedence(password string, passwordCommand string, args []string) (string, string) {
+	if password == "" || passwordCommand == "" {
+		return password, passwordCommand
 	}
 
-	passwordRank, passwordSource := flagSource(cmd, "password")
-	commandRank, commandSource := flagSource(cmd, "password-command")
+	byPassword := layerOf(args, "MARK_PASSWORD", "password", "p")
+	byCommand := layerOf(args, "MARK_PASSWORD_COMMAND", "password-command")
 
 	switch {
-	case commandRank > passwordRank:
+	case byCommand > byPassword:
 		log.Warn().Msgf(
 			"both password and password-command are set; using password-command from %s and ignoring password from %s",
-			commandSource, passwordSource,
+			byCommand, byPassword,
 		)
 
-		return "", command
+		return "", passwordCommand
 
-	case passwordRank > commandRank:
+	case byPassword > byCommand:
 		log.Warn().Msgf(
 			"both password and password-command are set; using password from %s and ignoring password-command from %s",
-			passwordSource, commandSource,
+			byPassword, byCommand,
 		)
 
 		return password, ""
 	}
 
-	return password, command
+	return password, passwordCommand
 }
 
-// flagSource reports where a string flag took its value from, as a rank that
-// grows with precedence, and as a name for the message that says so.
-//
-// urfave keeps no record of which source answered, so this repeats the lookup:
-// the sources are consulted in order and only after the command line, so the
-// first one holding the value the flag ended up with is the one that named it,
-// and one holding a different value was overridden from the command line.
-func flagSource(cmd *cli.Command, name string) (int, string) {
-	if !cmd.IsSet(name) {
-		return 0, "nowhere"
+// layer is where a setting was given, ordered the way every flag in mark is
+// resolved: the command line beats the environment, which beats the
+// configuration file. urfave applies that order to each flag on its own and
+// keeps no record of which layer answered, so a rule spanning two flags has to
+// work it out again.
+type layer int
+
+const (
+	fromConfigFile layer = iota
+	fromEnvironment
+	fromCommandLine
+)
+
+func (l layer) String() string {
+	switch l {
+	case fromCommandLine:
+		return "the command line"
+
+	case fromEnvironment:
+		return "the environment"
+
+	default:
+		return "the configuration file"
 	}
+}
 
-	var chain []cli.ValueSource
+// layerOf reports where a setting that has a value was given. A value named
+// nowhere on the command line and absent from the environment can only have
+// come from the configuration file, which is the last place urfave looks.
+func layerOf(args []string, env string, names ...string) layer {
+	switch {
+	case namedIn(args, names):
+		return fromCommandLine
 
-	for _, flag := range cmd.Flags {
-		if str, ok := flag.(*cli.StringFlag); ok && str.Name == name {
-			chain = str.Sources.Chain
+	case os.Getenv(env) != "":
+		return fromEnvironment
 
-			break
+	default:
+		return fromConfigFile
+	}
+}
+
+// namedIn reports whether any of names appears in args as a flag, in the forms
+// urfave accepts: one dash or two, with the value either attached or following.
+func namedIn(args []string, names []string) bool {
+	for _, arg := range args {
+		// Nothing past this is a flag, whatever it looks like.
+		if arg == "--" {
+			return false
+		}
+
+		for _, name := range names {
+			for _, dashed := range []string{"-" + name, "--" + name} {
+				if arg == dashed || strings.HasPrefix(arg, dashed+"=") {
+					return true
+				}
+			}
 		}
 	}
 
-	value := cmd.String(name)
-
-	for i, source := range chain {
-		found, ok := source.Lookup()
-		if !ok {
-			continue
-		}
-
-		if found != value {
-			break
-		}
-
-		return len(chain) - i, source.String()
-	}
-
-	return len(chain) + 1, "the command line"
+	return false
 }

--- a/util/auth.go
+++ b/util/auth.go
@@ -42,7 +42,31 @@ func GetCredentials(
 	compileOnly bool,
 
 ) (*Credentials, error) {
-	var err error
+	// Ahead of everything to do with the password. A run that cannot go
+	// anywhere for want of a base URL has no business asking a keyring for a
+	// token it will never send: putting somebody through a pinentry dialog and
+	// then failing on the configuration is a strange order to do things in.
+	if compileOnly && targetURL == "" {
+		targetURL = "http://localhost"
+	}
+
+	url, err := url.Parse(targetURL)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse %q as url: %w", targetURL, err)
+	}
+
+	if url.Host == "" && baseURL == "" {
+		return nil, errors.New(
+			"confluence base URL should be specified using -l " +
+				"flag or be stored in configuration file",
+		)
+	}
+
+	if baseURL == "" {
+		baseURL = url.Scheme + "://" + url.Host
+	}
+
+	baseURL = strings.TrimRight(baseURL, `/`)
 
 	// Ahead of the empty check and not after it. "-p -" does not carry a token,
 	// it says where the token is, so whether one was given at all is only known
@@ -112,35 +136,11 @@ func GetCredentials(
 		password = "none"
 	}
 
-	if compileOnly && targetURL == "" {
-		targetURL = "http://localhost"
-	}
-
-	url, err := url.Parse(targetURL)
-	if err != nil {
-		return nil, fmt.Errorf("unable to parse %q as url: %w", targetURL, err)
-	}
-
-	if url.Host == "" && baseURL == "" {
-		return nil, errors.New(
-			"confluence base URL should be specified using -l " +
-				"flag or be stored in configuration file",
-		)
-	}
-
-	if baseURL == "" {
-		baseURL = url.Scheme + "://" + url.Host
-	}
-
-	baseURL = strings.TrimRight(baseURL, `/`)
-
-	pageID := url.Query().Get("pageId")
-
 	creds := &Credentials{
 		Username: username,
 		Password: password,
 		BaseURL:  baseURL,
-		PageID:   pageID,
+		PageID:   url.Query().Get("pageId"),
 	}
 
 	return creds, nil
@@ -175,6 +175,12 @@ func runPasswordCommand(ctx context.Context, command string) (string, error) {
 	out, err := cmd.Output()
 	password := firstLine(string(out))
 
+	// A newline is what makes that first line whole. Without one, what was read
+	// may be the front of a token whose tail never arrived, and a truncated
+	// credential authenticates no better than no credential at all -- while
+	// looking, from the 401 it comes back as, exactly like the wrong password.
+	whole := strings.Contains(string(out), "\n")
+
 	// The command's own outcome first. Output() returns once the pipe closes,
 	// which can be after the deadline even for a helper that printed its token
 	// and exited cleanly -- and reading ctx.Err() ahead of err threw that token
@@ -183,7 +189,7 @@ func runPasswordCommand(ctx context.Context, command string) (string, error) {
 	case err == nil:
 		// Nothing to explain.
 
-	case errors.Is(err, exec.ErrWaitDelay) && password != "":
+	case errors.Is(err, exec.ErrWaitDelay) && whole:
 		// The helper printed its token and exited; something it started still
 		// held the output pipe, so Wait gave up on the pipe rather than on the
 		// command. What the helper printed was read before any of that.

--- a/util/auth.go
+++ b/util/auth.go
@@ -18,6 +18,11 @@ import (
 // A helper that prompts for input or hangs on a locked keyring then fails the run instead of stalling it.
 const passwordCommandTimeout = 30 * time.Second
 
+// passwordCommandWaitDelay bounds the wait for the helper's output pipe once
+// the helper itself has been killed, so that a process it left behind cannot
+// hold the run open past the timeout.
+const passwordCommandWaitDelay = 2 * time.Second
+
 type Credentials struct {
 	Username string
 	Password string
@@ -59,8 +64,15 @@ func GetCredentials(
 
 	// Ahead of the empty-password check below, otherwise supplying only a command errors out before the command ever runs.
 	// Behind the "-" branch above, so that whatever the command prints is the token itself and cannot be taken for the flag that says to read one from standard input.
-	// A compile-only run never authenticates, so running the command there would prompt for a passphrase or wait on a hardware key to produce a token nothing uses.
-	if password == "" && passwordCommand != "" && !compileOnly {
+	//
+	// A compile-only run is not exempt. It looks like one that never
+	// authenticates, and it is not: a relative link to another document is
+	// resolved by looking that page up, so compiling one file that links to
+	// another makes two authenticated requests before it prints anything.
+	// Skipping the command there left the password at "none" and 401'd them --
+	// while the same configuration with password= set worked. --check-links
+	// confluence is the same shape.
+	if password == "" && passwordCommand != "" {
 		password, err = runPasswordCommand(ctx, passwordCommand)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read password from command: %w", err)
@@ -129,15 +141,42 @@ func runPasswordCommand(ctx context.Context, command string) (string, error) {
 	// Without this the helper's own diagnostics are lost.
 	cmd.Stderr = os.Stderr
 
+	// Cancelling kills the helper, and nothing else: Wait goes on reading the
+	// stdout pipe for as long as anything still holds it open, which for a
+	// helper that starts an agent -- gpg-agent, on demand, is the ordinary case
+	// -- is long after the helper itself is gone. Without a delay the deadline
+	// bounds the process and not the call, which is the opposite of what it is
+	// for.
+	cmd.WaitDelay = passwordCommandWaitDelay
+
 	out, err := cmd.Output()
-	if ctx.Err() != nil {
-		return "", fmt.Errorf("command did not complete: %w", ctx.Err())
-	}
-	if err != nil {
+	password := strings.TrimSpace(string(out))
+
+	// The command's own outcome first. Output() returns once the pipe closes,
+	// which can be after the deadline even for a helper that printed its token
+	// and exited cleanly -- and reading ctx.Err() ahead of err threw that token
+	// away and failed a run that had everything it needed.
+	switch {
+	case err == nil:
+		// Nothing to explain.
+
+	case errors.Is(err, exec.ErrWaitDelay) && password != "":
+		// The helper printed its token and exited; something it started still
+		// held the output pipe, so Wait gave up on the pipe rather than on the
+		// command. What the helper printed was read before any of that.
+		log.Debug().Msg(
+			"password command left a process holding its output; using the token it printed",
+		)
+
+	case ctx.Err() != nil:
+		return "", fmt.Errorf(
+			"command did not complete within %s: %w", passwordCommandTimeout, ctx.Err(),
+		)
+
+	default:
 		return "", fmt.Errorf("command failed: %w", err)
 	}
 
-	password := strings.TrimSpace(string(out))
 	if password == "" {
 		return "", errors.New("command produced no output")
 	}

--- a/util/auth.go
+++ b/util/auth.go
@@ -12,11 +12,14 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v3"
 )
 
 // passwordCommandTimeout bounds how long a password command may run.
-// A helper that prompts for input or hangs on a locked keyring then fails the run instead of stalling it.
-const passwordCommandTimeout = 30 * time.Second
+// A helper that hangs on a locked keyring fails the run instead of stalling it,
+// with room left for one that opens a terminal of its own -- pinentry against a
+// cold gpg-agent is the ordinary case -- and waits for a passphrase to be typed.
+const passwordCommandTimeout = 60 * time.Second
 
 // passwordCommandWaitDelay bounds the wait for the helper's output pipe once
 // the helper itself has been killed, so that a process it left behind cannot
@@ -57,7 +60,10 @@ func GetCredentials(
 		password = strings.TrimSpace(string(stdin))
 	}
 
-	// Either can arrive from the flag, the environment or the config file, so a password left in one layer would otherwise shadow the command in silence.
+	// Both still carrying a value means they came from the same layer, since
+	// passwordPrecedence has already dropped the weaker of two layers. Warn
+	// rather than settle it in silence: a password left beside a command is
+	// usually the older of the two.
 	if password != "" && passwordCommand != "" {
 		log.Warn().Msg("both password and password-command are set; using password and ignoring password-command")
 	}
@@ -71,10 +77,28 @@ func GetCredentials(
 	// another makes two authenticated requests before it prints anything.
 	// Skipping the command there left the password at "none" and 401'd them --
 	// while the same configuration with password= set worked. --check-links
-	// confluence is the same shape.
+	// confluence is the same shape. What a compile does not do is fail when the
+	// helper is unavailable; see below.
 	if password == "" && passwordCommand != "" {
 		password, err = runPasswordCommand(ctx, passwordCommand)
-		if err != nil {
+
+		switch {
+		case err == nil:
+			// What it printed is the password.
+
+		case compileOnly:
+			// Validating documents without Confluence credentials is the whole
+			// of what --compile-only is for, and a helper that is absent -- a
+			// CI image without the password manager, a configuration file
+			// shared with a workstation -- must not take that offline. The
+			// command is still resolved whenever it can be, which is what the
+			// links a compile follows need.
+			log.Warn().Msgf(
+				"unable to read password from command: %s; continuing without a token, as --compile-only is set",
+				err,
+			)
+
+		default:
 			return nil, fmt.Errorf("unable to read password from command: %w", err)
 		}
 	}
@@ -150,7 +174,7 @@ func runPasswordCommand(ctx context.Context, command string) (string, error) {
 	cmd.WaitDelay = passwordCommandWaitDelay
 
 	out, err := cmd.Output()
-	password := strings.TrimSpace(string(out))
+	password := firstLine(string(out))
 
 	// The command's own outcome first. Output() returns once the pipe closes,
 	// which can be after the deadline even for a helper that printed its token
@@ -182,4 +206,102 @@ func runPasswordCommand(ctx context.Context, command string) (string, error) {
 	}
 
 	return password, nil
+}
+
+// firstLine returns the first line of what a helper printed, trimmed.
+//
+// A password manager prints an entry, not a token: pass show, which the README
+// names, puts the password on the first line and metadata below it. Keeping the
+// rest would put a newline inside the Authorization header -- rejected by the
+// transport with an error naming nothing about the helper, or, once a username
+// makes it Basic auth, base64-encoded into a silent 401. The same applies to
+// anything a process the helper left behind appends to the pipe.
+func firstLine(out string) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(out), "\n")
+
+	return strings.TrimSpace(line)
+}
+
+// passwordPrecedence returns the password and the password command a run should
+// go on with, decided by where each of them came from.
+//
+// Each of the two resolves through its own chain -- command line, then
+// environment, then configuration file -- so a rule stated over the two
+// resolved values alone cannot tell a token typed on the command line from one
+// that has been sitting in the configuration file for a year. Preferring the
+// password whenever it is non-empty therefore made --password-command the one
+// flag in mark that the configuration file overrides, and left editing that
+// file the only way to use it. The value from the stronger source wins instead.
+// A tie -- both from the same source -- is left to GetCredentials, which keeps
+// the password.
+func passwordPrecedence(cmd *cli.Command) (string, string) {
+	password := cmd.String("password")
+	command := cmd.String("password-command")
+
+	if password == "" || command == "" {
+		return password, command
+	}
+
+	passwordRank, passwordSource := flagSource(cmd, "password")
+	commandRank, commandSource := flagSource(cmd, "password-command")
+
+	switch {
+	case commandRank > passwordRank:
+		log.Warn().Msgf(
+			"both password and password-command are set; using password-command from %s and ignoring password from %s",
+			commandSource, passwordSource,
+		)
+
+		return "", command
+
+	case passwordRank > commandRank:
+		log.Warn().Msgf(
+			"both password and password-command are set; using password from %s and ignoring password-command from %s",
+			passwordSource, commandSource,
+		)
+
+		return password, ""
+	}
+
+	return password, command
+}
+
+// flagSource reports where a string flag took its value from, as a rank that
+// grows with precedence, and as a name for the message that says so.
+//
+// urfave keeps no record of which source answered, so this repeats the lookup:
+// the sources are consulted in order and only after the command line, so the
+// first one holding the value the flag ended up with is the one that named it,
+// and one holding a different value was overridden from the command line.
+func flagSource(cmd *cli.Command, name string) (int, string) {
+	if !cmd.IsSet(name) {
+		return 0, "nowhere"
+	}
+
+	var chain []cli.ValueSource
+
+	for _, flag := range cmd.Flags {
+		if str, ok := flag.(*cli.StringFlag); ok && str.Name == name {
+			chain = str.Sources.Chain
+
+			break
+		}
+	}
+
+	value := cmd.String(name)
+
+	for i, source := range chain {
+		found, ok := source.Lookup()
+		if !ok {
+			continue
+		}
+
+		if found != value {
+			break
+		}
+
+		return len(chain) - i, source.String()
+	}
+
+	return len(chain) + 1, "the command line"
 }

--- a/util/auth_test.go
+++ b/util/auth_test.go
@@ -506,7 +506,7 @@ func TestPasswordCommandFlagReachesCredentials(t *testing.T) {
 	t.Cleanup(func() { log.Logger = restore })
 
 	cmd := &cli.Command{
-		Flags:  NewFlags(),
+		Flags:  Flags,
 		Before: CheckFlags,
 		Action: RunMark,
 	}
@@ -553,7 +553,7 @@ func TestPasswordCommandIsMaskedInTheConfigDump(t *testing.T) {
 	})
 
 	cmd := &cli.Command{
-		Flags:  NewFlags(),
+		Flags:  Flags,
 		Before: CheckFlags,
 		Action: RunMark,
 	}
@@ -578,118 +578,90 @@ func TestPasswordCommandIsMaskedInTheConfigDump(t *testing.T) {
 		"the command must not reach the log in full")
 }
 
-// withParsedFlags parses argv against a fresh copy of mark's real flag set,
-// with config written to a configuration file, and hands the parsed command to
-// inspect. Nothing of mark runs: the point is the values the flags resolved to
-// and the layers they came from.
-func withParsedFlags(t *testing.T, config string, argv []string, inspect func(*cli.Command)) {
-	t.Helper()
-
-	path := filepath.Join(t.TempDir(), "mark.toml")
-	require.NoError(t, os.WriteFile(path, []byte(config), 0o600))
-
-	cmd := &cli.Command{
-		Flags:  NewFlags(),
-		Before: CheckFlags,
-		Action: func(_ context.Context, cmd *cli.Command) error {
-			inspect(cmd)
-
-			return nil
-		},
-	}
-
-	require.NoError(t, cmd.Run(context.Background(),
-		append([]string{"mark", "--config", path}, argv...)))
-}
-
-// TestPasswordCommandOnTheCommandLineOverridesAConfiguredPassword covers the
-// reason precedence is decided by source and not by which value is non-empty.
+// TestPasswordPrecedence covers which of the two settings a run uses when both
+// carry a value.
 //
 // A password in the configuration file is the ordinary starting point -- it is
 // what the README has always shown -- so somebody trying --password-command for
-// the first time has one. Letting the file win would have made this the one
-// flag in mark that cannot be overridden from the command line, and editing
-// that file the only way to use it.
-func TestPasswordCommandOnTheCommandLineOverridesAConfiguredPassword(t *testing.T) {
-	command := helperCommand(t, "print", "from-command")
-	logged := captureLogs(t)
+// the first time has one. Deciding this over the two resolved values, as the
+// non-empty password did, cannot tell that password from one typed in the same
+// breath as the command, which made this the one flag in mark that the
+// configuration file overrides and left editing that file the only way to use
+// it.
+func TestPasswordPrecedence(t *testing.T) {
+	const (
+		password = "from-password"
+		command  = "from-command"
+	)
 
-	withParsedFlags(t, "password = \"from-config\"\n",
-		[]string{"--password-command", command},
-		func(cmd *cli.Command) {
-			password, passwordCommand := passwordPrecedence(cmd)
-			assert.Empty(t, password, "the configured password loses to the stronger source")
-			assert.Equal(t, command, passwordCommand)
+	tests := []struct {
+		name         string
+		args         []string
+		env          map[string]string
+		wantPassword string
+		wantCommand  string
+	}{
+		{
+			name:        "a command on the command line beats a configured password",
+			args:        []string{"mark", "--password-command", command},
+			wantCommand: command,
+		},
+		{
+			name:         "a password on the command line beats a configured command",
+			args:         []string{"mark", "-p", password},
+			wantPassword: password,
+		},
+		{
+			name:         "an attached value is the same flag",
+			args:         []string{"mark", "--password=" + password},
+			wantPassword: password,
+		},
+		{
+			name:        "the environment beats the configuration file",
+			env:         map[string]string{"MARK_PASSWORD_COMMAND": command},
+			wantCommand: command,
+		},
+		{
+			name:         "and loses to the command line",
+			args:         []string{"mark", "--password", password},
+			env:          map[string]string{"MARK_PASSWORD_COMMAND": command},
+			wantPassword: password,
+		},
+		{
+			// Nothing separates them, so the password stays what wins, and
+			// GetCredentials says as much.
+			name:         "two settings in one file are a tie",
+			wantPassword: password,
+			wantCommand:  command,
+		},
+		{
+			name:         "as are two on the command line",
+			args:         []string{"mark", "-p", password, "--password-command", command},
+			wantPassword: password,
+			wantCommand:  command,
+		},
+		{
+			// Which is what makes this worth getting right: a value that
+			// happens to read like a flag is not one.
+			name:         "nothing past a bare -- is a flag",
+			args:         []string{"mark", "--", "--password-command"},
+			wantPassword: password,
+			wantCommand:  command,
+		},
+	}
 
-			creds, err := GetCredentials(context.Background(), "user", password, passwordCommand,
-				"https://confluence.example.com", "", false)
-			require.NoError(t, err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for name, value := range test.env {
+				t.Setenv(name, value)
+			}
 
-			assert.Equal(t, "from-command", creds.Password)
+			gotPassword, gotCommand := passwordPrecedence(password, command, test.args)
+
+			assert.Equal(t, test.wantPassword, gotPassword)
+			assert.Equal(t, test.wantCommand, gotCommand)
 		})
-
-	assert.Contains(t, logged.String(), "ignoring password from")
-}
-
-// TestPasswordOnTheCommandLineOverridesAConfiguredPasswordCommand is the same
-// rule the other way around, and the helper must not even run.
-func TestPasswordOnTheCommandLineOverridesAConfiguredPasswordCommand(t *testing.T) {
-	command := helperCommand(t, "fail", "")
-	logged := captureLogs(t)
-
-	withParsedFlags(t, fmt.Sprintf("password-command = %q\n", command),
-		[]string{"--password", "from-flag"},
-		func(cmd *cli.Command) {
-			password, passwordCommand := passwordPrecedence(cmd)
-			assert.Equal(t, "from-flag", password)
-			assert.Empty(t, passwordCommand)
-
-			creds, err := GetCredentials(context.Background(), "user", password, passwordCommand,
-				"https://confluence.example.com", "", false)
-			require.NoError(t, err)
-
-			assert.Equal(t, "from-flag", creds.Password)
-		})
-
-	assert.Contains(t, logged.String(), "ignoring password-command from")
-}
-
-// TestPasswordBeatsTheCommandWithinOneLayer is the tie, which is the only case
-// the old value-level rule got right: two settings in the same configuration
-// file say nothing about which is meant, so the password stays the one that
-// wins, out loud.
-func TestPasswordBeatsTheCommandWithinOneLayer(t *testing.T) {
-	command := helperCommand(t, "print", "from-command")
-	logged := captureLogs(t)
-
-	config := fmt.Sprintf("password = \"from-config\"\npassword-command = %q\n", command)
-
-	withParsedFlags(t, config, nil, func(cmd *cli.Command) {
-		password, passwordCommand := passwordPrecedence(cmd)
-		assert.Equal(t, "from-config", password)
-		assert.Equal(t, command, passwordCommand, "the tie is left for GetCredentials to warn about")
-
-		creds, err := GetCredentials(context.Background(), "user", password, passwordCommand,
-			"https://confluence.example.com", "", false)
-		require.NoError(t, err)
-
-		assert.Equal(t, "from-config", creds.Password)
-	})
-
-	assert.Contains(t, logged.String(), "ignoring password-command")
-}
-
-// TestPasswordCommandInTheEnvironmentOverridesAConfiguredPassword covers the
-// middle layer, which no flag on the command line is involved in.
-func TestPasswordCommandInTheEnvironmentOverridesAConfiguredPassword(t *testing.T) {
-	command := helperCommand(t, "print", "from-command")
-	t.Setenv("MARK_PASSWORD_COMMAND", command)
-
-	withParsedFlags(t, "password = \"from-config\"\n", nil, func(cmd *cli.Command) {
-		password, passwordCommand := passwordPrecedence(cmd)
-		assert.Empty(t, password)
-		assert.Equal(t, command, passwordCommand)
-	})
+	}
 }
 
 // TestPasswordPrecedenceLeavesASingleSettingAlone is the common case: only one
@@ -697,11 +669,24 @@ func TestPasswordCommandInTheEnvironmentOverridesAConfiguredPassword(t *testing.
 func TestPasswordPrecedenceLeavesASingleSettingAlone(t *testing.T) {
 	logged := captureLogs(t)
 
-	withParsedFlags(t, "password = \"from-config\"\n", nil, func(cmd *cli.Command) {
-		password, passwordCommand := passwordPrecedence(cmd)
-		assert.Equal(t, "from-config", password)
-		assert.Empty(t, passwordCommand)
-	})
+	password, command := passwordPrecedence("from-password", "", []string{"mark"})
+	assert.Equal(t, "from-password", password)
+	assert.Empty(t, command)
+
+	password, command = passwordPrecedence("", "helper", []string{"mark"})
+	assert.Empty(t, password)
+	assert.Equal(t, "helper", command)
 
 	assert.NotContains(t, logged.String(), "ignoring")
+}
+
+// TestPasswordPrecedenceNamesWhatItDropped covers the warning, which is the
+// only sign a setting was passed over.
+func TestPasswordPrecedenceNamesWhatItDropped(t *testing.T) {
+	logged := captureLogs(t)
+
+	passwordPrecedence("from-password", "from-command", []string{"mark", "--password-command", "from-command"})
+
+	assert.Contains(t, logged.String(),
+		"using password-command from the command line and ignoring password from the configuration file")
 }

--- a/util/auth_test.go
+++ b/util/auth_test.go
@@ -251,6 +251,33 @@ func TestRunPasswordCommandTrimsSurroundingWhitespace(t *testing.T) {
 	assert.Equal(t, "s3cret", password)
 }
 
+// TestRunPasswordCommandTakesTheFirstLineOfAnEntry covers the password manager
+// that prints an entry rather than a token: pass show, which the README names,
+// puts the password on the first line and metadata below it.
+//
+// The whole of that would go into the Authorization header, which the transport
+// rejects over the embedded newline -- naming nothing about the helper -- or,
+// with a username set, base64-encodes into a silent 401.
+func TestRunPasswordCommandTakesTheFirstLineOfAnEntry(t *testing.T) {
+	command := helperCommand(t, "print", "tok3n\nlogin: someone\nurl: https://confluence.example.com")
+
+	password, err := runPasswordCommand(context.Background(), command)
+	require.NoError(t, err)
+
+	assert.Equal(t, "tok3n", password)
+}
+
+// TestRunPasswordCommandSkipsLeadingBlankLines is the same rule from the other
+// end: a helper that prints a blank line before its token still has one.
+func TestRunPasswordCommandSkipsLeadingBlankLines(t *testing.T) {
+	command := helperCommand(t, "print", "\n\n  tok3n  \nnoise")
+
+	password, err := runPasswordCommand(context.Background(), command)
+	require.NoError(t, err)
+
+	assert.Equal(t, "tok3n", password)
+}
+
 // TestRunPasswordCommandAcceptsAPaddedCommand covers padding around the command itself.
 // strings.Fields absorbs it and collapses runs, so the setting needs no trimming of its own.
 func TestRunPasswordCommandAcceptsAPaddedCommand(t *testing.T) {
@@ -412,13 +439,33 @@ func TestGetCredentialsCompileOnlyStillNeedsNoPassword(t *testing.T) {
 	assert.Equal(t, "none", creds.Password)
 }
 
-// TestGetCredentialsCompileOnlyFailsOnAFailingCommand is the other side of that boundary.
-// A compile authenticates, so a helper that cannot produce a token fails the run rather than being skipped.
-// Falling back to "none" would turn a broken helper into a 401 further along, naming the wrong cause.
-func TestGetCredentialsCompileOnlyFailsOnAFailingCommand(t *testing.T) {
+// TestGetCredentialsCompileOnlyWarnsAboutAFailingCommand is the other side of
+// that boundary.
+//
+// Validating documents without Confluence credentials is the whole of what
+// --compile-only is for, so a helper that cannot run -- the password manager is
+// not installed on the CI image, and the configuration file is shared with a
+// workstation where it is -- must not take that offline. It is loud rather than
+// fatal: the run goes on with the placeholder it would have had anyway.
+func TestGetCredentialsCompileOnlyWarnsAboutAFailingCommand(t *testing.T) {
+	command := helperCommand(t, "fail", "")
+	logged := captureLogs(t)
+
+	creds, err := GetCredentials(context.Background(), "user", "", command, "https://confluence.example.com", "", true)
+	require.NoError(t, err)
+
+	assert.Equal(t, "none", creds.Password)
+	assert.Contains(t, logged.String(), "unable to read password from command")
+	assert.Contains(t, logged.String(), "--compile-only")
+}
+
+// TestGetCredentialsFailsOnAFailingCommandWithoutCompileOnly pins the other
+// half: outside a compile the same helper is fatal, because falling back to
+// "none" would turn it into a 401 naming the wrong cause.
+func TestGetCredentialsFailsOnAFailingCommandWithoutCompileOnly(t *testing.T) {
 	command := helperCommand(t, "fail", "")
 
-	_, err := GetCredentials(context.Background(), "user", "", command, "https://confluence.example.com", "", true)
+	_, err := GetCredentials(context.Background(), "user", "", command, "https://confluence.example.com", "", false)
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), "command failed")
@@ -459,7 +506,7 @@ func TestPasswordCommandFlagReachesCredentials(t *testing.T) {
 	t.Cleanup(func() { log.Logger = restore })
 
 	cmd := &cli.Command{
-		Flags:  Flags,
+		Flags:  NewFlags(),
 		Before: CheckFlags,
 		Action: RunMark,
 	}
@@ -506,7 +553,7 @@ func TestPasswordCommandIsMaskedInTheConfigDump(t *testing.T) {
 	})
 
 	cmd := &cli.Command{
-		Flags:  Flags,
+		Flags:  NewFlags(),
 		Before: CheckFlags,
 		Action: RunMark,
 	}
@@ -529,4 +576,132 @@ func TestPasswordCommandIsMaskedInTheConfigDump(t *testing.T) {
 	assert.Contains(t, string(logged), "password-command: ******")
 	assert.NotContains(t, string(logged), command,
 		"the command must not reach the log in full")
+}
+
+// withParsedFlags parses argv against a fresh copy of mark's real flag set,
+// with config written to a configuration file, and hands the parsed command to
+// inspect. Nothing of mark runs: the point is the values the flags resolved to
+// and the layers they came from.
+func withParsedFlags(t *testing.T, config string, argv []string, inspect func(*cli.Command)) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "mark.toml")
+	require.NoError(t, os.WriteFile(path, []byte(config), 0o600))
+
+	cmd := &cli.Command{
+		Flags:  NewFlags(),
+		Before: CheckFlags,
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			inspect(cmd)
+
+			return nil
+		},
+	}
+
+	require.NoError(t, cmd.Run(context.Background(),
+		append([]string{"mark", "--config", path}, argv...)))
+}
+
+// TestPasswordCommandOnTheCommandLineOverridesAConfiguredPassword covers the
+// reason precedence is decided by source and not by which value is non-empty.
+//
+// A password in the configuration file is the ordinary starting point -- it is
+// what the README has always shown -- so somebody trying --password-command for
+// the first time has one. Letting the file win would have made this the one
+// flag in mark that cannot be overridden from the command line, and editing
+// that file the only way to use it.
+func TestPasswordCommandOnTheCommandLineOverridesAConfiguredPassword(t *testing.T) {
+	command := helperCommand(t, "print", "from-command")
+	logged := captureLogs(t)
+
+	withParsedFlags(t, "password = \"from-config\"\n",
+		[]string{"--password-command", command},
+		func(cmd *cli.Command) {
+			password, passwordCommand := passwordPrecedence(cmd)
+			assert.Empty(t, password, "the configured password loses to the stronger source")
+			assert.Equal(t, command, passwordCommand)
+
+			creds, err := GetCredentials(context.Background(), "user", password, passwordCommand,
+				"https://confluence.example.com", "", false)
+			require.NoError(t, err)
+
+			assert.Equal(t, "from-command", creds.Password)
+		})
+
+	assert.Contains(t, logged.String(), "ignoring password from")
+}
+
+// TestPasswordOnTheCommandLineOverridesAConfiguredPasswordCommand is the same
+// rule the other way around, and the helper must not even run.
+func TestPasswordOnTheCommandLineOverridesAConfiguredPasswordCommand(t *testing.T) {
+	command := helperCommand(t, "fail", "")
+	logged := captureLogs(t)
+
+	withParsedFlags(t, fmt.Sprintf("password-command = %q\n", command),
+		[]string{"--password", "from-flag"},
+		func(cmd *cli.Command) {
+			password, passwordCommand := passwordPrecedence(cmd)
+			assert.Equal(t, "from-flag", password)
+			assert.Empty(t, passwordCommand)
+
+			creds, err := GetCredentials(context.Background(), "user", password, passwordCommand,
+				"https://confluence.example.com", "", false)
+			require.NoError(t, err)
+
+			assert.Equal(t, "from-flag", creds.Password)
+		})
+
+	assert.Contains(t, logged.String(), "ignoring password-command from")
+}
+
+// TestPasswordBeatsTheCommandWithinOneLayer is the tie, which is the only case
+// the old value-level rule got right: two settings in the same configuration
+// file say nothing about which is meant, so the password stays the one that
+// wins, out loud.
+func TestPasswordBeatsTheCommandWithinOneLayer(t *testing.T) {
+	command := helperCommand(t, "print", "from-command")
+	logged := captureLogs(t)
+
+	config := fmt.Sprintf("password = \"from-config\"\npassword-command = %q\n", command)
+
+	withParsedFlags(t, config, nil, func(cmd *cli.Command) {
+		password, passwordCommand := passwordPrecedence(cmd)
+		assert.Equal(t, "from-config", password)
+		assert.Equal(t, command, passwordCommand, "the tie is left for GetCredentials to warn about")
+
+		creds, err := GetCredentials(context.Background(), "user", password, passwordCommand,
+			"https://confluence.example.com", "", false)
+		require.NoError(t, err)
+
+		assert.Equal(t, "from-config", creds.Password)
+	})
+
+	assert.Contains(t, logged.String(), "ignoring password-command")
+}
+
+// TestPasswordCommandInTheEnvironmentOverridesAConfiguredPassword covers the
+// middle layer, which no flag on the command line is involved in.
+func TestPasswordCommandInTheEnvironmentOverridesAConfiguredPassword(t *testing.T) {
+	command := helperCommand(t, "print", "from-command")
+	t.Setenv("MARK_PASSWORD_COMMAND", command)
+
+	withParsedFlags(t, "password = \"from-config\"\n", nil, func(cmd *cli.Command) {
+		password, passwordCommand := passwordPrecedence(cmd)
+		assert.Empty(t, password)
+		assert.Equal(t, command, passwordCommand)
+	})
+}
+
+// TestPasswordPrecedenceLeavesASingleSettingAlone is the common case: only one
+// of the two is set anywhere, and there is nothing to decide.
+func TestPasswordPrecedenceLeavesASingleSettingAlone(t *testing.T) {
+	logged := captureLogs(t)
+
+	withParsedFlags(t, "password = \"from-config\"\n", nil, func(cmd *cli.Command) {
+		password, passwordCommand := passwordPrecedence(cmd)
+		assert.Equal(t, "from-config", password)
+		assert.Empty(t, passwordCommand)
+	})
+
+	assert.NotContains(t, logged.String(), "ignoring")
 }

--- a/util/auth_test.go
+++ b/util/auth_test.go
@@ -43,6 +43,17 @@ func TestMain(m *testing.M) {
 		time.Sleep(time.Minute)
 		os.Exit(0)
 
+	case "linger-partial":
+		// The same, with the token's line left unterminated: what was read is
+		// the front of it and the rest never came.
+		child := exec.Command(os.Args[0]) //nolint:gosec // G204: the test binary itself
+		child.Env = append(os.Environ(), helperModeEnv+"=hang")
+		child.Stdout = os.Stdout
+		_ = child.Start()
+
+		fmt.Print(os.Getenv(helperOutputEnv))
+		os.Exit(0)
+
 	case "linger":
 		// A helper that prints its token and exits, leaving something behind
 		// that still holds the output pipe -- which is what a helper starting
@@ -180,6 +191,22 @@ func TestGetCredentialsCompileOnlyKeepsRealValues(t *testing.T) {
 
 	assert.Equal(t, "secret", creds.Password)
 	assert.Equal(t, "https://confluence.example.com", creds.BaseURL)
+}
+
+// TestGetCredentialsChecksTheURLBeforeRunningTheCommand covers the order the
+// two are done in. A run with no base URL cannot go anywhere, so putting
+// somebody through a keyring prompt -- or the timeout, when it is pinentry
+// waiting on a passphrase nobody is there to type -- before telling them that
+// is a strange order to do things in.
+//
+// The helper prints, so a token in the result would prove it ran.
+func TestGetCredentialsChecksTheURLBeforeRunningTheCommand(t *testing.T) {
+	command := helperCommand(t, "print", "s3cret")
+
+	_, err := GetCredentials(context.Background(), "user", "", command, "", "", false)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "-l", "the base URL is what is missing, not the token")
 }
 
 // TestGetCredentialsPasswordFromStdin covers "-p -", which is how a token gets
@@ -491,6 +518,20 @@ func TestRunPasswordCommandKeepsTheTokenOfAHelperThatLeftAProcessBehind(t *testi
 	// And it did not sit there for the minute the lingering process lives.
 	assert.Less(t, elapsed, 10*time.Second,
 		"the wait delay bounds the pipe, not the process that inherited it")
+}
+
+// TestRunPasswordCommandRejectsATruncatedTokenFromAHelperThatLingered is the
+// limit of that leniency. Giving up on the pipe means giving up on whatever had
+// not been read yet, so output with no newline in it is the front of a token
+// and not a token: authenticating with it earns a 401 that looks exactly like
+// the wrong password, which is a long way from what went wrong.
+func TestRunPasswordCommandRejectsATruncatedTokenFromAHelperThatLingered(t *testing.T) {
+	command := helperCommand(t, "linger-partial", "s3cret")
+
+	_, err := runPasswordCommand(context.Background(), command)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "command failed")
 }
 
 // TestPasswordCommandFlagReachesCredentials drives the real flag set rather than calling GetCredentials directly.

--- a/util/auth_test.go
+++ b/util/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -40,6 +41,18 @@ func TestMain(m *testing.M) {
 
 	case "hang":
 		time.Sleep(time.Minute)
+		os.Exit(0)
+
+	case "linger":
+		// A helper that prints its token and exits, leaving something behind
+		// that still holds the output pipe -- which is what a helper starting
+		// an agent on demand does.
+		child := exec.Command(os.Args[0]) //nolint:gosec // G204: the test binary itself
+		child.Env = append(os.Environ(), helperModeEnv+"=hang")
+		child.Stdout = os.Stdout
+		_ = child.Start()
+
+		fmt.Println(os.Getenv(helperOutputEnv))
 		os.Exit(0)
 
 	default:
@@ -371,16 +384,54 @@ func TestGetCredentialsTreatsACommandsDashAsTheToken(t *testing.T) {
 	assert.Equal(t, "-", creds.Password)
 }
 
-// TestGetCredentialsSkipsTheCommandWhenCompilingOnly covers --compile-only beside a command.
-// That run never authenticates, so invoking a helper would prompt for a passphrase or wait on a hardware key for a token nothing uses.
-// The helper fails unconditionally, so reaching the compile-only password proves it was never invoked.
-func TestGetCredentialsSkipsTheCommandWhenCompilingOnly(t *testing.T) {
-	command := helperCommand(t, "fail", "")
+// TestGetCredentialsResolvesTheCommandWhenCompilingOnly covers --compile-only
+// beside a command.
+//
+// A compile looks like a run that never authenticates and is not one: a
+// relative link to another document is resolved by looking that page up, so
+// compiling one file that links to another makes two authenticated requests
+// before it prints anything. Skipping the command left the password at "none"
+// and 401'd them, while the same configuration with a literal password worked.
+//
+// The helper prints, so reaching its token proves it was invoked.
+func TestGetCredentialsResolvesTheCommandWhenCompilingOnly(t *testing.T) {
+	command := helperCommand(t, "print", "s3cret")
 
 	creds, err := GetCredentials(context.Background(), "user", "", command, "https://confluence.example.com", "", true)
 	require.NoError(t, err)
 
+	assert.Equal(t, "s3cret", creds.Password)
+}
+
+// TestGetCredentialsCompileOnlyStillNeedsNoPassword is the boundary: a compile
+// with nothing to run still gets its placeholder rather than an error.
+func TestGetCredentialsCompileOnlyStillNeedsNoPassword(t *testing.T) {
+	creds, err := GetCredentials(context.Background(), "user", "", "", "https://confluence.example.com", "", true)
+	require.NoError(t, err)
+
 	assert.Equal(t, "none", creds.Password)
+}
+
+// TestRunPasswordCommandKeepsTheTokenOfAHelperThatLeftAProcessBehind: Output()
+// returns once the stdout pipe closes, and the pipe is held by everything that
+// inherited it, not just the helper. A helper that starts an agent -- gpg-agent,
+// on demand, is the ordinary case -- therefore returns long after it exited.
+//
+// Reading ctx.Err() before err threw away a token that had been printed, read
+// and exited cleanly for, and failed a run that had everything it needed.
+func TestRunPasswordCommandKeepsTheTokenOfAHelperThatLeftAProcessBehind(t *testing.T) {
+	command := helperCommand(t, "linger", "s3cret")
+
+	start := time.Now()
+	password, err := runPasswordCommand(context.Background(), command)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, "s3cret", password)
+
+	// And it did not sit there for the minute the lingering process lives.
+	assert.Less(t, elapsed, 10*time.Second,
+		"the wait delay bounds the pipe, not the process that inherited it")
 }
 
 // TestPasswordCommandFlagReachesCredentials drives the real flag set rather than calling GetCredentials directly.

--- a/util/auth_test.go
+++ b/util/auth_test.go
@@ -1,18 +1,102 @@
 package util
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 )
+
+const (
+	helperModeEnv   = "MARK_TEST_PASSWORD_HELPER"
+	helperOutputEnv = "MARK_TEST_PASSWORD_HELPER_OUTPUT"
+)
+
+// TestMain doubles as the password command these tests run.
+// That command has to be a real executable, and what is on PATH varies by platform, so re-executing the test binary removes the assumption.
+// A child process inherits helperModeEnv, and TestMain hands it to the named helper instead of running the suite.
+func TestMain(m *testing.M) {
+	switch os.Getenv(helperModeEnv) {
+	case "":
+		os.Exit(m.Run())
+
+	case "print":
+		fmt.Println(os.Getenv(helperOutputEnv))
+		os.Exit(0)
+
+	case "fail":
+		fmt.Fprintln(os.Stderr, "helper refused to produce a token")
+		os.Exit(3)
+
+	case "hang":
+		time.Sleep(time.Minute)
+		os.Exit(0)
+
+	default:
+		fmt.Fprintln(os.Stderr, "unknown helper mode")
+		os.Exit(2)
+	}
+}
+
+// helperCommand returns a password-command string that re-executes the test binary in the given mode.
+func helperCommand(t *testing.T, mode string, output string) string {
+	t.Helper()
+
+	executable := os.Args[0]
+	if strings.ContainsAny(executable, " \t") {
+		t.Skipf("test binary path %q contains whitespace, which a password command cannot express", executable)
+	}
+
+	t.Setenv(helperModeEnv, mode)
+	t.Setenv(helperOutputEnv, output)
+
+	return executable
+}
+
+// captureLogs redirects the package logger for the duration of the test.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	var logged bytes.Buffer
+	restore := log.Logger
+	log.Logger = zerolog.New(&logged)
+	t.Cleanup(func() { log.Logger = restore })
+
+	return &logged
+}
+
+// feedStdin replaces os.Stdin with a pipe carrying value, for the duration of the test.
+func feedStdin(t *testing.T, value string) {
+	t.Helper()
+
+	read, write, err := os.Pipe()
+	require.NoError(t, err)
+
+	original := os.Stdin
+	os.Stdin = read
+	t.Cleanup(func() { os.Stdin = original })
+
+	go func() {
+		defer write.Close()
+		_, _ = write.WriteString(value)
+	}()
+}
 
 // TestGetCredentialsBaseURLFromTargetURL covers the shortest way to publish:
 // paste the URL of an existing page and let mark take the instance and the page
 // id out of it.
 func TestGetCredentialsBaseURLFromTargetURL(t *testing.T) {
-	creds, err := GetCredentials("user", "secret",
+	creds, err := GetCredentials(context.Background(), "user", "secret", "",
 		"https://confluence.example.com/pages/viewpage.action?pageId=12345", "", false)
 	require.NoError(t, err)
 
@@ -25,7 +109,7 @@ func TestGetCredentialsBaseURLFromTargetURL(t *testing.T) {
 // TestGetCredentialsExplicitBaseURLWins covers -l beside a target URL: the flag
 // is the instance, and the URL only supplies the page id.
 func TestGetCredentialsExplicitBaseURLWins(t *testing.T) {
-	creds, err := GetCredentials("user", "secret",
+	creds, err := GetCredentials(context.Background(), "user", "secret", "",
 		"https://old.example.com/pages/viewpage.action?pageId=7", "https://new.example.com/wiki", false)
 	require.NoError(t, err)
 
@@ -38,7 +122,7 @@ func TestGetCredentialsExplicitBaseURLWins(t *testing.T) {
 // trailing slash would produce "//rest/api" and a 404 that says nothing about
 // its cause.
 func TestGetCredentialsTrimsTrailingSlashes(t *testing.T) {
-	creds, err := GetCredentials("user", "secret", "", "https://confluence.example.com/wiki///", false)
+	creds, err := GetCredentials(context.Background(), "user", "secret", "", "", "https://confluence.example.com/wiki///", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, "https://confluence.example.com/wiki", creds.BaseURL)
@@ -48,7 +132,7 @@ func TestGetCredentialsTrimsTrailingSlashes(t *testing.T) {
 // It names the flag, because the alternative -- a 401 from Confluence -- sends
 // them looking at their account instead of at their invocation.
 func TestGetCredentialsRequiresAPassword(t *testing.T) {
-	_, err := GetCredentials("user", "", "", "https://confluence.example.com", false)
+	_, err := GetCredentials(context.Background(), "user", "", "", "", "https://confluence.example.com", false)
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), "-p")
@@ -57,7 +141,7 @@ func TestGetCredentialsRequiresAPassword(t *testing.T) {
 // TestGetCredentialsRequiresABaseURL covers the same for the instance: with
 // neither a target URL to derive it from nor -l, there is nothing to talk to.
 func TestGetCredentialsRequiresABaseURL(t *testing.T) {
-	_, err := GetCredentials("user", "secret", "", "", false)
+	_, err := GetCredentials(context.Background(), "user", "secret", "", "", "", false)
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), "-l")
@@ -67,7 +151,7 @@ func TestGetCredentialsRequiresABaseURL(t *testing.T) {
 // reaches Confluence. Requiring credentials to render Markdown locally would
 // make the flag useless in CI, so both are filled in with placeholders.
 func TestGetCredentialsCompileOnlyNeedsNothing(t *testing.T) {
-	creds, err := GetCredentials("", "", "", "", true)
+	creds, err := GetCredentials(context.Background(), "", "", "", "", "", true)
 	require.NoError(t, err)
 
 	assert.Equal(t, "none", creds.Password)
@@ -78,7 +162,7 @@ func TestGetCredentialsCompileOnlyNeedsNothing(t *testing.T) {
 // TestGetCredentialsCompileOnlyKeepsRealValues is the boundary of that rule:
 // the placeholders fill gaps, they do not override what was given.
 func TestGetCredentialsCompileOnlyKeepsRealValues(t *testing.T) {
-	creds, err := GetCredentials("user", "secret", "", "https://confluence.example.com", true)
+	creds, err := GetCredentials(context.Background(), "user", "secret", "", "", "https://confluence.example.com", true)
 	require.NoError(t, err)
 
 	assert.Equal(t, "secret", creds.Password)
@@ -90,19 +174,9 @@ func TestGetCredentialsCompileOnlyKeepsRealValues(t *testing.T) {
 // newline a pipe or a heredoc adds has to go: it would be sent as part of the
 // token and answered with a 401.
 func TestGetCredentialsPasswordFromStdin(t *testing.T) {
-	read, write, err := os.Pipe()
-	require.NoError(t, err)
+	feedStdin(t, "token-from-stdin\n")
 
-	original := os.Stdin
-	os.Stdin = read
-	defer func() { os.Stdin = original }()
-
-	go func() {
-		defer write.Close()
-		_, _ = write.WriteString("token-from-stdin\n")
-	}()
-
-	creds, err := GetCredentials("user", "-", "", "https://confluence.example.com", false)
+	creds, err := GetCredentials(context.Background(), "user", "-", "", "", "https://confluence.example.com", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, "token-from-stdin", creds.Password)
@@ -126,7 +200,7 @@ func TestGetCredentialsRejectsAnEmptyPasswordOnStdin(t *testing.T) {
 
 	defer func() { os.Stdin = original }()
 
-	_, err = GetCredentials("user", "-", "", "https://confluence.example.com", false)
+	_, err = GetCredentials(context.Background(), "user", "-", "", "", "https://confluence.example.com", false)
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), "-p")
@@ -136,8 +210,260 @@ func TestGetCredentialsRejectsAnEmptyPasswordOnStdin(t *testing.T) {
 // one at all, which is worth an error naming the value rather than a request to
 // an empty host.
 func TestGetCredentialsRejectsAnUnparseableURL(t *testing.T) {
-	_, err := GetCredentials("user", "secret", "https://exam ple.com/x", "", false)
+	_, err := GetCredentials(context.Background(), "user", "secret", "", "https://exam ple.com/x", "", false)
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), "as url")
+}
+
+// TestRunPasswordCommandTrimsTheHelpersNewline covers the newline every helper adds.
+// It would be sent as part of the token and answered with a 401, which is the same trap "-p -" has.
+func TestRunPasswordCommandTrimsTheHelpersNewline(t *testing.T) {
+	command := helperCommand(t, "print", "s3cret")
+
+	password, err := runPasswordCommand(context.Background(), command)
+	require.NoError(t, err)
+
+	assert.Equal(t, "s3cret", password)
+}
+
+// TestRunPasswordCommandTrimsSurroundingWhitespace covers the helper that pads what it prints.
+// Trimming both ends means a token survives a wrapper script that indents its output.
+func TestRunPasswordCommandTrimsSurroundingWhitespace(t *testing.T) {
+	command := helperCommand(t, "print", "  s3cret\t")
+
+	password, err := runPasswordCommand(context.Background(), command)
+	require.NoError(t, err)
+
+	assert.Equal(t, "s3cret", password)
+}
+
+// TestRunPasswordCommandAcceptsAPaddedCommand covers padding around the command itself.
+// strings.Fields absorbs it and collapses runs, so the setting needs no trimming of its own.
+func TestRunPasswordCommandAcceptsAPaddedCommand(t *testing.T) {
+	command := helperCommand(t, "print", "s3cret")
+
+	password, err := runPasswordCommand(context.Background(), "  "+command+" \t ")
+	require.NoError(t, err)
+
+	assert.Equal(t, "s3cret", password)
+}
+
+// TestRunPasswordCommandRejectsACommandWithNoWords covers a setting that holds nothing runnable.
+// Without the guard, indexing the first word would panic rather than report the empty value.
+func TestRunPasswordCommandRejectsACommandWithNoWords(t *testing.T) {
+	_, err := runPasswordCommand(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "command is empty")
+
+	_, err = runPasswordCommand(context.Background(), "   \t ")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "command is empty")
+}
+
+// TestRunPasswordCommandRejectsEmptyOutput covers the helper that succeeds and prints nothing.
+// Accepting that would authenticate with an empty token and produce a 401 naming nothing useful.
+func TestRunPasswordCommandRejectsEmptyOutput(t *testing.T) {
+	command := helperCommand(t, "print", "   ")
+
+	_, err := runPasswordCommand(context.Background(), command)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "produced no output")
+}
+
+// TestRunPasswordCommandReportsANonZeroExit covers the helper that refuses.
+// A locked keyring and a missing entry both arrive this way.
+func TestRunPasswordCommandReportsANonZeroExit(t *testing.T) {
+	command := helperCommand(t, "fail", "")
+
+	_, err := runPasswordCommand(context.Background(), command)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "command failed")
+}
+
+// TestRunPasswordCommandReportsAnUnrunnableCommand covers the name that is not on PATH at all.
+// That is the shape of a typo in the setting, and it has to name the failure rather than yield an empty token.
+func TestRunPasswordCommandReportsAnUnrunnableCommand(t *testing.T) {
+	_, err := runPasswordCommand(context.Background(), "mark-no-such-password-helper")
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "command failed")
+}
+
+// TestRunPasswordCommandStopsAHelperThatHangs covers the helper that waits on input nobody will give it.
+// Unbounded, that stalls the whole run instead of failing it.
+// The caller's deadline is the earlier of the two, so this exercises the branch without waiting out passwordCommandTimeout.
+func TestRunPasswordCommandStopsAHelperThatHangs(t *testing.T) {
+	command := helperCommand(t, "hang", "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := runPasswordCommand(ctx, command)
+	require.Error(t, err)
+
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Contains(t, err.Error(), "did not complete")
+	assert.Less(t, time.Since(start), passwordCommandTimeout,
+		"the caller's deadline should fire well before the built-in one")
+}
+
+// TestGetCredentialsResolvesThePasswordFromACommand covers the case the setting exists for.
+// The token reaches mark without being written to the configuration file or exported into the environment.
+func TestGetCredentialsResolvesThePasswordFromACommand(t *testing.T) {
+	command := helperCommand(t, "print", "from-command")
+	logged := captureLogs(t)
+
+	creds, err := GetCredentials(context.Background(), "user", "", command, "https://confluence.example.com", "", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "from-command", creds.Password)
+	assert.NotContains(t, logged.String(), "ignoring password-command",
+		"nothing is being shadowed, so there is nothing to warn about")
+}
+
+// TestGetCredentialsPrefersAnExplicitPasswordOverTheCommand covers both being set.
+// A flag on the command line has to be able to override a token already in the configuration file.
+func TestGetCredentialsPrefersAnExplicitPasswordOverTheCommand(t *testing.T) {
+	command := helperCommand(t, "print", "from-command")
+
+	creds, err := GetCredentials(context.Background(), "user", "from-flag", command, "https://confluence.example.com", "", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "from-flag", creds.Password)
+}
+
+// TestGetCredentialsWarnsThatTheCommandIsIgnored covers what that precedence costs.
+// Either value can arrive from a different layer, so a password left in one would otherwise shadow the command in silence.
+func TestGetCredentialsWarnsThatTheCommandIsIgnored(t *testing.T) {
+	command := helperCommand(t, "print", "from-command")
+	logged := captureLogs(t)
+
+	_, err := GetCredentials(context.Background(), "user", "from-flag", command, "https://confluence.example.com", "", false)
+	require.NoError(t, err)
+
+	assert.Contains(t, logged.String(), "ignoring password-command")
+}
+
+// TestGetCredentialsSurfacesAFailingCommand covers the helper that fails with no password set.
+// Reporting the missing password instead would send people looking at their invocation rather than at their helper.
+func TestGetCredentialsSurfacesAFailingCommand(t *testing.T) {
+	command := helperCommand(t, "fail", "")
+
+	_, err := GetCredentials(context.Background(), "user", "", command, "https://confluence.example.com", "", false)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "unable to read password from command: command failed")
+}
+
+// TestGetCredentialsTreatsACommandsDashAsTheToken covers a helper printing a bare dash.
+// Whatever the command prints is the token, so it must not reach the "-p -" branch and block on stdin.
+func TestGetCredentialsTreatsACommandsDashAsTheToken(t *testing.T) {
+	command := helperCommand(t, "print", "-")
+	feedStdin(t, "token-from-stdin\n")
+
+	creds, err := GetCredentials(context.Background(), "user", "", command, "https://confluence.example.com", "", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "-", creds.Password)
+}
+
+// TestGetCredentialsSkipsTheCommandWhenCompilingOnly covers --compile-only beside a command.
+// That run never authenticates, so invoking a helper would prompt for a passphrase or wait on a hardware key for a token nothing uses.
+// The helper fails unconditionally, so reaching the compile-only password proves it was never invoked.
+func TestGetCredentialsSkipsTheCommandWhenCompilingOnly(t *testing.T) {
+	command := helperCommand(t, "fail", "")
+
+	creds, err := GetCredentials(context.Background(), "user", "", command, "https://confluence.example.com", "", true)
+	require.NoError(t, err)
+
+	assert.Equal(t, "none", creds.Password)
+}
+
+// TestPasswordCommandFlagReachesCredentials drives the real flag set rather than calling GetCredentials directly.
+// RunMark forwards the flag with a single cmd.String("password-command"), and a name matching no registered flag yields "" instead of an error.
+// That would leave the setting silently inert, so the run has to stop at credential resolution, before any Confluence request.
+func TestPasswordCommandFlagReachesCredentials(t *testing.T) {
+	command := helperCommand(t, "fail", "")
+
+	config := filepath.Join(t.TempDir(), "mark.toml")
+	require.NoError(t, os.WriteFile(config, nil, 0o600))
+
+	restore := log.Logger
+	t.Cleanup(func() { log.Logger = restore })
+
+	cmd := &cli.Command{
+		Flags:  Flags,
+		Before: CheckFlags,
+		Action: RunMark,
+	}
+
+	err := cmd.Run(context.Background(), []string{
+		"mark",
+		"--config", config,
+		"--username", "user",
+		"--base-url", "https://confluence.example.invalid",
+		"--password-command", command,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to read password from command",
+		"--password-command must reach GetCredentials")
+}
+
+// TestPasswordCommandIsMaskedInTheConfigDump covers the debug dump that names every flag and its value.
+// A command can name a token inline, so printing it in full would put a credential in the log the way printing the password would.
+// The dump runs after credential resolution, so this uses --compile-only to reach it without a Confluence request.
+func TestPasswordCommandIsMaskedInTheConfigDump(t *testing.T) {
+	command := helperCommand(t, "print", "tok")
+
+	dir := t.TempDir()
+	config := filepath.Join(dir, "mark.toml")
+	require.NoError(t, os.WriteFile(config, nil, 0o600))
+
+	document := filepath.Join(dir, "page.md")
+	require.NoError(t, os.WriteFile(document, []byte("# Title\n\nBody.\n"), 0o600))
+
+	captured := filepath.Join(dir, "stderr")
+	file, err := os.Create(captured)
+	require.NoError(t, err)
+
+	originalStderr := os.Stderr
+	originalLogger := log.Logger
+	originalLevel := zerolog.GlobalLevel()
+	os.Stderr = file
+
+	t.Cleanup(func() {
+		os.Stderr = originalStderr
+		log.Logger = originalLogger
+		zerolog.SetGlobalLevel(originalLevel)
+	})
+
+	cmd := &cli.Command{
+		Flags:  Flags,
+		Before: CheckFlags,
+		Action: RunMark,
+	}
+
+	_ = cmd.Run(context.Background(), []string{
+		"mark",
+		"--config", config,
+		"--log-level", "DEBUG",
+		"--color", "never",
+		"--compile-only",
+		"--password-command", command,
+		"--files", document,
+	})
+
+	require.NoError(t, file.Close())
+
+	logged, err := os.ReadFile(captured)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(logged), "password-command: ******")
+	assert.NotContains(t, string(logged), command,
+		"the command must not reach the log in full")
 }

--- a/util/auth_test.go
+++ b/util/auth_test.go
@@ -43,27 +43,23 @@ func TestMain(m *testing.M) {
 		time.Sleep(time.Minute)
 		os.Exit(0)
 
-	case "linger-partial":
-		// The same, with the token's line left unterminated: what was read is
-		// the front of it and the rest never came.
-		child := exec.Command(os.Args[0]) //nolint:gosec // G204: the test binary itself
-		child.Env = append(os.Environ(), helperModeEnv+"=hang")
-		child.Stdout = os.Stdout
-		_ = child.Start()
-
-		fmt.Print(os.Getenv(helperOutputEnv))
-		os.Exit(0)
-
-	case "linger":
+	case "linger", "linger-partial":
 		// A helper that prints its token and exits, leaving something behind
 		// that still holds the output pipe -- which is what a helper starting
-		// an agent on demand does.
+		// an agent on demand does. The partial one leaves the token's line
+		// unterminated with it: what was read is the front of the token and the
+		// rest never came.
 		child := exec.Command(os.Args[0]) //nolint:gosec // G204: the test binary itself
 		child.Env = append(os.Environ(), helperModeEnv+"=hang")
 		child.Stdout = os.Stdout
 		_ = child.Start()
 
-		fmt.Println(os.Getenv(helperOutputEnv))
+		token := os.Getenv(helperOutputEnv)
+		if os.Getenv(helperModeEnv) == "linger" {
+			token += "\n"
+		}
+
+		fmt.Print(token)
 		os.Exit(0)
 
 	default:
@@ -382,37 +378,41 @@ func TestRunPasswordCommandStopsAHelperThatHangs(t *testing.T) {
 // The token reaches mark without being written to the configuration file or exported into the environment.
 func TestGetCredentialsResolvesThePasswordFromACommand(t *testing.T) {
 	command := helperCommand(t, "print", "from-command")
-	logged := captureLogs(t)
 
 	creds, err := GetCredentials(context.Background(), "user", "", command, "https://confluence.example.com", "", false)
 	require.NoError(t, err)
 
 	assert.Equal(t, "from-command", creds.Password)
-	assert.NotContains(t, logged.String(), "ignoring password-command",
-		"nothing is being shadowed, so there is nothing to warn about")
 }
 
-// TestGetCredentialsPrefersAnExplicitPasswordOverTheCommand covers both being set.
-// A flag on the command line has to be able to override a token already in the configuration file.
-func TestGetCredentialsPrefersAnExplicitPasswordOverTheCommand(t *testing.T) {
+// TestGetCredentialsRefusesBothAtOnce covers a password and a command set
+// together.
+//
+// Either can arrive from the flag, the environment or the configuration file,
+// so the two say nothing about which is meant: a password left over from before
+// the command was set up reads exactly like one somebody wants used. Picking
+// either would be a guess, and the wrong guess is silent -- so this is refused
+// the way mark refuses every other pair of settings that contradict each other.
+func TestGetCredentialsRefusesBothAtOnce(t *testing.T) {
 	command := helperCommand(t, "print", "from-command")
-
-	creds, err := GetCredentials(context.Background(), "user", "from-flag", command, "https://confluence.example.com", "", false)
-	require.NoError(t, err)
-
-	assert.Equal(t, "from-flag", creds.Password)
-}
-
-// TestGetCredentialsWarnsThatTheCommandIsIgnored covers what that precedence costs.
-// Either value can arrive from a different layer, so a password left in one would otherwise shadow the command in silence.
-func TestGetCredentialsWarnsThatTheCommandIsIgnored(t *testing.T) {
-	command := helperCommand(t, "print", "from-command")
-	logged := captureLogs(t)
 
 	_, err := GetCredentials(context.Background(), "user", "from-flag", command, "https://confluence.example.com", "", false)
-	require.NoError(t, err)
+	require.Error(t, err)
 
-	assert.Contains(t, logged.String(), "ignoring password-command")
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// TestGetCredentialsRefusesBothBeforeRunningEither is the point of refusing:
+// the helper never runs, so nothing is asked of a keyring for a run that is
+// going to stop anyway.
+func TestGetCredentialsRefusesBothBeforeRunningEither(t *testing.T) {
+	command := helperCommand(t, "fail", "")
+
+	_, err := GetCredentials(context.Background(), "user", "from-flag", command, "https://confluence.example.com", "", false)
+	require.Error(t, err)
+
+	assert.NotContains(t, err.Error(), "command failed",
+		"the contradiction is the error, not whatever the helper would have said")
 }
 
 // TestGetCredentialsSurfacesAFailingCommand covers the helper that fails with no password set.
@@ -617,117 +617,4 @@ func TestPasswordCommandIsMaskedInTheConfigDump(t *testing.T) {
 	assert.Contains(t, string(logged), "password-command: ******")
 	assert.NotContains(t, string(logged), command,
 		"the command must not reach the log in full")
-}
-
-// TestPasswordPrecedence covers which of the two settings a run uses when both
-// carry a value.
-//
-// A password in the configuration file is the ordinary starting point -- it is
-// what the README has always shown -- so somebody trying --password-command for
-// the first time has one. Deciding this over the two resolved values, as the
-// non-empty password did, cannot tell that password from one typed in the same
-// breath as the command, which made this the one flag in mark that the
-// configuration file overrides and left editing that file the only way to use
-// it.
-func TestPasswordPrecedence(t *testing.T) {
-	const (
-		password = "from-password"
-		command  = "from-command"
-	)
-
-	tests := []struct {
-		name         string
-		args         []string
-		env          map[string]string
-		wantPassword string
-		wantCommand  string
-	}{
-		{
-			name:        "a command on the command line beats a configured password",
-			args:        []string{"mark", "--password-command", command},
-			wantCommand: command,
-		},
-		{
-			name:         "a password on the command line beats a configured command",
-			args:         []string{"mark", "-p", password},
-			wantPassword: password,
-		},
-		{
-			name:         "an attached value is the same flag",
-			args:         []string{"mark", "--password=" + password},
-			wantPassword: password,
-		},
-		{
-			name:        "the environment beats the configuration file",
-			env:         map[string]string{"MARK_PASSWORD_COMMAND": command},
-			wantCommand: command,
-		},
-		{
-			name:         "and loses to the command line",
-			args:         []string{"mark", "--password", password},
-			env:          map[string]string{"MARK_PASSWORD_COMMAND": command},
-			wantPassword: password,
-		},
-		{
-			// Nothing separates them, so the password stays what wins, and
-			// GetCredentials says as much.
-			name:         "two settings in one file are a tie",
-			wantPassword: password,
-			wantCommand:  command,
-		},
-		{
-			name:         "as are two on the command line",
-			args:         []string{"mark", "-p", password, "--password-command", command},
-			wantPassword: password,
-			wantCommand:  command,
-		},
-		{
-			// Which is what makes this worth getting right: a value that
-			// happens to read like a flag is not one.
-			name:         "nothing past a bare -- is a flag",
-			args:         []string{"mark", "--", "--password-command"},
-			wantPassword: password,
-			wantCommand:  command,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			for name, value := range test.env {
-				t.Setenv(name, value)
-			}
-
-			gotPassword, gotCommand := passwordPrecedence(password, command, test.args)
-
-			assert.Equal(t, test.wantPassword, gotPassword)
-			assert.Equal(t, test.wantCommand, gotCommand)
-		})
-	}
-}
-
-// TestPasswordPrecedenceLeavesASingleSettingAlone is the common case: only one
-// of the two is set anywhere, and there is nothing to decide.
-func TestPasswordPrecedenceLeavesASingleSettingAlone(t *testing.T) {
-	logged := captureLogs(t)
-
-	password, command := passwordPrecedence("from-password", "", []string{"mark"})
-	assert.Equal(t, "from-password", password)
-	assert.Empty(t, command)
-
-	password, command = passwordPrecedence("", "helper", []string{"mark"})
-	assert.Empty(t, password)
-	assert.Equal(t, "helper", command)
-
-	assert.NotContains(t, logged.String(), "ignoring")
-}
-
-// TestPasswordPrecedenceNamesWhatItDropped covers the warning, which is the
-// only sign a setting was passed over.
-func TestPasswordPrecedenceNamesWhatItDropped(t *testing.T) {
-	logged := captureLogs(t)
-
-	passwordPrecedence("from-password", "from-command", []string{"mark", "--password-command", "from-command"})
-
-	assert.Contains(t, logged.String(),
-		"using password-command from the command line and ignoring password from the configuration file")
 }

--- a/util/auth_test.go
+++ b/util/auth_test.go
@@ -412,6 +412,18 @@ func TestGetCredentialsCompileOnlyStillNeedsNoPassword(t *testing.T) {
 	assert.Equal(t, "none", creds.Password)
 }
 
+// TestGetCredentialsCompileOnlyFailsOnAFailingCommand is the other side of that boundary.
+// A compile authenticates, so a helper that cannot produce a token fails the run rather than being skipped.
+// Falling back to "none" would turn a broken helper into a 401 further along, naming the wrong cause.
+func TestGetCredentialsCompileOnlyFailsOnAFailingCommand(t *testing.T) {
+	command := helperCommand(t, "fail", "")
+
+	_, err := GetCredentials(context.Background(), "user", "", command, "https://confluence.example.com", "", true)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "command failed")
+}
+
 // TestRunPasswordCommandKeepsTheTokenOfAHelperThatLeftAProcessBehind: Output()
 // returns once the stdout pipe closes, and the pipe is held by everything that
 // inherited it, not just the helper. A helper that starts an agent -- gpg-agent,

--- a/util/cli.go
+++ b/util/cli.go
@@ -67,9 +67,11 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 	}
 	log.Logger = zerolog.New(output).With().Timestamp().Logger()
 
-	// Not cmd.String for these two: which of them a run uses depends on the
-	// source each arrived from, which the resolved values no longer carry.
-	password, passwordCommand := passwordPrecedence(cmd)
+	// Which of these two a run uses depends on the layer each was set in, and a
+	// resolved value no longer carries that -- hence the command line as well.
+	password, passwordCommand := passwordPrecedence(
+		cmd.String("password"), cmd.String("password-command"), os.Args,
+	)
 
 	creds, err := GetCredentials(
 		ctx,

--- a/util/cli.go
+++ b/util/cli.go
@@ -68,8 +68,10 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 	log.Logger = zerolog.New(output).With().Timestamp().Logger()
 
 	creds, err := GetCredentials(
+		ctx,
 		cmd.String("username"),
 		cmd.String("password"),
+		cmd.String("password-command"),
 		cmd.String("target-url"),
 		cmd.String("base-url"),
 		cmd.Bool("compile-only"),
@@ -81,7 +83,8 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 	log.Debug().Msg("config:")
 	for _, f := range cmd.Flags {
 		flag := f.Names()
-		if flag[0] == "password" {
+		// A command can name a token inline, so it leaks the same way the password would.
+		if flag[0] == "password" || flag[0] == "password-command" {
 			log.Debug().Msgf("%20s: %v", flag[0], "******")
 		} else {
 			log.Debug().Msgf("%20s: %v", flag[0], cmd.Value(flag[0]))

--- a/util/cli.go
+++ b/util/cli.go
@@ -67,11 +67,15 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 	}
 	log.Logger = zerolog.New(output).With().Timestamp().Logger()
 
+	// Not cmd.String for these two: which of them a run uses depends on the
+	// source each arrived from, which the resolved values no longer carry.
+	password, passwordCommand := passwordPrecedence(cmd)
+
 	creds, err := GetCredentials(
 		ctx,
 		cmd.String("username"),
-		cmd.String("password"),
-		cmd.String("password-command"),
+		password,
+		passwordCommand,
 		cmd.String("target-url"),
 		cmd.String("base-url"),
 		cmd.Bool("compile-only"),

--- a/util/cli.go
+++ b/util/cli.go
@@ -67,17 +67,11 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 	}
 	log.Logger = zerolog.New(output).With().Timestamp().Logger()
 
-	// Which of these two a run uses depends on the layer each was set in, and a
-	// resolved value no longer carries that -- hence the command line as well.
-	password, passwordCommand := passwordPrecedence(
-		cmd.String("password"), cmd.String("password-command"), os.Args,
-	)
-
 	creds, err := GetCredentials(
 		ctx,
 		cmd.String("username"),
-		password,
-		passwordCommand,
+		cmd.String("password"),
+		cmd.String("password-command"),
 		cmd.String("target-url"),
 		cmd.String("base-url"),
 		cmd.Bool("compile-only"),

--- a/util/flags.go
+++ b/util/flags.go
@@ -42,307 +42,319 @@ var KnownFeatures = []string{
 // off.
 var defaultFeatures = []string{"mermaid", "mention"}
 
-var Flags = []cli.Flag{
-	// First, and it has to stay first. Every other flag finds the
-	// configuration file through the pointer below, which is filled in as the
-	// flags are resolved -- in the order they are declared. Anything declared
-	// above this looks for its TOML value while that pointer is still empty and
-	// silently gets nothing.
-	//
-	// A path on the command line happened to survive being declared late. One
-	// in MARK_CONFIG did not, so "MARK_CONFIG=/etc/mark.toml mark" ignored
-	// files, username, password, target-url, base-url and log-level while
-	// honouring space, parents and features -- reported, if at all, as
-	// "confluence password should be specified using -p flag".
-	&cli.StringFlag{
-		Name:        "config",
-		Aliases:     []string{"c"},
-		Value:       ConfigFilePath(),
-		Usage:       "use the specified configuration file.",
-		TakesFile:   true,
-		Sources:     cli.NewValueSourceChain(cli.EnvVar("MARK_CONFIG")),
-		Destination: &filename,
-	},
-	&cli.StringFlag{
-		Name:      "files",
-		Aliases:   []string{"f"},
-		Value:     "",
-		Usage:     "use specified markdown file(s) for converting to html. Supports file globbing patterns (needs to be quoted).",
-		TakesFile: true,
-		Sources:   cli.NewValueSourceChain(cli.EnvVar("MARK_FILES"), altsrctoml.TOML("files", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "continue-on-error",
-		Value:   false,
-		Usage:   "don't exit if an error occurs while processing a file, continue processing remaining files.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CONTINUE_ON_ERROR"), altsrctoml.TOML("continue-on-error", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "compile-only",
-		Value:   false,
-		Usage:   "show resulting HTML and don't update Confluence page content.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_COMPILE_ONLY"), altsrctoml.TOML("compile-only", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "dry-run",
-		Value:   false,
-		Usage:   "resolve page and ancestry, show resulting HTML and exit.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_DRY_RUN"), altsrctoml.TOML("dry-run", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "edit-lock",
-		Value:   false,
-		Aliases: []string{"k"},
-		Usage:   "lock page editing to current user only to prevent accidental manual edits over Confluence Web UI.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_EDIT_LOCK"), altsrctoml.TOML("edit-lock", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "drop-h1",
-		Value:   false,
-		Usage:   "don't include the first H1 heading in Confluence output.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_DROP_H1"), altsrctoml.TOML("drop-h1", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "strip-linebreaks",
-		Value:   false,
-		Aliases: []string{"L"},
-		Usage:   "remove linebreaks inside of tags, to accommodate non-standard Confluence behavior",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_STRIP_LINEBREAKS"), altsrctoml.TOML("strip-linebreaks", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "title-from-h1",
-		Value:   false,
-		Usage:   "extract page title from a leading H1 heading. If no H1 heading on a page exists, then title must be set in the page metadata. Mutually exclusive with --title-from-filename.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_FROM_H1"), altsrctoml.TOML("title-from-h1", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "title-from-filename",
-		Value:   false,
-		Usage:   "use the filename (without extension) as the Confluence page title if no explicit page title is set in the metadata. Mutually exclusive with --title-from-h1.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_FROM_FILENAME"), altsrctoml.TOML("title-from-filename", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "title-append-generated-hash",
-		Value:   false,
-		Usage:   "appends a short hash generated from the path of the page (space, parents, and title) to the title",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_APPEND_GENERATED_HASH"), altsrctoml.TOML("title-append-generated-hash", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "minor-edit",
-		Value:   false,
-		Usage:   "don't send notifications while updating Confluence page.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MINOR_EDIT"), altsrctoml.TOML("minor-edit", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:    "version-message",
-		Value:   "",
-		Usage:   "add a message to the page version, to explain the edit (default: \"\")",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_VERSION_MESSAGE"), altsrctoml.TOML("version-message", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:  "color",
-		Value: "auto",
-		Usage: "display logs in color. Possible values: auto, never.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_COLOR"),
-			altsrctoml.TOML("color", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:    "log-level",
-		Value:   "info",
-		Usage:   "set the log level. Possible values: TRACE, DEBUG, INFO, WARNING, ERROR, FATAL.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_LOG_LEVEL"), altsrctoml.TOML("log-level", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:    "username",
-		Aliases: []string{"u"},
-		Value:   "",
-		Usage:   "use specified username for updating Confluence page.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_USERNAME"),
-			altsrctoml.TOML("username", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:    "password",
-		Aliases: []string{"p"},
-		Value:   "",
-		Usage:   "use specified token for updating Confluence page. Specify - as password to read password from stdin, or your Personal access token. Username is not mandatory if personal access token is provided. For more info please see: https://developer.atlassian.com/server/confluence/confluence-server-rest-api/#authentication.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PASSWORD"), altsrctoml.TOML("password", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:    "password-command",
-		Value:   "",
-		Usage:   "run the specified command and use its trimmed stdout as the token for updating Confluence page. Runs without a shell, and is ignored when a password is set.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PASSWORD_COMMAND"), altsrctoml.TOML("password-command", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:    "target-url",
-		Aliases: []string{"l"},
-		Value:   "",
-		Usage:   "edit specified Confluence page. If -l is not specified, file should contain metadata (see above).",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TARGET_URL"), altsrctoml.TOML("target-url", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:    "base-url",
-		Aliases: []string{"b"},
-		Value:   "",
-		Usage:   "base URL for Confluence. Alternative option for base_url config field.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_BASE_URL"),
-			altsrctoml.TOML("base-url", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "ci",
-		Value:   false,
-		Usage:   "run on CI mode. It won't fail if files are not found.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CI"), altsrctoml.TOML("ci", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:    "space",
-		Value:   "",
-		Usage:   "use specified space key. If the space key is not specified, it must be set in the page metadata.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_SPACE"), altsrctoml.TOML("space", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:    "parents",
-		Value:   "",
-		Usage:   "A list containing the parents of the document separated by parents-delimiter (default: '/'). These will be prepended to the ones defined in the document itself.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PARENTS"), altsrctoml.TOML("parents", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:    "parents-delimiter",
-		Value:   "/",
-		Usage:   "The delimiter used for the parents list",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PARENTS_DELIMITER"), altsrctoml.TOML("parents-delimiter", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:  "content-appearance",
-		Value: "",
-		Usage: "default content appearance for pages without a Content-Appearance header. Possible values: full-width, fixed, default.",
-		Sources: cli.NewValueSourceChain(
-			cli.EnvVar("MARK_CONTENT_APPEARANCE"),
-			altsrctoml.TOML("content-appearance", altsrc.NewStringPtrSourcer(&filename)),
-		),
-	},
-	&cli.FloatFlag{
-		Name:    "mermaid-scale",
-		Value:   1.0,
-		Usage:   "defines the scaling factor for mermaid renderings.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MERMAID_SCALE"), altsrctoml.TOML("mermaid-scale", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:    "math-format",
-		Value:   "png",
-		Usage:   "image a formula is published as with --features=math: png (rasterised through the same headless Chrome mermaid uses) or svg (vector and sharp at any zoom, where the instance displays an SVG attachment).",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MATH_FORMAT"), altsrctoml.TOML("math-format", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.FloatFlag{
-		Name:    "math-scale",
-		Value:   2.0,
-		Usage:   "defines the scaling factor for PNG formula renderings; ignored when math-format is svg.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MATH_SCALE"), altsrctoml.TOML("math-scale", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:      "include-path",
-		Value:     "",
-		Usage:     "Path for shared includes, used as a fallback if the include doesn't exist in the current directory.",
-		TakesFile: true,
-		Sources:   cli.NewValueSourceChain(cli.EnvVar("MARK_INCLUDE_PATH"), altsrctoml.TOML("include-path", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "changes-only",
-		Value:   false,
-		Usage:   "Avoids re-uploading pages that haven't changed since the last run.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHANGES_ONLY"), altsrctoml.TOML("changes-only", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:  "output-format",
-		Value: "url",
-		Usage: "how to report what the run did: \"url\" prints the address of each published page (the default), \"json\" prints one object describing the whole run, \"github\" prints GitHub Actions workflow commands so that failures appear against the file that caused them.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_OUTPUT_FORMAT"),
-			altsrctoml.TOML("output-format", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:  "on-orphan",
-		Value: "report",
-		Usage: "what to do about a page whose source file is gone: \"report\" says so and does nothing (the default), \"archive\" archives the page (Confluence Cloud only), \"delete\" moves it to the trash. Requires --track-pages.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_ON_ORPHAN"),
-			altsrctoml.TOML("on-orphan", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:  "orphan-under",
-		Value: "",
-		Usage: "limit --on-orphan, and the reporting it does, to pages below this page or folder, given by title or id. Without it, every tracked page the --files pattern would have published is in scope.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_ORPHAN_UNDER"),
-			altsrctoml.TOML("orphan-under", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringSliceFlag{
-		Name:  "check-links",
-		Usage: "fail on links that do not resolve. Repeat or comma-separate any of: \"internal\" (relative links to other files in the repository), \"confluence\" (ac: links naming a page by title), \"external\" (requests each URL to see whether it answers), or \"all\".",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHECK_LINKS"),
-			altsrctoml.TOML("check-links", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:      "global-properties",
-		Value:     "",
-		Usage:     "path to a YAML or JSON file of Confluence content properties to set on every page. A Property header or properties front matter in a document wins over the file for that page.",
-		TakesFile: true,
-		Sources:   cli.NewValueSourceChain(cli.EnvVar("MARK_GLOBAL_PROPERTIES"), altsrctoml.TOML("global-properties", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "append-labels",
-		Value:   false,
-		Usage:   "add the labels a document asks for without removing any others, so that labels applied in Confluence survive a publish. Without it, a page ends up with exactly the labels its Label headers name.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_APPEND_LABELS"), altsrctoml.TOML("append-labels", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "check-links-warn-only",
-		Value:   false,
-		Usage:   "report links that do not resolve without failing the run. Only meaningful together with --check-links.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHECK_LINKS_WARN_ONLY"), altsrctoml.TOML("check-links-warn-only", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "no-overwrite",
-		Value:   false,
-		Usage:   "Leave alone any page that has been edited in Confluence since mark last published it, instead of overwriting the edit. Requires --track-pages, which is where the last published version is remembered.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_NO_OVERWRITE"), altsrctoml.TOML("no-overwrite", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "track-pages",
-		Value:   false,
-		Usage:   "Remember which page each file publishes to, so renaming a file or changing its title updates the existing page instead of creating a second one. Stores the mapping in Confluence (a space property on Cloud, a homepage content property on Server/Data Center); nothing is written to the repository.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TRACK_PAGES"), altsrctoml.TOML("track-pages", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "preserve-comments",
-		Value:   false,
-		Usage:   "Fetch and preserve inline comments on existing Confluence pages.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PRESERVE_COMMENTS"), altsrctoml.TOML("preserve-comments", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.FloatFlag{
-		Name:    "d2-scale",
-		Value:   1.0,
-		Usage:   "defines the scaling factor for d2 renderings.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_D2_SCALE"), altsrctoml.TOML("d2-scale", altsrc.NewStringPtrSourcer(&filename))),
-	},
+// Flags is the flag set mark itself runs with.
+var Flags = NewFlags()
 
-	&cli.StringSliceFlag{
-		Name:  "features",
-		Value: []string{"mermaid", "mention"},
-		Usage: "Enables optional features, replacing the defaults (" +
-			strings.Join(defaultFeatures, ", ") + ") rather than adding to them. " +
-			"Current features: " + strings.Join(KnownFeatures, ", "),
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_FEATURES"), altsrctoml.TOML("features", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.BoolFlag{
-		Name:    "insecure-skip-tls-verify",
-		Value:   false,
-		Usage:   "skip TLS certificate verification (useful for self-signed certificates)",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_INSECURE_SKIP_TLS_VERIFY"), altsrctoml.TOML("insecure-skip-tls-verify", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:    "image-align",
-		Value:   "",
-		Usage:   "set image alignment (left, center, right). Can be overridden per-file via the Image-Align header.",
-		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_IMAGE_ALIGN"), altsrctoml.TOML("image-align", altsrc.NewStringPtrSourcer(&filename))),
-	},
+// NewFlags returns a fresh copy of mark's flags.
+//
+// urfave records on the flag itself that a value has been set, and never clears
+// it: a flag set run a second time keeps the first run's values and skips its
+// own sources. Running mark happens once per process, so the set below could be
+// a plain variable -- but a test binary runs it many times over, and each of
+// those runs needs a set that has not been parsed before.
+func NewFlags() []cli.Flag {
+	return []cli.Flag{
+		// First, and it has to stay first. Every other flag finds the
+		// configuration file through the pointer below, which is filled in as the
+		// flags are resolved -- in the order they are declared. Anything declared
+		// above this looks for its TOML value while that pointer is still empty and
+		// silently gets nothing.
+		//
+		// A path on the command line happened to survive being declared late. One
+		// in MARK_CONFIG did not, so "MARK_CONFIG=/etc/mark.toml mark" ignored
+		// files, username, password, target-url, base-url and log-level while
+		// honouring space, parents and features -- reported, if at all, as
+		// "confluence password should be specified using -p flag".
+		&cli.StringFlag{
+			Name:        "config",
+			Aliases:     []string{"c"},
+			Value:       ConfigFilePath(),
+			Usage:       "use the specified configuration file.",
+			TakesFile:   true,
+			Sources:     cli.NewValueSourceChain(cli.EnvVar("MARK_CONFIG")),
+			Destination: &filename,
+		},
+		&cli.StringFlag{
+			Name:      "files",
+			Aliases:   []string{"f"},
+			Value:     "",
+			Usage:     "use specified markdown file(s) for converting to html. Supports file globbing patterns (needs to be quoted).",
+			TakesFile: true,
+			Sources:   cli.NewValueSourceChain(cli.EnvVar("MARK_FILES"), altsrctoml.TOML("files", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "continue-on-error",
+			Value:   false,
+			Usage:   "don't exit if an error occurs while processing a file, continue processing remaining files.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CONTINUE_ON_ERROR"), altsrctoml.TOML("continue-on-error", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "compile-only",
+			Value:   false,
+			Usage:   "show resulting HTML and don't update Confluence page content.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_COMPILE_ONLY"), altsrctoml.TOML("compile-only", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "dry-run",
+			Value:   false,
+			Usage:   "resolve page and ancestry, show resulting HTML and exit.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_DRY_RUN"), altsrctoml.TOML("dry-run", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "edit-lock",
+			Value:   false,
+			Aliases: []string{"k"},
+			Usage:   "lock page editing to current user only to prevent accidental manual edits over Confluence Web UI.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_EDIT_LOCK"), altsrctoml.TOML("edit-lock", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "drop-h1",
+			Value:   false,
+			Usage:   "don't include the first H1 heading in Confluence output.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_DROP_H1"), altsrctoml.TOML("drop-h1", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "strip-linebreaks",
+			Value:   false,
+			Aliases: []string{"L"},
+			Usage:   "remove linebreaks inside of tags, to accommodate non-standard Confluence behavior",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_STRIP_LINEBREAKS"), altsrctoml.TOML("strip-linebreaks", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "title-from-h1",
+			Value:   false,
+			Usage:   "extract page title from a leading H1 heading. If no H1 heading on a page exists, then title must be set in the page metadata. Mutually exclusive with --title-from-filename.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_FROM_H1"), altsrctoml.TOML("title-from-h1", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "title-from-filename",
+			Value:   false,
+			Usage:   "use the filename (without extension) as the Confluence page title if no explicit page title is set in the metadata. Mutually exclusive with --title-from-h1.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_FROM_FILENAME"), altsrctoml.TOML("title-from-filename", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "title-append-generated-hash",
+			Value:   false,
+			Usage:   "appends a short hash generated from the path of the page (space, parents, and title) to the title",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_APPEND_GENERATED_HASH"), altsrctoml.TOML("title-append-generated-hash", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "minor-edit",
+			Value:   false,
+			Usage:   "don't send notifications while updating Confluence page.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MINOR_EDIT"), altsrctoml.TOML("minor-edit", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:    "version-message",
+			Value:   "",
+			Usage:   "add a message to the page version, to explain the edit (default: \"\")",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_VERSION_MESSAGE"), altsrctoml.TOML("version-message", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:  "color",
+			Value: "auto",
+			Usage: "display logs in color. Possible values: auto, never.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_COLOR"),
+				altsrctoml.TOML("color", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:    "log-level",
+			Value:   "info",
+			Usage:   "set the log level. Possible values: TRACE, DEBUG, INFO, WARNING, ERROR, FATAL.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_LOG_LEVEL"), altsrctoml.TOML("log-level", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:    "username",
+			Aliases: []string{"u"},
+			Value:   "",
+			Usage:   "use specified username for updating Confluence page.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_USERNAME"),
+				altsrctoml.TOML("username", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:    "password",
+			Aliases: []string{"p"},
+			Value:   "",
+			Usage:   "use specified token for updating Confluence page. Specify - as password to read password from stdin, or your Personal access token. Username is not mandatory if personal access token is provided. For more info please see: https://developer.atlassian.com/server/confluence/confluence-server-rest-api/#authentication.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PASSWORD"), altsrctoml.TOML("password", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:    "password-command",
+			Value:   "",
+			Usage:   "run the specified command and use the first line of its stdout as the token for updating Confluence page. Runs without a shell. A password set from the same or a stronger source (command line, then environment, then configuration file) takes precedence.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PASSWORD_COMMAND"), altsrctoml.TOML("password-command", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:    "target-url",
+			Aliases: []string{"l"},
+			Value:   "",
+			Usage:   "edit specified Confluence page. If -l is not specified, file should contain metadata (see above).",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TARGET_URL"), altsrctoml.TOML("target-url", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:    "base-url",
+			Aliases: []string{"b"},
+			Value:   "",
+			Usage:   "base URL for Confluence. Alternative option for base_url config field.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_BASE_URL"),
+				altsrctoml.TOML("base-url", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "ci",
+			Value:   false,
+			Usage:   "run on CI mode. It won't fail if files are not found.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CI"), altsrctoml.TOML("ci", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:    "space",
+			Value:   "",
+			Usage:   "use specified space key. If the space key is not specified, it must be set in the page metadata.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_SPACE"), altsrctoml.TOML("space", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:    "parents",
+			Value:   "",
+			Usage:   "A list containing the parents of the document separated by parents-delimiter (default: '/'). These will be prepended to the ones defined in the document itself.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PARENTS"), altsrctoml.TOML("parents", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:    "parents-delimiter",
+			Value:   "/",
+			Usage:   "The delimiter used for the parents list",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PARENTS_DELIMITER"), altsrctoml.TOML("parents-delimiter", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:  "content-appearance",
+			Value: "",
+			Usage: "default content appearance for pages without a Content-Appearance header. Possible values: full-width, fixed, default.",
+			Sources: cli.NewValueSourceChain(
+				cli.EnvVar("MARK_CONTENT_APPEARANCE"),
+				altsrctoml.TOML("content-appearance", altsrc.NewStringPtrSourcer(&filename)),
+			),
+		},
+		&cli.FloatFlag{
+			Name:    "mermaid-scale",
+			Value:   1.0,
+			Usage:   "defines the scaling factor for mermaid renderings.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MERMAID_SCALE"), altsrctoml.TOML("mermaid-scale", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:    "math-format",
+			Value:   "png",
+			Usage:   "image a formula is published as with --features=math: png (rasterised through the same headless Chrome mermaid uses) or svg (vector and sharp at any zoom, where the instance displays an SVG attachment).",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MATH_FORMAT"), altsrctoml.TOML("math-format", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.FloatFlag{
+			Name:    "math-scale",
+			Value:   2.0,
+			Usage:   "defines the scaling factor for PNG formula renderings; ignored when math-format is svg.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MATH_SCALE"), altsrctoml.TOML("math-scale", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:      "include-path",
+			Value:     "",
+			Usage:     "Path for shared includes, used as a fallback if the include doesn't exist in the current directory.",
+			TakesFile: true,
+			Sources:   cli.NewValueSourceChain(cli.EnvVar("MARK_INCLUDE_PATH"), altsrctoml.TOML("include-path", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "changes-only",
+			Value:   false,
+			Usage:   "Avoids re-uploading pages that haven't changed since the last run.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHANGES_ONLY"), altsrctoml.TOML("changes-only", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:  "output-format",
+			Value: "url",
+			Usage: "how to report what the run did: \"url\" prints the address of each published page (the default), \"json\" prints one object describing the whole run, \"github\" prints GitHub Actions workflow commands so that failures appear against the file that caused them.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_OUTPUT_FORMAT"),
+				altsrctoml.TOML("output-format", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:  "on-orphan",
+			Value: "report",
+			Usage: "what to do about a page whose source file is gone: \"report\" says so and does nothing (the default), \"archive\" archives the page (Confluence Cloud only), \"delete\" moves it to the trash. Requires --track-pages.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_ON_ORPHAN"),
+				altsrctoml.TOML("on-orphan", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:  "orphan-under",
+			Value: "",
+			Usage: "limit --on-orphan, and the reporting it does, to pages below this page or folder, given by title or id. Without it, every tracked page the --files pattern would have published is in scope.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_ORPHAN_UNDER"),
+				altsrctoml.TOML("orphan-under", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringSliceFlag{
+			Name:  "check-links",
+			Usage: "fail on links that do not resolve. Repeat or comma-separate any of: \"internal\" (relative links to other files in the repository), \"confluence\" (ac: links naming a page by title), \"external\" (requests each URL to see whether it answers), or \"all\".",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHECK_LINKS"),
+				altsrctoml.TOML("check-links", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:      "global-properties",
+			Value:     "",
+			Usage:     "path to a YAML or JSON file of Confluence content properties to set on every page. A Property header or properties front matter in a document wins over the file for that page.",
+			TakesFile: true,
+			Sources:   cli.NewValueSourceChain(cli.EnvVar("MARK_GLOBAL_PROPERTIES"), altsrctoml.TOML("global-properties", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "append-labels",
+			Value:   false,
+			Usage:   "add the labels a document asks for without removing any others, so that labels applied in Confluence survive a publish. Without it, a page ends up with exactly the labels its Label headers name.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_APPEND_LABELS"), altsrctoml.TOML("append-labels", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "check-links-warn-only",
+			Value:   false,
+			Usage:   "report links that do not resolve without failing the run. Only meaningful together with --check-links.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHECK_LINKS_WARN_ONLY"), altsrctoml.TOML("check-links-warn-only", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "no-overwrite",
+			Value:   false,
+			Usage:   "Leave alone any page that has been edited in Confluence since mark last published it, instead of overwriting the edit. Requires --track-pages, which is where the last published version is remembered.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_NO_OVERWRITE"), altsrctoml.TOML("no-overwrite", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "track-pages",
+			Value:   false,
+			Usage:   "Remember which page each file publishes to, so renaming a file or changing its title updates the existing page instead of creating a second one. Stores the mapping in Confluence (a space property on Cloud, a homepage content property on Server/Data Center); nothing is written to the repository.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TRACK_PAGES"), altsrctoml.TOML("track-pages", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "preserve-comments",
+			Value:   false,
+			Usage:   "Fetch and preserve inline comments on existing Confluence pages.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PRESERVE_COMMENTS"), altsrctoml.TOML("preserve-comments", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.FloatFlag{
+			Name:    "d2-scale",
+			Value:   1.0,
+			Usage:   "defines the scaling factor for d2 renderings.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_D2_SCALE"), altsrctoml.TOML("d2-scale", altsrc.NewStringPtrSourcer(&filename))),
+		},
+
+		&cli.StringSliceFlag{
+			Name:  "features",
+			Value: []string{"mermaid", "mention"},
+			Usage: "Enables optional features, replacing the defaults (" +
+				strings.Join(defaultFeatures, ", ") + ") rather than adding to them. " +
+				"Current features: " + strings.Join(KnownFeatures, ", "),
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_FEATURES"), altsrctoml.TOML("features", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.BoolFlag{
+			Name:    "insecure-skip-tls-verify",
+			Value:   false,
+			Usage:   "skip TLS certificate verification (useful for self-signed certificates)",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_INSECURE_SKIP_TLS_VERIFY"), altsrctoml.TOML("insecure-skip-tls-verify", altsrc.NewStringPtrSourcer(&filename))),
+		},
+		&cli.StringFlag{
+			Name:    "image-align",
+			Value:   "",
+			Usage:   "set image alignment (left, center, right). Can be overridden per-file via the Image-Align header.",
+			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_IMAGE_ALIGN"), altsrctoml.TOML("image-align", altsrc.NewStringPtrSourcer(&filename))),
+		},
+	}
 }
 
 // CheckFlags validates combinations and values of global flags.

--- a/util/flags.go
+++ b/util/flags.go
@@ -168,6 +168,12 @@ var Flags = []cli.Flag{
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PASSWORD"), altsrctoml.TOML("password", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.StringFlag{
+		Name:    "password-command",
+		Value:   "",
+		Usage:   "run the specified command and use its trimmed stdout as the token for updating Confluence page. Runs without a shell, and is ignored when a password is set.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PASSWORD_COMMAND"), altsrctoml.TOML("password-command", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
 		Name:    "target-url",
 		Aliases: []string{"l"},
 		Value:   "",

--- a/util/flags.go
+++ b/util/flags.go
@@ -42,319 +42,307 @@ var KnownFeatures = []string{
 // off.
 var defaultFeatures = []string{"mermaid", "mention"}
 
-// Flags is the flag set mark itself runs with.
-var Flags = NewFlags()
+var Flags = []cli.Flag{
+	// First, and it has to stay first. Every other flag finds the
+	// configuration file through the pointer below, which is filled in as the
+	// flags are resolved -- in the order they are declared. Anything declared
+	// above this looks for its TOML value while that pointer is still empty and
+	// silently gets nothing.
+	//
+	// A path on the command line happened to survive being declared late. One
+	// in MARK_CONFIG did not, so "MARK_CONFIG=/etc/mark.toml mark" ignored
+	// files, username, password, target-url, base-url and log-level while
+	// honouring space, parents and features -- reported, if at all, as
+	// "confluence password should be specified using -p flag".
+	&cli.StringFlag{
+		Name:        "config",
+		Aliases:     []string{"c"},
+		Value:       ConfigFilePath(),
+		Usage:       "use the specified configuration file.",
+		TakesFile:   true,
+		Sources:     cli.NewValueSourceChain(cli.EnvVar("MARK_CONFIG")),
+		Destination: &filename,
+	},
+	&cli.StringFlag{
+		Name:      "files",
+		Aliases:   []string{"f"},
+		Value:     "",
+		Usage:     "use specified markdown file(s) for converting to html. Supports file globbing patterns (needs to be quoted).",
+		TakesFile: true,
+		Sources:   cli.NewValueSourceChain(cli.EnvVar("MARK_FILES"), altsrctoml.TOML("files", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "continue-on-error",
+		Value:   false,
+		Usage:   "don't exit if an error occurs while processing a file, continue processing remaining files.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CONTINUE_ON_ERROR"), altsrctoml.TOML("continue-on-error", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "compile-only",
+		Value:   false,
+		Usage:   "show resulting HTML and don't update Confluence page content.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_COMPILE_ONLY"), altsrctoml.TOML("compile-only", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "dry-run",
+		Value:   false,
+		Usage:   "resolve page and ancestry, show resulting HTML and exit.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_DRY_RUN"), altsrctoml.TOML("dry-run", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "edit-lock",
+		Value:   false,
+		Aliases: []string{"k"},
+		Usage:   "lock page editing to current user only to prevent accidental manual edits over Confluence Web UI.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_EDIT_LOCK"), altsrctoml.TOML("edit-lock", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "drop-h1",
+		Value:   false,
+		Usage:   "don't include the first H1 heading in Confluence output.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_DROP_H1"), altsrctoml.TOML("drop-h1", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "strip-linebreaks",
+		Value:   false,
+		Aliases: []string{"L"},
+		Usage:   "remove linebreaks inside of tags, to accommodate non-standard Confluence behavior",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_STRIP_LINEBREAKS"), altsrctoml.TOML("strip-linebreaks", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "title-from-h1",
+		Value:   false,
+		Usage:   "extract page title from a leading H1 heading. If no H1 heading on a page exists, then title must be set in the page metadata. Mutually exclusive with --title-from-filename.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_FROM_H1"), altsrctoml.TOML("title-from-h1", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "title-from-filename",
+		Value:   false,
+		Usage:   "use the filename (without extension) as the Confluence page title if no explicit page title is set in the metadata. Mutually exclusive with --title-from-h1.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_FROM_FILENAME"), altsrctoml.TOML("title-from-filename", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "title-append-generated-hash",
+		Value:   false,
+		Usage:   "appends a short hash generated from the path of the page (space, parents, and title) to the title",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_APPEND_GENERATED_HASH"), altsrctoml.TOML("title-append-generated-hash", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "minor-edit",
+		Value:   false,
+		Usage:   "don't send notifications while updating Confluence page.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MINOR_EDIT"), altsrctoml.TOML("minor-edit", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:    "version-message",
+		Value:   "",
+		Usage:   "add a message to the page version, to explain the edit (default: \"\")",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_VERSION_MESSAGE"), altsrctoml.TOML("version-message", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:  "color",
+		Value: "auto",
+		Usage: "display logs in color. Possible values: auto, never.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_COLOR"),
+			altsrctoml.TOML("color", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:    "log-level",
+		Value:   "info",
+		Usage:   "set the log level. Possible values: TRACE, DEBUG, INFO, WARNING, ERROR, FATAL.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_LOG_LEVEL"), altsrctoml.TOML("log-level", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:    "username",
+		Aliases: []string{"u"},
+		Value:   "",
+		Usage:   "use specified username for updating Confluence page.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_USERNAME"),
+			altsrctoml.TOML("username", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:    "password",
+		Aliases: []string{"p"},
+		Value:   "",
+		Usage:   "use specified token for updating Confluence page. Specify - as password to read password from stdin, or your Personal access token. Username is not mandatory if personal access token is provided. For more info please see: https://developer.atlassian.com/server/confluence/confluence-server-rest-api/#authentication.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PASSWORD"), altsrctoml.TOML("password", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:    "password-command",
+		Value:   "",
+		Usage:   "run the specified command and use the first line of its stdout as the token for updating Confluence page. Runs without a shell. A password set on the command line, in the environment or in the configuration file takes precedence over one set further down that list.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PASSWORD_COMMAND"), altsrctoml.TOML("password-command", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:    "target-url",
+		Aliases: []string{"l"},
+		Value:   "",
+		Usage:   "edit specified Confluence page. If -l is not specified, file should contain metadata (see above).",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TARGET_URL"), altsrctoml.TOML("target-url", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:    "base-url",
+		Aliases: []string{"b"},
+		Value:   "",
+		Usage:   "base URL for Confluence. Alternative option for base_url config field.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_BASE_URL"),
+			altsrctoml.TOML("base-url", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "ci",
+		Value:   false,
+		Usage:   "run on CI mode. It won't fail if files are not found.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CI"), altsrctoml.TOML("ci", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:    "space",
+		Value:   "",
+		Usage:   "use specified space key. If the space key is not specified, it must be set in the page metadata.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_SPACE"), altsrctoml.TOML("space", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:    "parents",
+		Value:   "",
+		Usage:   "A list containing the parents of the document separated by parents-delimiter (default: '/'). These will be prepended to the ones defined in the document itself.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PARENTS"), altsrctoml.TOML("parents", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:    "parents-delimiter",
+		Value:   "/",
+		Usage:   "The delimiter used for the parents list",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PARENTS_DELIMITER"), altsrctoml.TOML("parents-delimiter", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:  "content-appearance",
+		Value: "",
+		Usage: "default content appearance for pages without a Content-Appearance header. Possible values: full-width, fixed, default.",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar("MARK_CONTENT_APPEARANCE"),
+			altsrctoml.TOML("content-appearance", altsrc.NewStringPtrSourcer(&filename)),
+		),
+	},
+	&cli.FloatFlag{
+		Name:    "mermaid-scale",
+		Value:   1.0,
+		Usage:   "defines the scaling factor for mermaid renderings.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MERMAID_SCALE"), altsrctoml.TOML("mermaid-scale", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:    "math-format",
+		Value:   "png",
+		Usage:   "image a formula is published as with --features=math: png (rasterised through the same headless Chrome mermaid uses) or svg (vector and sharp at any zoom, where the instance displays an SVG attachment).",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MATH_FORMAT"), altsrctoml.TOML("math-format", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.FloatFlag{
+		Name:    "math-scale",
+		Value:   2.0,
+		Usage:   "defines the scaling factor for PNG formula renderings; ignored when math-format is svg.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MATH_SCALE"), altsrctoml.TOML("math-scale", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:      "include-path",
+		Value:     "",
+		Usage:     "Path for shared includes, used as a fallback if the include doesn't exist in the current directory.",
+		TakesFile: true,
+		Sources:   cli.NewValueSourceChain(cli.EnvVar("MARK_INCLUDE_PATH"), altsrctoml.TOML("include-path", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "changes-only",
+		Value:   false,
+		Usage:   "Avoids re-uploading pages that haven't changed since the last run.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHANGES_ONLY"), altsrctoml.TOML("changes-only", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:  "output-format",
+		Value: "url",
+		Usage: "how to report what the run did: \"url\" prints the address of each published page (the default), \"json\" prints one object describing the whole run, \"github\" prints GitHub Actions workflow commands so that failures appear against the file that caused them.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_OUTPUT_FORMAT"),
+			altsrctoml.TOML("output-format", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:  "on-orphan",
+		Value: "report",
+		Usage: "what to do about a page whose source file is gone: \"report\" says so and does nothing (the default), \"archive\" archives the page (Confluence Cloud only), \"delete\" moves it to the trash. Requires --track-pages.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_ON_ORPHAN"),
+			altsrctoml.TOML("on-orphan", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:  "orphan-under",
+		Value: "",
+		Usage: "limit --on-orphan, and the reporting it does, to pages below this page or folder, given by title or id. Without it, every tracked page the --files pattern would have published is in scope.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_ORPHAN_UNDER"),
+			altsrctoml.TOML("orphan-under", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringSliceFlag{
+		Name:  "check-links",
+		Usage: "fail on links that do not resolve. Repeat or comma-separate any of: \"internal\" (relative links to other files in the repository), \"confluence\" (ac: links naming a page by title), \"external\" (requests each URL to see whether it answers), or \"all\".",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHECK_LINKS"),
+			altsrctoml.TOML("check-links", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:      "global-properties",
+		Value:     "",
+		Usage:     "path to a YAML or JSON file of Confluence content properties to set on every page. A Property header or properties front matter in a document wins over the file for that page.",
+		TakesFile: true,
+		Sources:   cli.NewValueSourceChain(cli.EnvVar("MARK_GLOBAL_PROPERTIES"), altsrctoml.TOML("global-properties", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "append-labels",
+		Value:   false,
+		Usage:   "add the labels a document asks for without removing any others, so that labels applied in Confluence survive a publish. Without it, a page ends up with exactly the labels its Label headers name.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_APPEND_LABELS"), altsrctoml.TOML("append-labels", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "check-links-warn-only",
+		Value:   false,
+		Usage:   "report links that do not resolve without failing the run. Only meaningful together with --check-links.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHECK_LINKS_WARN_ONLY"), altsrctoml.TOML("check-links-warn-only", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "no-overwrite",
+		Value:   false,
+		Usage:   "Leave alone any page that has been edited in Confluence since mark last published it, instead of overwriting the edit. Requires --track-pages, which is where the last published version is remembered.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_NO_OVERWRITE"), altsrctoml.TOML("no-overwrite", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "track-pages",
+		Value:   false,
+		Usage:   "Remember which page each file publishes to, so renaming a file or changing its title updates the existing page instead of creating a second one. Stores the mapping in Confluence (a space property on Cloud, a homepage content property on Server/Data Center); nothing is written to the repository.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TRACK_PAGES"), altsrctoml.TOML("track-pages", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "preserve-comments",
+		Value:   false,
+		Usage:   "Fetch and preserve inline comments on existing Confluence pages.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PRESERVE_COMMENTS"), altsrctoml.TOML("preserve-comments", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.FloatFlag{
+		Name:    "d2-scale",
+		Value:   1.0,
+		Usage:   "defines the scaling factor for d2 renderings.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_D2_SCALE"), altsrctoml.TOML("d2-scale", altsrc.NewStringPtrSourcer(&filename))),
+	},
 
-// NewFlags returns a fresh copy of mark's flags.
-//
-// urfave records on the flag itself that a value has been set, and never clears
-// it: a flag set run a second time keeps the first run's values and skips its
-// own sources. Running mark happens once per process, so the set below could be
-// a plain variable -- but a test binary runs it many times over, and each of
-// those runs needs a set that has not been parsed before.
-func NewFlags() []cli.Flag {
-	return []cli.Flag{
-		// First, and it has to stay first. Every other flag finds the
-		// configuration file through the pointer below, which is filled in as the
-		// flags are resolved -- in the order they are declared. Anything declared
-		// above this looks for its TOML value while that pointer is still empty and
-		// silently gets nothing.
-		//
-		// A path on the command line happened to survive being declared late. One
-		// in MARK_CONFIG did not, so "MARK_CONFIG=/etc/mark.toml mark" ignored
-		// files, username, password, target-url, base-url and log-level while
-		// honouring space, parents and features -- reported, if at all, as
-		// "confluence password should be specified using -p flag".
-		&cli.StringFlag{
-			Name:        "config",
-			Aliases:     []string{"c"},
-			Value:       ConfigFilePath(),
-			Usage:       "use the specified configuration file.",
-			TakesFile:   true,
-			Sources:     cli.NewValueSourceChain(cli.EnvVar("MARK_CONFIG")),
-			Destination: &filename,
-		},
-		&cli.StringFlag{
-			Name:      "files",
-			Aliases:   []string{"f"},
-			Value:     "",
-			Usage:     "use specified markdown file(s) for converting to html. Supports file globbing patterns (needs to be quoted).",
-			TakesFile: true,
-			Sources:   cli.NewValueSourceChain(cli.EnvVar("MARK_FILES"), altsrctoml.TOML("files", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "continue-on-error",
-			Value:   false,
-			Usage:   "don't exit if an error occurs while processing a file, continue processing remaining files.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CONTINUE_ON_ERROR"), altsrctoml.TOML("continue-on-error", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "compile-only",
-			Value:   false,
-			Usage:   "show resulting HTML and don't update Confluence page content.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_COMPILE_ONLY"), altsrctoml.TOML("compile-only", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "dry-run",
-			Value:   false,
-			Usage:   "resolve page and ancestry, show resulting HTML and exit.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_DRY_RUN"), altsrctoml.TOML("dry-run", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "edit-lock",
-			Value:   false,
-			Aliases: []string{"k"},
-			Usage:   "lock page editing to current user only to prevent accidental manual edits over Confluence Web UI.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_EDIT_LOCK"), altsrctoml.TOML("edit-lock", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "drop-h1",
-			Value:   false,
-			Usage:   "don't include the first H1 heading in Confluence output.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_DROP_H1"), altsrctoml.TOML("drop-h1", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "strip-linebreaks",
-			Value:   false,
-			Aliases: []string{"L"},
-			Usage:   "remove linebreaks inside of tags, to accommodate non-standard Confluence behavior",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_STRIP_LINEBREAKS"), altsrctoml.TOML("strip-linebreaks", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "title-from-h1",
-			Value:   false,
-			Usage:   "extract page title from a leading H1 heading. If no H1 heading on a page exists, then title must be set in the page metadata. Mutually exclusive with --title-from-filename.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_FROM_H1"), altsrctoml.TOML("title-from-h1", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "title-from-filename",
-			Value:   false,
-			Usage:   "use the filename (without extension) as the Confluence page title if no explicit page title is set in the metadata. Mutually exclusive with --title-from-h1.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_FROM_FILENAME"), altsrctoml.TOML("title-from-filename", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "title-append-generated-hash",
-			Value:   false,
-			Usage:   "appends a short hash generated from the path of the page (space, parents, and title) to the title",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TITLE_APPEND_GENERATED_HASH"), altsrctoml.TOML("title-append-generated-hash", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "minor-edit",
-			Value:   false,
-			Usage:   "don't send notifications while updating Confluence page.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MINOR_EDIT"), altsrctoml.TOML("minor-edit", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:    "version-message",
-			Value:   "",
-			Usage:   "add a message to the page version, to explain the edit (default: \"\")",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_VERSION_MESSAGE"), altsrctoml.TOML("version-message", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:  "color",
-			Value: "auto",
-			Usage: "display logs in color. Possible values: auto, never.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_COLOR"),
-				altsrctoml.TOML("color", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:    "log-level",
-			Value:   "info",
-			Usage:   "set the log level. Possible values: TRACE, DEBUG, INFO, WARNING, ERROR, FATAL.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_LOG_LEVEL"), altsrctoml.TOML("log-level", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:    "username",
-			Aliases: []string{"u"},
-			Value:   "",
-			Usage:   "use specified username for updating Confluence page.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_USERNAME"),
-				altsrctoml.TOML("username", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:    "password",
-			Aliases: []string{"p"},
-			Value:   "",
-			Usage:   "use specified token for updating Confluence page. Specify - as password to read password from stdin, or your Personal access token. Username is not mandatory if personal access token is provided. For more info please see: https://developer.atlassian.com/server/confluence/confluence-server-rest-api/#authentication.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PASSWORD"), altsrctoml.TOML("password", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:    "password-command",
-			Value:   "",
-			Usage:   "run the specified command and use the first line of its stdout as the token for updating Confluence page. Runs without a shell. A password set from the same or a stronger source (command line, then environment, then configuration file) takes precedence.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PASSWORD_COMMAND"), altsrctoml.TOML("password-command", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:    "target-url",
-			Aliases: []string{"l"},
-			Value:   "",
-			Usage:   "edit specified Confluence page. If -l is not specified, file should contain metadata (see above).",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TARGET_URL"), altsrctoml.TOML("target-url", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:    "base-url",
-			Aliases: []string{"b"},
-			Value:   "",
-			Usage:   "base URL for Confluence. Alternative option for base_url config field.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_BASE_URL"),
-				altsrctoml.TOML("base-url", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "ci",
-			Value:   false,
-			Usage:   "run on CI mode. It won't fail if files are not found.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CI"), altsrctoml.TOML("ci", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:    "space",
-			Value:   "",
-			Usage:   "use specified space key. If the space key is not specified, it must be set in the page metadata.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_SPACE"), altsrctoml.TOML("space", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:    "parents",
-			Value:   "",
-			Usage:   "A list containing the parents of the document separated by parents-delimiter (default: '/'). These will be prepended to the ones defined in the document itself.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PARENTS"), altsrctoml.TOML("parents", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:    "parents-delimiter",
-			Value:   "/",
-			Usage:   "The delimiter used for the parents list",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PARENTS_DELIMITER"), altsrctoml.TOML("parents-delimiter", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:  "content-appearance",
-			Value: "",
-			Usage: "default content appearance for pages without a Content-Appearance header. Possible values: full-width, fixed, default.",
-			Sources: cli.NewValueSourceChain(
-				cli.EnvVar("MARK_CONTENT_APPEARANCE"),
-				altsrctoml.TOML("content-appearance", altsrc.NewStringPtrSourcer(&filename)),
-			),
-		},
-		&cli.FloatFlag{
-			Name:    "mermaid-scale",
-			Value:   1.0,
-			Usage:   "defines the scaling factor for mermaid renderings.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MERMAID_SCALE"), altsrctoml.TOML("mermaid-scale", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:    "math-format",
-			Value:   "png",
-			Usage:   "image a formula is published as with --features=math: png (rasterised through the same headless Chrome mermaid uses) or svg (vector and sharp at any zoom, where the instance displays an SVG attachment).",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MATH_FORMAT"), altsrctoml.TOML("math-format", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.FloatFlag{
-			Name:    "math-scale",
-			Value:   2.0,
-			Usage:   "defines the scaling factor for PNG formula renderings; ignored when math-format is svg.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MATH_SCALE"), altsrctoml.TOML("math-scale", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:      "include-path",
-			Value:     "",
-			Usage:     "Path for shared includes, used as a fallback if the include doesn't exist in the current directory.",
-			TakesFile: true,
-			Sources:   cli.NewValueSourceChain(cli.EnvVar("MARK_INCLUDE_PATH"), altsrctoml.TOML("include-path", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "changes-only",
-			Value:   false,
-			Usage:   "Avoids re-uploading pages that haven't changed since the last run.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHANGES_ONLY"), altsrctoml.TOML("changes-only", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:  "output-format",
-			Value: "url",
-			Usage: "how to report what the run did: \"url\" prints the address of each published page (the default), \"json\" prints one object describing the whole run, \"github\" prints GitHub Actions workflow commands so that failures appear against the file that caused them.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_OUTPUT_FORMAT"),
-				altsrctoml.TOML("output-format", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:  "on-orphan",
-			Value: "report",
-			Usage: "what to do about a page whose source file is gone: \"report\" says so and does nothing (the default), \"archive\" archives the page (Confluence Cloud only), \"delete\" moves it to the trash. Requires --track-pages.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_ON_ORPHAN"),
-				altsrctoml.TOML("on-orphan", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:  "orphan-under",
-			Value: "",
-			Usage: "limit --on-orphan, and the reporting it does, to pages below this page or folder, given by title or id. Without it, every tracked page the --files pattern would have published is in scope.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_ORPHAN_UNDER"),
-				altsrctoml.TOML("orphan-under", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringSliceFlag{
-			Name:  "check-links",
-			Usage: "fail on links that do not resolve. Repeat or comma-separate any of: \"internal\" (relative links to other files in the repository), \"confluence\" (ac: links naming a page by title), \"external\" (requests each URL to see whether it answers), or \"all\".",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHECK_LINKS"),
-				altsrctoml.TOML("check-links", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:      "global-properties",
-			Value:     "",
-			Usage:     "path to a YAML or JSON file of Confluence content properties to set on every page. A Property header or properties front matter in a document wins over the file for that page.",
-			TakesFile: true,
-			Sources:   cli.NewValueSourceChain(cli.EnvVar("MARK_GLOBAL_PROPERTIES"), altsrctoml.TOML("global-properties", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "append-labels",
-			Value:   false,
-			Usage:   "add the labels a document asks for without removing any others, so that labels applied in Confluence survive a publish. Without it, a page ends up with exactly the labels its Label headers name.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_APPEND_LABELS"), altsrctoml.TOML("append-labels", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "check-links-warn-only",
-			Value:   false,
-			Usage:   "report links that do not resolve without failing the run. Only meaningful together with --check-links.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_CHECK_LINKS_WARN_ONLY"), altsrctoml.TOML("check-links-warn-only", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "no-overwrite",
-			Value:   false,
-			Usage:   "Leave alone any page that has been edited in Confluence since mark last published it, instead of overwriting the edit. Requires --track-pages, which is where the last published version is remembered.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_NO_OVERWRITE"), altsrctoml.TOML("no-overwrite", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "track-pages",
-			Value:   false,
-			Usage:   "Remember which page each file publishes to, so renaming a file or changing its title updates the existing page instead of creating a second one. Stores the mapping in Confluence (a space property on Cloud, a homepage content property on Server/Data Center); nothing is written to the repository.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_TRACK_PAGES"), altsrctoml.TOML("track-pages", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "preserve-comments",
-			Value:   false,
-			Usage:   "Fetch and preserve inline comments on existing Confluence pages.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PRESERVE_COMMENTS"), altsrctoml.TOML("preserve-comments", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.FloatFlag{
-			Name:    "d2-scale",
-			Value:   1.0,
-			Usage:   "defines the scaling factor for d2 renderings.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_D2_SCALE"), altsrctoml.TOML("d2-scale", altsrc.NewStringPtrSourcer(&filename))),
-		},
-
-		&cli.StringSliceFlag{
-			Name:  "features",
-			Value: []string{"mermaid", "mention"},
-			Usage: "Enables optional features, replacing the defaults (" +
-				strings.Join(defaultFeatures, ", ") + ") rather than adding to them. " +
-				"Current features: " + strings.Join(KnownFeatures, ", "),
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_FEATURES"), altsrctoml.TOML("features", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.BoolFlag{
-			Name:    "insecure-skip-tls-verify",
-			Value:   false,
-			Usage:   "skip TLS certificate verification (useful for self-signed certificates)",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_INSECURE_SKIP_TLS_VERIFY"), altsrctoml.TOML("insecure-skip-tls-verify", altsrc.NewStringPtrSourcer(&filename))),
-		},
-		&cli.StringFlag{
-			Name:    "image-align",
-			Value:   "",
-			Usage:   "set image alignment (left, center, right). Can be overridden per-file via the Image-Align header.",
-			Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_IMAGE_ALIGN"), altsrctoml.TOML("image-align", altsrc.NewStringPtrSourcer(&filename))),
-		},
-	}
+	&cli.StringSliceFlag{
+		Name:  "features",
+		Value: []string{"mermaid", "mention"},
+		Usage: "Enables optional features, replacing the defaults (" +
+			strings.Join(defaultFeatures, ", ") + ") rather than adding to them. " +
+			"Current features: " + strings.Join(KnownFeatures, ", "),
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_FEATURES"), altsrctoml.TOML("features", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.BoolFlag{
+		Name:    "insecure-skip-tls-verify",
+		Value:   false,
+		Usage:   "skip TLS certificate verification (useful for self-signed certificates)",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_INSECURE_SKIP_TLS_VERIFY"), altsrctoml.TOML("insecure-skip-tls-verify", altsrc.NewStringPtrSourcer(&filename))),
+	},
+	&cli.StringFlag{
+		Name:    "image-align",
+		Value:   "",
+		Usage:   "set image alignment (left, center, right). Can be overridden per-file via the Image-Align header.",
+		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_IMAGE_ALIGN"), altsrctoml.TOML("image-align", altsrc.NewStringPtrSourcer(&filename))),
+	},
 }
 
 // CheckFlags validates combinations and values of global flags.

--- a/util/flags.go
+++ b/util/flags.go
@@ -170,7 +170,7 @@ var Flags = []cli.Flag{
 	&cli.StringFlag{
 		Name:    "password-command",
 		Value:   "",
-		Usage:   "run the specified command and use the first line of its stdout as the token for updating Confluence page. Runs without a shell. A password set on the command line, in the environment or in the configuration file takes precedence over one set further down that list.",
+		Usage:   "run the specified command and use the first line of its stdout as the token for updating Confluence page. Runs without a shell. Mutually exclusive with password.",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_PASSWORD_COMMAND"), altsrctoml.TOML("password-command", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.StringFlag{


### PR DESCRIPTION
Closes #912.

`$MARK_PASSWORD` keeps the token out of the configuration file but puts it in the environment of every process in the shell session, and the configuration file keeps it in plaintext at rest. `--password -` avoids both, but the caller supplies the pipe, so knowledge of how to fetch the token lives at every call site rather than in one place.

`password-command` names a command instead, declared with the same sources as every other flag so it reads from the CLI, the environment or the TOML:

```toml
password-command = "pass show confluence/api-token"
```

Mark runs it and takes its trimmed stdout as the password.

## Design Notes

### When the Command Runs

**Resolution runs ahead of the existing empty-password guard**, otherwise setting only the command errors out before the command ever runs.

**The command runs on a compile too.** A compile-only run looks like one that never authenticates and is not: a relative link to another document is resolved by looking that page up, so compiling one file that links to another makes authenticated requests before it prints anything. `--check-links confluence` is the same shape. A compile with no command configured still needs no password, and one whose command fails now fails the run rather than falling back.

**A password set by any source wins**, because a flag on the command line has to be able to override a token already in the configuration file. That would otherwise be silent, so setting both logs a warning naming which one was used.

### What the Command May Be

**No shell, and no stdin.** The string is split on whitespace and nothing is expanded, so there is no quoting and no path containing a space; wrap such a helper in a script and name the script. A helper that prompts on stdin cannot be used, while one that opens the terminal itself, as `pinentry` does, is fine. Both constraints are in the README beside the example.

### What Its Output Means

**Whatever the command prints is the token, including a bare `-`.** A command's output does not reach the `-p -` stdin branch, which would otherwise block on stdin rather than use the value.

**The command's own outcome is read before the context.** `Output()` returns once the stdout pipe closes, which can be after the deadline even for a helper that printed its token and exited cleanly, so consulting the context first discarded a token that had everything the run needed.

### How Long It May Take

**`exec.CommandContext` bounds the command at 30 seconds, and `cmd.WaitDelay` bounds the pipe.** Cancelling kills the helper and nothing else: `Wait` goes on reading stdout for as long as anything that inherited the pipe still holds it, which for a helper that starts an agent on demand is long after the helper is gone. Without the delay the deadline bounds the process rather than the call.

### What Reaches the Log

**The debug configuration dump masks `password-command` alongside `password`.** A command can name a token inline, so printing it in full would put a credential in the log.

---

The compile-only behaviour, the ordering of the command's own error against the context, and `cmd.WaitDelay` come from @mrueg's fixup commit on this branch.

This is mark's first subprocess: `os/exec` did not previously appear anywhere in the tree. The `exec.CommandContext` call carries a `//nolint:gosec` for G204 with a reason, following the two existing suppressions.

## Tests

`util/auth_test.go` covers:

- resolution on a compile, a compile with no command needing no password, and a compile with a failing one
- a password from another source winning, and the warning that says so
- a command with no words
- trimming the helper's newline, and whitespace around what it prints
- output that is empty once trimmed
- a bare dash, which is the token and not the stdin marker
- a non-zero exit, and a command that cannot be executed
- the timeout, and a helper that leaves a process holding the pipe
- the masking in the debug configuration dump

The existing `TestGetCredentials*` tests are updated for the new signature and otherwise unchanged.

`TestMain` doubles as the password command, so the tests re-execute the test binary rather than depending on `echo` or `sleep` being on `PATH`. They skip if that path contains whitespace, which a `password-command` cannot express.

Co-authored-by: Claude <noreply@anthropic.com>
