### PR TITLE
feat(renderer): render footnotes as anchors Confluence can follow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,16 +68,19 @@ table cells. `macro.ExtractMacros` and `includes.ProcessIncludes` run on the raw
 `CompileMarkdown` before the converter is built. Do not move this work into an AST
 transformer without understanding why it was moved out of one.
 
-**4. goldmark priorities run in opposite directions for parsers and renderers.**
+**4. A smaller goldmark priority number wins, for parsers and renderers alike.**
 
-- *Node renderers*: registered in ascending priority order, so a **larger** number is
-  registered later and **overrides** an earlier registration for the same node kind. The
-  GH-alerts blockquote/text renderers use `200` specifically to beat the `100` defaults.
 - *Inline/block parsers*: a **smaller** number is tried **first**. `ConfluenceTagParser`
   uses `199` to run before goldmark's own link parser at `200`, so that `<ac:*/>` tags are
   not parsed as links.
+- *Node renderers*: goldmark sorts them ascending and then calls `RegisterFuncs` from the
+  **end backwards** (`renderer/renderer.go`), and each registration overwrites the last
+  for a given node kind -- so the **smaller** number is the one that renders. The
+  footnote renderers use `100` to beat goldmark's own footnote extension at `500`.
+  The GH-alerts blockquote/text renderers' `200` is not doing this job: the main
+  extension registers no competing blockquote or text renderer, so they are unopposed.
 
-Getting this backwards silently produces the default rendering.
+Getting this backwards silently produces the default rendering, with no error anywhere.
 
 **5. AST transformers cannot return errors.** goldmark's `ASTTransformer` interface has no
 error return, so `transformer.PipelineTransformer` accumulates errors internally and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,10 +75,12 @@ transformer without understanding why it was moved out of one.
   not parsed as links.
 - *Node renderers*: goldmark sorts them ascending and then calls `RegisterFuncs` from the
   **end backwards** (`renderer/renderer.go`), and each registration overwrites the last
-  for a given node kind -- so the **smaller** number is the one that renders. The
-  footnote renderers use `100` to beat goldmark's own footnote extension at `500`.
-  The GH-alerts blockquote/text renderers' `200` is not doing this job: the main
-  extension registers no competing blockquote or text renderer, so they are unopposed.
+  for a given node kind -- so the **smaller** number is the one that renders. Every
+  renderer in this repo is competing with one of goldmark's: the default `html.Renderer`
+  goes in at `1000` (`markdown.go`) and claims every core kind, so anything meant to
+  replace it has to sit below that. Both numbers you will see are load-bearing --- the
+  GH-alerts blockquote/text renderers' `200` clears the default renderer, and the
+  footnote renderers' `100` has to clear the footnote extension's `500` as well.
 
 Getting this backwards silently produces the default rendering, with no error anywhere.
 

--- a/README.md
+++ b/README.md
@@ -1278,6 +1278,63 @@ display text and render as regular hyperlinks, unchanged.
 
 *Note: Inline Smart Cards (`data-card-appearance="inline"`) are a **Confluence Cloud** feature. On Confluence Data Center / Server, the attribute is safely ignored and the link displays as a standard hyperlink.*
 
+### Footnotes
+
+Optionally you can render Markdown footnotes as footnotes Confluence can
+actually navigate, via `--features="footnotes"`.
+
+```markdown
+The estimate is optimistic[^basis], and the deadline is not[^deadline].
+
+[^basis]: Measured on the staging cluster, which has half the nodes.
+[^deadline]: Set before the scope changed.
+```
+
+Each marker becomes a superscript `[1]` linking down to the note, and each note
+ends with a `↩` linking back to the sentence that cited it. Notes are collected
+into a numbered list under a horizontal rule at the foot of the page, in the
+order they were first cited -- so the definitions can be written in whatever
+order suits the source file, and a definition nothing cites is left out rather
+than numbered.
+
+Citing the same note twice gives it one entry with a numbered arrow per
+citation, so both ways back are distinguishable.
+
+#### Why the feature exists
+
+Markdown footnote syntax is parsed whether or not the feature is on -- that part
+has always worked. What did not work is the navigation. Goldmark, like every
+other Markdown renderer, wires the two ends together with `id` attributes and
+`href="#id"` links, and Confluence keeps neither: it discards the ids in the
+storage format and generates its own from element text. The result renders,
+looks right, and does nothing when clicked.
+
+This feature replaces that plumbing with the two things Confluence does
+understand:
+
+* the **Anchor macro** for the jump targets, which is bundled with both Cloud
+  and Data Center and so needs no marketplace plugin, and
+* `<ac:link ac:anchor="...">` for the jumps, with no `ri:page` -- an anchor link
+  within the current page, which scrolls rather than reloads.
+
+```html
+<!-- at the marker -->
+<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">footnote-ref-1</ac:parameter></ac:structured-macro>
+<ac:link ac:anchor="footnote-1"><ac:link-body><sup>[1]</sup></ac:link-body></ac:link>
+
+<!-- at the note -->
+<li><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">footnote-1</ac:parameter></ac:structured-macro>
+<p>Measured on the staging cluster, which has half the nodes.&#160;<ac:link ac:anchor="footnote-ref-1"><ac:link-body>&#x21a9;&#xfe0e;</ac:link-body></ac:link></p>
+</li>
+```
+
+Anchor names are `footnote-<n>` and `footnote-ref-<n>`, which share a namespace
+with the page's heading anchors -- avoid headings that would generate the same
+names.
+
+Leaving the feature off keeps the previous output: plain HTML footnotes, which
+still read correctly top to bottom but whose links go nowhere.
+
 **Note**: `mark` will read configuration from your environment variables or the configuration file.
 
 ## Installation
@@ -1370,7 +1427,7 @@ GLOBAL OPTIONS:
    --track-pages                            Remember which page each file publishes to, so renaming a file or changing its title updates the existing page instead of creating a second one. Stores the mapping in Confluence (a space property on Cloud, a homepage content property on Server/Data Center); nothing is written to the repository. [$MARK_TRACK_PAGES]
    --preserve-comments                      Fetch and preserve inline comments on existing Confluence pages. [$MARK_PRESERVE_COMMENTS]
    --d2-scale float                         defines the scaling factor for d2 renderings. (default: 1) [$MARK_D2_SCALE]
-   --features string [ --features string ]  Enables optional features. Current features: d2, date, details, frontmatter, html-img-tag, inline-link-card, math, mention, mermaid, mkdocsadmonitions, plantuml (default: "mermaid", "mention") [$MARK_FEATURES]
+   --features string [ --features string ]  Enables optional features. Current features: d2, date, details, footnotes, frontmatter, html-img-tag, inline-link-card, math, mention, mermaid, mkdocsadmonitions, plantuml (default: "mermaid", "mention") [$MARK_FEATURES]
    --insecure-skip-tls-verify               skip TLS certificate verification (useful for self-signed certificates) [$MARK_INSECURE_SKIP_TLS_VERIFY]
    --image-align string                     set image alignment (left, center, right). Can be overridden per-file via the Image-Align header. [$MARK_IMAGE_ALIGN]
    --help, -h                               show help

--- a/markdown/footnote_test.go
+++ b/markdown/footnote_test.go
@@ -1,0 +1,142 @@
+package mark_test
+
+import (
+	"encoding/xml"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	mark "github.com/kovetskiy/mark/v16/markdown"
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func compileFootnotes(t *testing.T, markdown string, features ...string) string {
+	t.Helper()
+
+	lib, err := stdlib.New(nil)
+	assert.NoError(t, err)
+
+	actual, _, err := mark.CompileMarkdown([]byte(markdown), lib, "testdata/test.md", types.MarkConfig{
+		Features: features,
+	})
+	assert.NoError(t, err)
+
+	return actual
+}
+
+// assertWellFormed parses the body the way Confluence does. Confluence answers
+// a body that is not well-formed with BadRequestException and rejects the whole
+// page, so a stray tag here would not show up as one broken footnote but as a
+// document that never uploads.
+func assertWellFormed(t *testing.T, body string) {
+	t.Helper()
+
+	decoder := xml.NewDecoder(strings.NewReader(`<root xmlns:ac="ac" xmlns:ri="ri">` + body + `</root>`))
+	decoder.Strict = true
+	decoder.Entity = xml.HTMLEntity
+
+	for {
+		_, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return
+		}
+		if !assert.NoError(t, err, "storage format must be well-formed XML") {
+			return
+		}
+	}
+}
+
+func TestFootnotesFeature(t *testing.T) {
+	markdown := "A claim[^src].\n\n[^src]: Where it came from.\n"
+
+	enabled := compileFootnotes(t, markdown, "footnotes")
+	assertWellFormed(t, enabled)
+
+	// The marker links down to the note, and the note carries the anchor that
+	// link names. Both halves have to be present for the jump to land: an
+	// ac:link naming an anchor no macro declares is silently inert.
+	assert.Contains(t, enabled, `<ac:link ac:anchor="footnote-1"><ac:link-body><sup>[1]</sup></ac:link-body></ac:link>`)
+	assert.Contains(t, enabled, `<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">footnote-1</ac:parameter></ac:structured-macro>`)
+
+	// And the same in the other direction, so a reader can get back to the
+	// sentence that sent them down.
+	assert.Contains(t, enabled, `<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">footnote-ref-1</ac:parameter></ac:structured-macro>`)
+	assert.Contains(t, enabled, `<ac:link ac:anchor="footnote-ref-1">`)
+
+	// Nothing that depends on an id survives the trip through Confluence, so
+	// none of it may be relied on.
+	assert.NotContains(t, enabled, `id="fn:1"`)
+	assert.NotContains(t, enabled, `href="#fn:1"`)
+
+	disabled := compileFootnotes(t, markdown, "mermaid", "mention")
+	assert.Contains(t, disabled, `id="fn:1"`, "without the feature goldmark's own HTML is left alone")
+	assert.NotContains(t, disabled, `ac:name="anchor"`)
+}
+
+// TestFootnotesRepeatedCitation covers a note cited more than once: the ways
+// back have to be told apart, which means one anchor per citation rather than
+// one per note.
+func TestFootnotesRepeatedCitation(t *testing.T) {
+	actual := compileFootnotes(t, "First[^a]. Second[^a].\n\n[^a]: Once.\n", "footnotes")
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `<ac:parameter ac:name="">footnote-ref-1</ac:parameter>`)
+	assert.Contains(t, actual, `<ac:parameter ac:name="">footnote-ref-1-1</ac:parameter>`)
+
+	// Numbered arrows, so the two ways back are distinguishable.
+	assert.Contains(t, actual, `<ac:link ac:anchor="footnote-ref-1"><ac:link-body>&#x21a9;&#xfe0e;<sup>1</sup></ac:link-body></ac:link>`)
+	assert.Contains(t, actual, `<ac:link ac:anchor="footnote-ref-1-1"><ac:link-body>&#x21a9;&#xfe0e;<sup>2</sup></ac:link-body></ac:link>`)
+
+	// One note, cited twice, is still one entry in the list.
+	assert.Equal(t, 1, strings.Count(actual, "<li>"))
+
+	// A note cited once gets a bare arrow, with nothing to disambiguate.
+	single := compileFootnotes(t, "Only[^a].\n\n[^a]: Once.\n", "footnotes")
+	assert.Contains(t, single, `<ac:link-body>&#x21a9;&#xfe0e;</ac:link-body>`)
+}
+
+// TestFootnotesNumberingFollowsCitationOrder pins the property the <ol> relies
+// on. The list takes no numbers of its own -- it lets Confluence number the
+// items -- which is only correct because goldmark orders the notes by the index
+// it gave each marker, not by where the definitions were written.
+func TestFootnotesNumberingFollowsCitationOrder(t *testing.T) {
+	actual := compileFootnotes(t, "Second[^b] then first[^a].\n\n[^a]: A.\n[^b]: B.\n", "footnotes")
+	assertWellFormed(t, actual)
+
+	assert.Less(t,
+		strings.Index(actual, `<ac:parameter ac:name="">footnote-1</ac:parameter>`),
+		strings.Index(actual, `<ac:parameter ac:name="">footnote-2</ac:parameter>`),
+		"notes must be listed in the order their markers are numbered")
+
+	assert.Less(t,
+		strings.Index(actual, "B."),
+		strings.Index(actual, "A."),
+		"the note cited first is note 1, whichever was defined first")
+}
+
+// TestFootnotesUncitedDefinitionDropped records that a definition nothing
+// points at is left out rather than given a number, which is what keeps the
+// <ol> counting in step with the markers.
+func TestFootnotesUncitedDefinitionDropped(t *testing.T) {
+	actual := compileFootnotes(t, "Cited[^a].\n\n[^a]: Used.\n[^b]: Never used.\n", "footnotes")
+	assertWellFormed(t, actual)
+
+	assert.NotContains(t, actual, "Never used.")
+	assert.Equal(t, 1, strings.Count(actual, "<li>"))
+}
+
+// TestFootnotesEscaping covers a note whose text would break the body if it
+// reached the storage format as written. Nothing out of the document is
+// interpolated into the footnote markup itself -- the anchor names and the
+// marker are generated from an integer -- so what this really pins is that the
+// note's own text still goes through the ordinary renderers.
+func TestFootnotesEscaping(t *testing.T) {
+	actual := compileFootnotes(t, "Claim[^a].\n\n[^a]: A & B, \"quoted\" and 3 < 4.\n", "footnotes")
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "A &amp; B")
+	assert.Contains(t, actual, "3 &lt; 4")
+}

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -73,6 +73,16 @@ func (c *ConfluenceLegacyExtension) Extend(m goldmark.Markdown) {
 		))
 	}
 
+	if slices.Contains(c.MarkConfig.Features, "footnotes") {
+		m.Renderer().AddOptions(renderer.WithNodeRenderers(
+			// Below the 500 goldmark's own footnote extension registers at.
+			// Node renderers are registered from the highest priority number
+			// down, and each registration overwrites the last, so the *smaller*
+			// number is the one that ends up rendering the node.
+			util.Prioritized(crenderer.NewConfluenceFootnoteRenderer(c.Stdlib), 100),
+		))
+	}
+
 	if slices.Contains(c.MarkConfig.Features, "mkdocsadmonitions") {
 		m.Parser().AddOptions(
 			parser.WithBlockParsers(
@@ -373,6 +383,17 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 	if slices.Contains(c.MarkConfig.Features, "details") {
 		m.Parser().AddOptions(parser.WithASTTransformers(
 			util.Prioritized(ctransformer.NewDetailsTransformer(), 110),
+		))
+	}
+
+	// Add Confluence-native footnote rendering if requested
+	if slices.Contains(c.MarkConfig.Features, "footnotes") {
+		m.Renderer().AddOptions(renderer.WithNodeRenderers(
+			// Below the 500 goldmark's own footnote extension registers at.
+			// Node renderers are registered from the highest priority number
+			// down, and each registration overwrites the last, so the *smaller*
+			// number is the one that ends up rendering the node.
+			util.Prioritized(crenderer.NewConfluenceFootnoteRenderer(c.Stdlib), 100),
 		))
 	}
 

--- a/markdown/markdown_test.go
+++ b/markdown/markdown_test.go
@@ -252,6 +252,40 @@ func TestCompileMarkdownInlineLinkCard(t *testing.T) {
 	test.EqualValues(strings.TrimSuffix(string(html), "\n"), strings.TrimSuffix(actual, "\n"), fixture+" vs "+htmlname)
 }
 
+// TestCompileMarkdownFootnotes covers the footnotes feature. testdata/footnotes.md
+// is also picked up by the feature-off tests above, which pin goldmark's own
+// HTML footnotes -- the ids and #fragment links Confluence discards -- so the
+// pair of fixtures records exactly what the feature changes.
+func TestCompileMarkdownFootnotes(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	dir := path.Join(path.Dir(filename), "..")
+	err := os.Chdir(dir)
+	if err != nil {
+		panic(err)
+	}
+
+	test := assert.New(t)
+
+	lib, err := stdlib.New(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	const fixture = "testdata/footnotes.md"
+	markdown, htmlname, html := loadData(t, fixture, "-confluence")
+
+	cfg := types.MarkConfig{
+		MermaidScale:  1.0,
+		D2Scale:       1.0,
+		DropFirstH1:   false,
+		StripNewlines: false,
+		Features:      []string{"mkdocsadmonitions", "mention", "footnotes"},
+	}
+
+	actual, _, _ := mark.CompileMarkdown(markdown, lib, fixture, cfg)
+	test.EqualValues(strings.TrimSuffix(string(html), "\n"), strings.TrimSuffix(actual, "\n"), fixture+" vs "+htmlname)
+}
+
 // TestCompileMarkdownMath covers the math feature, which renders LaTeX to
 // KaTeX markup at compile time. testdata/math.md is also picked up by the
 // feature-off tests above, which assert the formulas pass through as plain

--- a/renderer/footnote.go
+++ b/renderer/footnote.go
@@ -1,0 +1,171 @@
+package renderer
+
+import (
+	"strconv"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/yuin/goldmark/ast"
+	ext_ast "github.com/yuin/goldmark/extension/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+// ConfluenceFootnoteRenderer renders Markdown footnotes as something Confluence
+// can actually navigate.
+//
+// Goldmark's own footnote output is ordinary HTML: an id on the marker, an id
+// on the note, and href="#id" between them. Confluence keeps none of that. It
+// strips the ids out of the storage format and derives its own from element
+// text, so both ends of every jump land nowhere -- the page renders, the
+// superscript is clickable, and clicking it does nothing.
+//
+// The replacement is built from the anchor macro, which is bundled with both
+// Data Center and Cloud and so needs nothing installed, plus an ac:link naming
+// that anchor. Anchors are placed at both ends, which is what makes the way
+// back from a note to the sentence that cited it work as well as the way down.
+type ConfluenceFootnoteRenderer struct {
+	Stdlib *stdlib.Lib
+}
+
+// NewConfluenceFootnoteRenderer creates a new instance of the ConfluenceFootnoteRenderer.
+func NewConfluenceFootnoteRenderer(stdlib *stdlib.Lib) renderer.NodeRenderer {
+	return &ConfluenceFootnoteRenderer{
+		Stdlib: stdlib,
+	}
+}
+
+// RegisterFuncs implements NodeRenderer.RegisterFuncs .
+func (r *ConfluenceFootnoteRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(ext_ast.KindFootnoteLink, r.renderFootnoteLink)
+	reg.Register(ext_ast.KindFootnoteBacklink, r.renderFootnoteBacklink)
+	reg.Register(ext_ast.KindFootnote, r.renderFootnote)
+	reg.Register(ext_ast.KindFootnoteList, r.renderFootnoteList)
+}
+
+// footnoteAnchor names the anchor sitting with the note itself.
+//
+// Anchor names share one namespace with every heading on the page, hence the
+// prefix. They are also part of the URL a reader copies out of the address bar,
+// so they are spelled out rather than shortened.
+func footnoteAnchor(index int) string {
+	return "footnote-" + strconv.Itoa(index)
+}
+
+// footnoteRefAnchor names the anchor sitting with a marker in the text.
+//
+// The same note may be cited several times; refIndex distinguishes those, and
+// is left off the first so that the common case of a note cited once reads as
+// "footnote-ref-3".
+func footnoteRefAnchor(index, refIndex int) string {
+	name := "footnote-ref-" + strconv.Itoa(index)
+	if refIndex > 0 {
+		name += "-" + strconv.Itoa(refIndex)
+	}
+	return name
+}
+
+// renderFootnoteLink renders the marker in the running text: an anchor for the
+// note to come back to, then a superscript link down to it.
+func (r *ConfluenceFootnoteRenderer) renderFootnoteLink(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+
+	n := node.(*ext_ast.FootnoteLink)
+
+	err := r.Stdlib.Templates.ExecuteTemplate(w, "ac:footnote:anchor", struct {
+		Anchor string
+	}{
+		Anchor: footnoteRefAnchor(n.Index, n.RefIndex),
+	})
+	if err != nil {
+		return ast.WalkStop, err
+	}
+
+	err = r.Stdlib.Templates.ExecuteTemplate(w, "ac:footnote:ref", struct {
+		Anchor string
+		Number int
+	}{
+		Anchor: footnoteAnchor(n.Index),
+		Number: n.Index,
+	})
+	if err != nil {
+		return ast.WalkStop, err
+	}
+
+	return ast.WalkContinue, nil
+}
+
+// renderFootnoteBacklink renders the arrow at the end of a note that leads back
+// to the text that cited it.
+func (r *ConfluenceFootnoteRenderer) renderFootnoteBacklink(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+
+	n := node.(*ext_ast.FootnoteBacklink)
+
+	// One arrow per citation, numbered only when there is more than one to
+	// choose between.
+	number := 0
+	if n.RefCount > 1 {
+		number = n.RefIndex + 1
+	}
+
+	err := r.Stdlib.Templates.ExecuteTemplate(w, "ac:footnote:backref", struct {
+		Anchor string
+		Number int
+	}{
+		Anchor: footnoteRefAnchor(n.Index, n.RefIndex),
+		Number: number,
+	})
+	if err != nil {
+		return ast.WalkStop, err
+	}
+
+	return ast.WalkContinue, nil
+}
+
+// renderFootnote renders one note as a list item carrying its own anchor.
+//
+// The item takes no number of its own: goldmark orders the list by the index it
+// handed each marker, so the numbering <ol> produces is already the numbering
+// the markers show.
+func (r *ConfluenceFootnoteRenderer) renderFootnote(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	n := node.(*ext_ast.Footnote)
+
+	if !entering {
+		_, _ = w.WriteString("</li>\n")
+		return ast.WalkContinue, nil
+	}
+
+	_, _ = w.WriteString("<li>")
+
+	err := r.Stdlib.Templates.ExecuteTemplate(w, "ac:footnote:anchor", struct {
+		Anchor string
+	}{
+		Anchor: footnoteAnchor(n.Index),
+	})
+	if err != nil {
+		return ast.WalkStop, err
+	}
+
+	_ = w.WriteByte('\n')
+
+	return ast.WalkContinue, nil
+}
+
+// renderFootnoteList renders the notes at the foot of the page.
+//
+// Goldmark's wrapping <div class="footnotes"> is dropped: Confluence keeps
+// neither the element's class nor its ARIA role, so it would arrive as an
+// anonymous div and buy nothing. The rule above the list is what actually
+// survives to mark the section off.
+func (r *ConfluenceFootnoteRenderer) renderFootnoteList(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		_, _ = w.WriteString("<hr />\n<ol>\n")
+	} else {
+		_, _ = w.WriteString("</ol>\n")
+	}
+	return ast.WalkContinue, nil
+}

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -318,6 +318,49 @@ func templates(api *confluence.API) (*template.Template, error) {
 			`</ac:structured-macro>`,
 		),
 
+		/*
+			Footnotes. Confluence has no footnote of its own outside the
+			marketplace, so a footnote is assembled from two things it does
+			have: the bundled anchor macro, and a link that names an anchor
+			instead of a page.
+
+			An id attribute is not an option -- Confluence discards the ids in
+			the storage format and generates its own from the element's text --
+			so every jump target here has to be a real anchor macro. The macro
+			renders nothing, which is what lets one sit in the middle of a
+			sentence next to the marker it belongs to.
+
+			A link with ac:anchor and no ri:* resource is a link within the
+			current page; the same tag with an ri:page would leave the page
+			first, which reloads it and loses the reader's place.
+		*/
+
+		`ac:footnote:anchor`: text(
+			`<ac:structured-macro ac:name="anchor">`,
+			`<ac:parameter ac:name="">{{ .Anchor | xmlesc }}</ac:parameter>`,
+			`</ac:structured-macro>`,
+		),
+
+		// The marker is superscript inside the link body rather than around
+		// the whole link: ac:link-body is documented to take sup, while a
+		// storage-format sup wrapping a macro is not, and the editor is free
+		// to normalise what it was not promised.
+		`ac:footnote:ref`: text(
+			`<ac:link ac:anchor="{{ .Anchor | xmlesc }}">`,
+			`<ac:link-body><sup>[{{ .Number }}]</sup></ac:link-body>`,
+			`</ac:link>`,
+		),
+
+		// U+21A9 followed by U+FE0E: the variation selector asks for the text
+		// glyph, without which the arrow is drawn as a colour emoji.
+		// .Number is zero unless the note is cited more than once, in which
+		// case each way back has to be told apart.
+		`ac:footnote:backref`: text(
+			`&#160;<ac:link ac:anchor="{{ .Anchor | xmlesc }}">`,
+			`<ac:link-body>&#x21a9;&#xfe0e;{{ if .Number }}<sup>{{ .Number }}</sup>{{ end }}</ac:link-body>`,
+			`</ac:link>`,
+		),
+
 		/* https://confluence.atlassian.com/conf59/expand-macro-792499106.html */
 
 		// The body is separated from the wrapper tags by blank lines; see

--- a/testdata/footnotes-confluence.html
+++ b/testdata/footnotes-confluence.html
@@ -1,0 +1,15 @@
+<p>Confluence has no footnote of its own<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">footnote-ref-1</ac:parameter></ac:structured-macro><ac:link ac:anchor="footnote-1"><ac:link-body><sup>[1]</sup></ac:link-body></ac:link>, so mark builds one out of the anchor macro<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">footnote-ref-2</ac:parameter></ac:structured-macro><ac:link ac:anchor="footnote-2"><ac:link-body><sup>[2]</sup></ac:link-body></ac:link>.</p>
+<p>A note may be cited more than once<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">footnote-ref-1-1</ac:parameter></ac:structured-macro><ac:link ac:anchor="footnote-1"><ac:link-body><sup>[1]</sup></ac:link-body></ac:link>, and each citation gets its own way back.</p>
+<p>A note may carry markup<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">footnote-ref-3</ac:parameter></ac:structured-macro><ac:link ac:anchor="footnote-3"><ac:link-body><sup>[3]</sup></ac:link-body></ac:link> of its own.</p>
+<hr />
+<ol>
+<li><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">footnote-1</ac:parameter></ac:structured-macro>
+<p>The marketplace has footnote plugins; the bundled macros do not include one.&#160;<ac:link ac:anchor="footnote-ref-1"><ac:link-body>&#x21a9;&#xfe0e;<sup>1</sup></ac:link-body></ac:link>&#160;<ac:link ac:anchor="footnote-ref-1-1"><ac:link-body>&#x21a9;&#xfe0e;<sup>2</sup></ac:link-body></ac:link></p>
+</li>
+<li><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">footnote-2</ac:parameter></ac:structured-macro>
+<p>Bundled with Data Center and Cloud alike, so nothing has to be installed.&#160;<ac:link ac:anchor="footnote-ref-2"><ac:link-body>&#x21a9;&#xfe0e;</ac:link-body></ac:link></p>
+</li>
+<li><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">footnote-3</ac:parameter></ac:structured-macro>
+<p>A note can hold <strong>bold</strong> text and a <a href="https://example.com">link</a>.&#160;<ac:link ac:anchor="footnote-ref-3"><ac:link-body>&#x21a9;&#xfe0e;</ac:link-body></ac:link></p>
+</li>
+</ol>

--- a/testdata/footnotes.html
+++ b/testdata/footnotes.html
@@ -1,0 +1,17 @@
+<p>Confluence has no footnote of its own<sup id="fnref:1"><a href="#fn:1" class="footnote-ref" role="doc-noteref">1</a></sup>, so mark builds one out of the anchor macro<sup id="fnref:2"><a href="#fn:2" class="footnote-ref" role="doc-noteref">2</a></sup>.</p>
+<p>A note may be cited more than once<sup id="fnref1:1"><a href="#fn:1" class="footnote-ref" role="doc-noteref">1</a></sup>, and each citation gets its own way back.</p>
+<p>A note may carry markup<sup id="fnref:3"><a href="#fn:3" class="footnote-ref" role="doc-noteref">3</a></sup> of its own.</p>
+<div class="footnotes" role="doc-endnotes">
+<hr />
+<ol>
+<li id="fn:1">
+<p>The marketplace has footnote plugins; the bundled macros do not include one.&#160;<a href="#fnref:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a>&#160;<a href="#fnref1:1" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+</li>
+<li id="fn:2">
+<p>Bundled with Data Center and Cloud alike, so nothing has to be installed.&#160;<a href="#fnref:2" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+</li>
+<li id="fn:3">
+<p>A note can hold <strong>bold</strong> text and a <a href="https://example.com">link</a>.&#160;<a href="#fnref:3" class="footnote-backref" role="doc-backlink">&#x21a9;&#xfe0e;</a></p>
+</li>
+</ol>
+</div>

--- a/testdata/footnotes.md
+++ b/testdata/footnotes.md
@@ -1,0 +1,10 @@
+Confluence has no footnote of its own[^why], so mark builds one out of the anchor macro[^anchor].
+
+A note may be cited more than once[^why], and each citation gets its own way back.
+
+A note may carry markup[^markup] of its own.
+
+[^why]: The marketplace has footnote plugins; the bundled macros do not include one.
+[^anchor]: Bundled with Data Center and Cloud alike, so nothing has to be installed.
+[^markup]: A note can hold **bold** text and a [link](https://example.com).
+[^unused]: A note nothing cites is dropped rather than numbered.

--- a/util/flags.go
+++ b/util/flags.go
@@ -272,7 +272,7 @@ var Flags = []cli.Flag{
 	&cli.StringSliceFlag{
 		Name:    "features",
 		Value:   []string{"mermaid", "mention"},
-		Usage:   "Enables optional features. Current features: d2, date, details, frontmatter, html-img-tag, inline-link-card, math, mention, mermaid, mkdocsadmonitions, plantuml",
+		Usage:   "Enables optional features. Current features: d2, date, details, footnotes, frontmatter, html-img-tag, inline-link-card, math, mention, mermaid, mkdocsadmonitions, plantuml",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_FEATURES"), altsrctoml.TOML("features", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.BoolFlag{


### PR DESCRIPTION
Adds a `footnotes` feature that renders Markdown footnotes as footnotes Confluence can actually navigate.

## The problem

Footnote syntax has always been parsed — goldmark's `Footnote` extension is unconditionally on in `compileMarkdownWithExtension`. What has never worked is the navigation.

Goldmark wires the marker and the note together the way every Markdown renderer does: `id="fn:1"` on the note, `href="#fn:1"` on the marker. Confluence keeps neither. It discards the ids in the storage format and generates its own from element text, so both ends of every jump land nowhere. The page renders, the superscript is clickable, and clicking it does nothing — the sort of fault nobody reports twice, they just stop using footnotes.

## The approach

`--features=footnotes` replaces that plumbing with the two things Confluence does understand, both bundled with Cloud *and* Data Center so nothing has to be installed:

- the **anchor macro** for the jump targets — not on Atlassian's [March 2025 Cloud deprecation list](https://community.atlassian.com/forums/Confluence-articles/Deprecating-infrequently-used-macros-in-Confluence-Cloud/ba-p/2981360), and [back on Cloud](https://community.atlassian.com/forums/Confluence-articles/Anchor-macros-are-back-on-Confluence-Cloud/ba-p/1632437) after the new-editor gap;
- **`<ac:link ac:anchor="…">` with no `ri:page`** for the jumps, which is the [documented](https://confluence.atlassian.com/doc/confluence-storage-format-790796544.html) form for a link within the current page and so scrolls rather than reloads.

```html
<!-- at the marker -->
<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">footnote-ref-1</ac:parameter></ac:structured-macro>
<ac:link ac:anchor="footnote-1"><ac:link-body><sup>[1]</sup></ac:link-body></ac:link>

<!-- at the note -->
<li><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">footnote-1</ac:parameter></ac:structured-macro>
<p>Measured on the staging cluster.&#160;<ac:link ac:anchor="footnote-ref-1"><ac:link-body>&#x21a9;&#xfe0e;</ac:link-body></ac:link></p>
</li>
```

Two details worth flagging:

- Anchors go at **both** ends. That is what makes the way back from a note to the sentence that cited it work as well as the way down.
- The marker is a `<sup>` **inside** `ac:link-body`, not a `<sup>` wrapping the link. `ac:link-body` is documented to take `sup`; the reverse is not, and the editor is free to normalise what it was not promised.

Notes collect into an `<ol>` under a rule. The list carries no numbers of its own, because goldmark orders the notes by the index it gave each marker — so what Confluence counts is already what the markers show. A definition nothing cites is dropped rather than numbered, which is what keeps those two in step.

## Compatibility

Leaving the feature off keeps the previous output byte for byte. `testdata/footnotes.html` pins that old HTML alongside `testdata/footnotes-confluence.html` for the new, so the pair records exactly what the feature changes.

## A correction to AGENTS.md

Invariant 4 said a **larger** priority number overrides an earlier node renderer registration. It is the other way round: goldmark sorts renderers ascending and calls `RegisterFuncs` from the end backwards (`renderer/renderer.go`), each registration overwriting the last, so the **smaller** number renders. Renderers registered at 600 to displace goldmark's footnote extension at 500 were silently ignored, with the default rendering coming out and no error anywhere.

My first pass at that note also claimed the GH-alerts renderers' `200` was inert, on the grounds that nothing else in this repo competes for those kinds. That was wrong, and the third commit fixes it: goldmark registers its default `html.Renderer` at `1000`, and that one claims every core kind including `Blockquote` and `Text`. The `200` is what beats `1000`. Both numbers are load-bearing; the footnote renderers' `100` additionally has to clear the footnote extension's `500`.

## Testing

- Golden pair for the feature on and off, plus `markdown/footnote_test.go` covering repeat citations, citation-order numbering, uncited definitions, escaping, and XML well-formedness (a body that is not well-formed is rejected whole by Confluence, so that is checked rather than assumed).
- `go test ./... -count=1`, `golangci-lint run ./...` and `markdownlint-cli2` all pass.
- Verified end to end through the CLI with `--compile-only`.

**Not verified against a live Confluence instance.** The markup is built from documented storage format and validates as XML, but I have no instance to publish to — worth a look from someone who does, particularly how the anchor macro sits inline mid-sentence in the Cloud editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

