### PR TITLE
test(renderer): cover the package that writes the storage format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,10 +123,18 @@ compared against `testdata/<name>.html`; variant suffixes cover flag combination
 Adding a `.md` fixture without its matching `.html` panics the test — the loader reads
 both unconditionally. There is no `-update` flag; golden files are written by hand.
 
-Coverage is uneven and worth knowing before you trust a green run: `page/` ~10%,
-`renderer/` ~14%, `confluence/` ~19%, and `stdlib/`, `vfs/`, `cmd/mark/` at 0%. There is
-no fake Confluence server, so nothing that touches the REST API is covered. If you change
-`page/ancestry.go` or `confluence/api.go`, the test suite will very likely still pass.
+Coverage is uneven, and where it is thin matters more than the number. Measured with
+`go test -cover ./...`: `markdown/` 82%, `renderer/` 74%, `confluence/` 61%, `stdlib/` 68%,
+`util/` 52%, `page/` 31%, `attachment/` 32%, and the root package 84%. `cmd/mark/`, `vfs/` and
+`chrome/` are at 0% on purpose: a thin `main`, a 19-line `os.Open` wrapper, and a package
+that needs a browser and is exercised through `d2/` and `mermaid/`.
+
+Two things to know before reading those numbers. `make test` passes no `-coverpkg`, so a
+package's figure counts only what its *own* tests exercise — renderer code driven by the
+`markdown/` golden tests does not show up in `renderer/`'s. And `confluence/confluencetest`
+is an in-memory fake of the REST API in the spirit of `httptest`: point `confluence.NewAPI`
+at its URL and drive real calls over real HTTP, rather than assuming anything that touches
+the API is untestable.
 
 ## Conventions
 

--- a/renderer/blockquote_test.go
+++ b/renderer/blockquote_test.go
@@ -1,0 +1,113 @@
+package renderer_test
+
+import (
+	"strings"
+	"testing"
+
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark/renderer"
+)
+
+func legacyBlockQuoteRenderers() []renderer.NodeRenderer {
+	return []renderer.NodeRenderer{
+		crenderer.NewConfluenceBlockQuoteRenderer(),
+		crenderer.NewConfluenceParagraphRenderer(),
+		crenderer.NewConfluenceTextLegacyRenderer(false),
+	}
+}
+
+// TestBlockQuoteClassification covers the legacy "> Info: ..." syntax, which is
+// what mark supported before GitHub Alerts and still supports.
+//
+// The four names are not interchangeable with the macros they produce: "warn"
+// selects Confluence's warning macro, and "note" selects note, so a mapping
+// slip shows up as the wrong colour and icon on the page rather than as an
+// error anywhere.
+func TestBlockQuoteClassification(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"info", "> Info: the build is nightly.\n", `ac:name="info"`},
+		{"note", "> Note: this is worth knowing.\n", `ac:name="note"`},
+		{"warning from warn", "> Warn: this deletes data.\n", `ac:name="warning"`},
+		{"tip", "> Tip: use the cache.\n", `ac:name="tip"`},
+		{"case insensitive", "> NOTE: shouting.\n", `ac:name="note"`},
+		{"markup around the word", "> **Note:** emphasised.\n", `ac:name="note"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := render(t, tt.input, legacyBlockQuoteRenderers())
+			assertWellFormed(t, actual)
+
+			assert.Contains(t, actual, tt.want)
+			assert.Contains(t, actual, `<ac:parameter ac:name="icon">true</ac:parameter>`)
+			assert.Contains(t, actual, "</ac:rich-text-body></ac:structured-macro>")
+			assert.NotContains(t, actual, "<blockquote>")
+		})
+	}
+}
+
+// TestBlockQuoteUnclassifiedStaysAQuote covers the quote that names none of the
+// four types: it has to stay a blockquote rather than become a macro of some
+// default kind.
+func TestBlockQuoteUnclassifiedStaysAQuote(t *testing.T) {
+	actual := render(t, "> An ordinary quotation.\n", legacyBlockQuoteRenderers())
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "<blockquote>")
+	assert.Contains(t, actual, "</blockquote>")
+	assert.NotContains(t, actual, "ac:structured-macro")
+}
+
+// TestBlockQuoteClassifierMatchesAnywhereInTheFirstLine records a trap in the
+// legacy syntax rather than an intention: the classifier looks for the word
+// anywhere in the first line, unanchored and case-insensitively, so a quote that
+// merely mentions the word becomes a macro. Authors who want a plain quotation
+// of a sentence containing "note" have to reword it or use a different
+// construct.
+func TestBlockQuoteClassifierMatchesAnywhereInTheFirstLine(t *testing.T) {
+	actual := render(t, "> Nothing here was noteworthy.\n", legacyBlockQuoteRenderers())
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `ac:name="note"`,
+		"the word inside another word still classifies the quote")
+}
+
+// TestBlockQuoteTypeComesFromTheFirstParagraphOnly pins the scope of the
+// classification. A quote whose second paragraph says "warning" must not be
+// reclassified by it -- the type belongs to the opening line.
+func TestBlockQuoteTypeComesFromTheFirstParagraphOnly(t *testing.T) {
+	actual := render(t, "> Info: the first line.\n>\n> A warning in the second.\n", legacyBlockQuoteRenderers())
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `ac:name="info"`)
+	assert.NotContains(t, actual, `ac:name="warning"`)
+}
+
+// TestBlockQuoteNestedStaysAQuote covers a quote inside a classified quote.
+// Only the outermost one becomes a macro; nesting a macro inside its own
+// rich-text body is not something the editor accepts, and the level map is what
+// keeps that from happening.
+func TestBlockQuoteNestedStaysAQuote(t *testing.T) {
+	actual := render(t, "> Note: the outer one.\n>\n> > The inner one.\n", legacyBlockQuoteRenderers())
+	assertWellFormed(t, actual)
+
+	assert.Equal(t, 1, strings.Count(actual, "<ac:structured-macro"),
+		"only the outer quote becomes a macro")
+	assert.Equal(t, 1, strings.Count(actual, "<blockquote>"))
+	assert.Equal(t, 1, strings.Count(actual, "</blockquote>"))
+}
+
+// TestParseBlockQuoteTypeString covers the names the enum prints, which are
+// interpolated straight into ac:name.
+func TestParseBlockQuoteTypeString(t *testing.T) {
+	assert.Equal(t, "info", crenderer.Info.String())
+	assert.Equal(t, "note", crenderer.Note.String())
+	assert.Equal(t, "warning", crenderer.Warn.String())
+	assert.Equal(t, "tip", crenderer.Tip.String())
+	assert.Equal(t, "none", crenderer.None.String())
+}

--- a/renderer/codeblock_test.go
+++ b/renderer/codeblock_test.go
@@ -1,0 +1,42 @@
+package renderer_test
+
+import (
+	"testing"
+
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark/renderer"
+)
+
+// TestIndentedCodeBlockBecomesTheCodeMacro covers the block written by
+// indentation rather than by fences. Confluence has no <pre>, so it has to
+// become the code macro like any other code block.
+func TestIndentedCodeBlockBecomesTheCodeMacro(t *testing.T) {
+	lib := newStdlib(t)
+
+	actual := render(t, "    package main\n    func main() {}\n", []renderer.NodeRenderer{
+		crenderer.NewConfluenceCodeBlockRenderer(lib, "test.md"),
+	})
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `<ac:structured-macro ac:name="code">`)
+	assert.Contains(t, actual, `<ac:parameter ac:name="language"></ac:parameter>`,
+		"an indented block names no language")
+	assert.Contains(t, actual, `<ac:parameter ac:name="collapse">false</ac:parameter>`)
+	assert.Contains(t, actual, "<![CDATA[package main\nfunc main() {}]]>",
+		"the trailing newline is trimmed, so the macro does not gain a blank last line")
+}
+
+// TestIndentedCodeBlockEscapesTheCDATATerminator covers a code sample that
+// contains "]]>" -- XML, a shell heredoc, anything -- which would end the CDATA
+// section in the middle of the sample and leave the rest as markup.
+func TestIndentedCodeBlockEscapesTheCDATATerminator(t *testing.T) {
+	lib := newStdlib(t)
+
+	actual := render(t, "    <![CDATA[x]]>\n", []renderer.NodeRenderer{
+		crenderer.NewConfluenceCodeBlockRenderer(lib, "test.md"),
+	})
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `]]><![CDATA[]]]]><![CDATA[>`)
+}

--- a/renderer/emoji_render_test.go
+++ b/renderer/emoji_render_test.go
@@ -1,0 +1,71 @@
+package renderer_test
+
+import (
+	"testing"
+
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	"github.com/stretchr/testify/assert"
+	emoji "github.com/yuin/goldmark-emoji"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+func emojiRender(t *testing.T, source string) string {
+	t.Helper()
+
+	return render(t, source,
+		[]renderer.NodeRenderer{
+			crenderer.NewConfluenceEmojiRenderer(newStdlib(t)),
+			crenderer.NewConfluenceParagraphRenderer(),
+			crenderer.NewConfluenceTextRenderer(false),
+		},
+		parser.WithInlineParsers(util.Prioritized(emoji.NewParser(), 999)))
+}
+
+// TestEmojiWithALegacyNameBecomesTheMacro covers the emoji Confluence Data
+// Center has a name for. The macro carries the name for Data Center and the
+// ac:emoji-* attributes for Cloud, so both render the same character.
+func TestEmojiWithALegacyNameBecomesTheMacro(t *testing.T) {
+	actual := emojiRender(t, "Green :white_check_mark:\n")
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual,
+		`<ac:emoticon ac:name="tick" ac:emoji-shortname=":white_check_mark:" ac:emoji-id="2705" ac:emoji-fallback="✅"/>`)
+}
+
+// TestEmojiWithoutALegacyNameBecomesTheCharacter covers everything else. Data
+// Center renders an ac:emoticon whose name it does not know as nothing at all,
+// so the character itself goes on the page instead -- text, which both flavours
+// render without having to understand a macro.
+func TestEmojiWithoutALegacyNameBecomesTheCharacter(t *testing.T) {
+	actual := emojiRender(t, "Shipped :tada:\n")
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "Shipped 🎉")
+	assert.NotContains(t, actual, "ac:emoticon")
+}
+
+// TestEmojiAliasesShareTheLegacyName pins that the name is chosen by the emoji
+// rather than by the shortcode: :+1: and :thumbsup: are one character.
+func TestEmojiAliasesShareTheLegacyName(t *testing.T) {
+	for _, shortcode := range []string{":+1:", ":thumbsup:"} {
+		actual := emojiRender(t, shortcode+"\n")
+		assertWellFormed(t, actual)
+
+		assert.Contains(t, actual, `ac:name="thumbs-up"`)
+		assert.Contains(t, actual, `ac:emoji-shortname="`+shortcode+`"`,
+			"the shortname is the one the author typed")
+	}
+}
+
+// TestEmojiUnknownShortcodeIsLeftAlone covers the text that only looks like a
+// shortcode.
+func TestEmojiUnknownShortcodeIsLeftAlone(t *testing.T) {
+	actual := emojiRender(t, "At 10:30 and :not_an_emoji: too\n")
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "At 10:30")
+	assert.Contains(t, actual, ":not_an_emoji:")
+	assert.NotContains(t, actual, "ac:emoticon")
+}

--- a/renderer/fencedcodeblock_test.go
+++ b/renderer/fencedcodeblock_test.go
@@ -1,0 +1,187 @@
+package renderer_test
+
+import (
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/attachment"
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark/renderer"
+)
+
+// collectingAttacher stands in for the extension, which is what collects the
+// attachments a diagram block produces. Nothing here renders a diagram -- that
+// needs a browser -- so it only has to exist.
+type collectingAttacher struct {
+	attachments []attachment.Attachment
+}
+
+func (c *collectingAttacher) Attach(a attachment.Attachment) {
+	c.attachments = append(c.attachments, a)
+}
+
+// fencedCode renders one fenced block with the given info string.
+//
+// The info string is parsed by reBlockDetails in fencedcodeblock.go. Note that
+// the exported ParseLanguage and ParseTitle in the same file are not used by
+// the renderer and do not agree with it -- ParseLanguage("collapse") returns no
+// language, while the renderer takes "collapse" as the language name.
+func fencedCode(t *testing.T, info string) string {
+	t.Helper()
+
+	return render(t, "```"+info+"\nsample\n```\n", []renderer.NodeRenderer{
+		crenderer.NewConfluenceFencedCodeBlockRenderer(newStdlib(t), &collectingAttacher{}, types.MarkConfig{}),
+	})
+}
+
+// TestFencedCodeBlockLanguage covers the language name, which is the part of
+// the info string with the most ways to go wrong: real language names carry
+// characters that are not word characters, and a \w-only class used to cut
+// "c#" down to "c" and leave "#" behind as a theme.
+func TestFencedCodeBlockLanguage(t *testing.T) {
+	tests := []struct {
+		info string
+		want string
+	}{
+		{"go", "go"},
+		{"c#", "c#"},
+		{"c++", "c++"},
+		{"objective-c", "objective-c"},
+		{"html/xml", "html/xml"},
+		{".NET", ".NET"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.info, func(t *testing.T) {
+			actual := fencedCode(t, tt.info)
+			assertWellFormed(t, actual)
+
+			assert.Contains(t, actual, `<ac:parameter ac:name="language">`+tt.want+`</ac:parameter>`)
+			assert.NotContains(t, actual, `ac:name="theme"`,
+				"a language is not an option, and must not fall through to the theme catch-all")
+		})
+	}
+}
+
+// TestFencedCodeBlockOptions covers everything after the language: the options
+// the README documents, and the numeric one that means two things at once.
+func TestFencedCodeBlockOptions(t *testing.T) {
+	tests := []struct {
+		name        string
+		info        string
+		contains    []string
+		notContains []string
+	}{
+		{
+			name:        "collapse",
+			info:        "go collapse",
+			contains:    []string{`<ac:parameter ac:name="collapse">true</ac:parameter>`},
+			notContains: []string{`ac:name="theme"`},
+		},
+		{
+			name:     "nocollapse wins over the default",
+			info:     "go nocollapse",
+			contains: []string{`<ac:parameter ac:name="collapse">false</ac:parameter>`},
+		},
+		{
+			name:     "linenumbers",
+			info:     "go linenumbers",
+			contains: []string{`<ac:parameter ac:name="linenumbers">true</ac:parameter>`},
+		},
+		{
+			name: "a number sets the first line and turns numbering on",
+			info: "go 10",
+			contains: []string{
+				`<ac:parameter ac:name="linenumbers">true</ac:parameter>`,
+				`<ac:parameter ac:name="firstline">10</ac:parameter>`,
+			},
+		},
+		{
+			name:     "an unrecognised option is a theme",
+			info:     "go Midnight",
+			contains: []string{`<ac:parameter ac:name="theme">Midnight</ac:parameter>`},
+		},
+		{
+			name:     "title takes the rest of the line",
+			info:     "go title Some long title",
+			contains: []string{`<ac:parameter ac:name="title">Some long title</ac:parameter>`},
+		},
+		{
+			name: "everything at once",
+			info: "bash 1 collapse midnight title Some long long bash function",
+			contains: []string{
+				`<ac:parameter ac:name="language">bash</ac:parameter>`,
+				`<ac:parameter ac:name="collapse">true</ac:parameter>`,
+				`<ac:parameter ac:name="theme">midnight</ac:parameter>`,
+				`<ac:parameter ac:name="firstline">1</ac:parameter>`,
+				`<ac:parameter ac:name="title">Some long long bash function</ac:parameter>`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := fencedCode(t, tt.info)
+			assertWellFormed(t, actual)
+
+			for _, want := range tt.contains {
+				assert.Contains(t, actual, want)
+			}
+			for _, unwanted := range tt.notContains {
+				assert.NotContains(t, actual, unwanted)
+			}
+		})
+	}
+}
+
+// TestFencedCodeBlockDashLanguage records what the "-" prefix currently does,
+// which is not what the README says it does.
+//
+// The README offers "-" as the way to write a block with no language but with
+// the other options ("- 1 collapse midnight title ..."). The regex means to
+// allow that -- its comment reads (<Lang>|-) -- but "-" is also in the language
+// character class, so the first alternative matches it and the language
+// parameter is published as a literal "-" rather than left empty.
+func TestFencedCodeBlockDashLanguage(t *testing.T) {
+	actual := fencedCode(t, "- 1 collapse title Some long long code")
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `<ac:parameter ac:name="language">-</ac:parameter>`)
+	assert.Contains(t, actual, `<ac:parameter ac:name="title">Some long long code</ac:parameter>`)
+}
+
+// TestFencedCodeBlockEscapesTheCDATATerminator covers a code sample carrying
+// the one sequence CDATA cannot hold.
+func TestFencedCodeBlockEscapesTheCDATATerminator(t *testing.T) {
+	actual := render(t, "```xml\n<![CDATA[x]]>\n```\n", []renderer.NodeRenderer{
+		crenderer.NewConfluenceFencedCodeBlockRenderer(newStdlib(t), &collectingAttacher{}, types.MarkConfig{}),
+	})
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `]]><![CDATA[]]]]><![CDATA[>`)
+}
+
+// TestFencedCodeBlockTitleIsEscaped covers a title carrying markup characters:
+// it is interpolated into an attribute, so an unescaped one would break the
+// document rather than the block.
+func TestFencedCodeBlockTitleIsEscaped(t *testing.T) {
+	actual := fencedCode(t, `go title A & B <script>`)
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `A &amp; B &lt;script&gt;`)
+}
+
+// TestFencedCodeBlockDiagramLanguagesNeedTheirFeature covers the guard in front
+// of the diagram renderers: without the feature, a d2 or mermaid block is an
+// ordinary code block, and nothing tries to start a browser.
+func TestFencedCodeBlockDiagramLanguagesNeedTheirFeature(t *testing.T) {
+	for _, lang := range []string{"d2", "mermaid"} {
+		actual := fencedCode(t, lang)
+		assertWellFormed(t, actual)
+
+		assert.Contains(t, actual, `<ac:parameter ac:name="language">`+lang+`</ac:parameter>`)
+		assert.NotContains(t, actual, "ac:image")
+	}
+}

--- a/renderer/footnote_render_test.go
+++ b/renderer/footnote_render_test.go
@@ -1,0 +1,84 @@
+package renderer_test
+
+import (
+	"strings"
+	"testing"
+
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/renderer"
+)
+
+func footnoteRender(t *testing.T, source string) string {
+	t.Helper()
+
+	return renderExtended(t, source,
+		[]goldmark.Extender{extension.Footnote},
+		[]renderer.NodeRenderer{
+			crenderer.NewConfluenceFootnoteRenderer(newStdlib(t)),
+			crenderer.NewConfluenceParagraphRenderer(),
+			crenderer.NewConfluenceTextRenderer(false),
+		})
+}
+
+// TestFootnoteBothEndsCarryAnAnchor covers the property the whole feature rests
+// on. Confluence discards the ids goldmark's own footnote output links with, so
+// the jump is rebuilt out of the anchor macro -- and an ac:link naming an
+// anchor that no macro declares is silently inert, so both ends have to be
+// present for either direction to work.
+func TestFootnoteBothEndsCarryAnAnchor(t *testing.T) {
+	actual := footnoteRender(t, "A claim[^src].\n\n[^src]: Where it came from.\n")
+	assertWellFormed(t, actual)
+
+	// Down: an anchor at the marker, and a link to the note.
+	assert.Contains(t, actual, `<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">footnote-ref-1</ac:parameter></ac:structured-macro>`)
+	assert.Contains(t, actual, `<ac:link ac:anchor="footnote-1"><ac:link-body><sup>[1]</sup></ac:link-body></ac:link>`)
+
+	// Back: an anchor at the note, and a link to the marker.
+	assert.Contains(t, actual, `<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">footnote-1</ac:parameter></ac:structured-macro>`)
+	assert.Contains(t, actual, `<ac:link ac:anchor="footnote-ref-1">`)
+
+	// Nothing that depends on an id, because none of it survives the upload.
+	assert.NotContains(t, actual, `id="fn:1"`)
+	assert.NotContains(t, actual, `href="#fn:1"`)
+}
+
+// TestFootnoteListIsAnOrdinaryOrderedList covers the shape of the notes at the
+// foot of the page: a rule and an <ol> whose items carry no numbers of their
+// own, because Confluence numbering the list is what keeps it in step with the
+// markers.
+func TestFootnoteListIsAnOrdinaryOrderedList(t *testing.T) {
+	actual := footnoteRender(t, "One[^a] and two[^b].\n\n[^a]: First.\n[^b]: Second.\n")
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "<hr />\n<ol>")
+	assert.Equal(t, 2, strings.Count(actual, "<li>"))
+	assert.NotContains(t, actual, `class="footnotes"`,
+		"the wrapping div is dropped: Confluence keeps neither its class nor its role")
+}
+
+// TestFootnoteRepeatedCitationNumbersTheWayBack covers a note cited twice. Each
+// citation needs its own anchor, or the second arrow leads back to the first
+// sentence.
+func TestFootnoteRepeatedCitationNumbersTheWayBack(t *testing.T) {
+	actual := footnoteRender(t, "First[^a]. Second[^a].\n\n[^a]: Once.\n")
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `<ac:parameter ac:name="">footnote-ref-1</ac:parameter>`)
+	assert.Contains(t, actual, `<ac:parameter ac:name="">footnote-ref-1-1</ac:parameter>`)
+	assert.Contains(t, actual, `<sup>1</sup></ac:link-body>`)
+	assert.Contains(t, actual, `<sup>2</sup></ac:link-body>`)
+	assert.Equal(t, 1, strings.Count(actual, "<li>"), "one note, cited twice, is still one entry")
+}
+
+// TestFootnoteSingleCitationHasABareArrow is the other half of that rule: with
+// only one way back there is nothing to disambiguate, so the arrow carries no
+// number.
+func TestFootnoteSingleCitationHasABareArrow(t *testing.T) {
+	actual := footnoteRender(t, "Only[^a].\n\n[^a]: Once.\n")
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `<ac:link-body>&#x21a9;&#xfe0e;</ac:link-body>`)
+}

--- a/renderer/gh_alerts_blockquote_test.go
+++ b/renderer/gh_alerts_blockquote_test.go
@@ -1,0 +1,110 @@
+package renderer_test
+
+import (
+	"strings"
+	"testing"
+
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	ctransformer "github.com/kovetskiy/mark/v16/transformer"
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+func ghAlertRenderers() []renderer.NodeRenderer {
+	return []renderer.NodeRenderer{
+		crenderer.NewConfluenceGHAlertsBlockQuoteRenderer(),
+		crenderer.NewConfluenceTextRenderer(false),
+		crenderer.NewConfluenceParagraphRenderer(),
+	}
+}
+
+func ghAlertParserOptions() []parser.Option {
+	return []parser.Option{
+		parser.WithASTTransformers(util.Prioritized(ctransformer.NewGHAlertsTransformer(), 100)),
+	}
+}
+
+// TestGHAlertMacroMapping pins which Confluence macro each GitHub alert becomes.
+//
+// The two vocabularies do not line up: GitHub has five alert types and
+// Confluence four macros, and the names that do exist on both sides do not mean
+// the same thing. GitHub's "warning" is the amber one and its "caution" is the
+// red one, so warning maps to Confluence's note (amber) and caution to warning
+// (red). Getting this backwards produces a page that renders perfectly and
+// tells the reader the opposite of what the author meant about how dangerous
+// something is, which no test of well-formedness would catch.
+func TestGHAlertMacroMapping(t *testing.T) {
+	tests := []struct {
+		alert string
+		want  string
+	}{
+		{"NOTE", "info"},
+		{"TIP", "tip"},
+		{"IMPORTANT", "info"},
+		{"WARNING", "note"},
+		{"CAUTION", "warning"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.alert, func(t *testing.T) {
+			actual := render(t, "> [!"+tt.alert+"]\n> The body.\n", ghAlertRenderers(), ghAlertParserOptions()...)
+			assertWellFormed(t, actual)
+
+			assert.Contains(t, actual, `<ac:structured-macro ac:name="`+tt.want+`">`)
+			assert.Contains(t, actual, "The body.")
+			assert.NotContains(t, actual, "<blockquote>")
+			// The marker itself is not content; it chose the macro.
+			assert.NotContains(t, actual, "[!"+tt.alert+"]")
+		})
+	}
+}
+
+// TestGHAlertRendererFallsBackToLegacySyntax covers the reason this renderer
+// replaces the legacy one rather than sitting beside it: with GitHub Alerts on,
+// it is the only thing registered for blockquotes, so it still has to handle
+// the "> Note:" syntax that predates them.
+func TestGHAlertRendererFallsBackToLegacySyntax(t *testing.T) {
+	actual := render(t, "> Warn: the old syntax.\n", ghAlertRenderers(), ghAlertParserOptions()...)
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `ac:name="warning"`)
+}
+
+// TestGHAlertRendererLeavesPlainQuotesAlone covers the third case the same
+// renderer has to serve: a quotation that is neither an alert nor the legacy
+// syntax must come out as a blockquote.
+func TestGHAlertRendererLeavesPlainQuotesAlone(t *testing.T) {
+	actual := render(t, "> Just a quotation.\n", ghAlertRenderers(), ghAlertParserOptions()...)
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "<blockquote>")
+	assert.NotContains(t, actual, "ac:structured-macro")
+}
+
+// TestGHAlertNestedQuoteStaysAQuote covers a quotation inside an alert. Only
+// the alert becomes a macro; the inner quote stays a blockquote, and the tags
+// still balance.
+func TestGHAlertNestedQuoteStaysAQuote(t *testing.T) {
+	actual := render(t, "> [!NOTE]\n> The body.\n>\n> > Quoted inside.\n", ghAlertRenderers(), ghAlertParserOptions()...)
+	assertWellFormed(t, actual)
+
+	assert.Equal(t, 1, strings.Count(actual, "<ac:structured-macro"))
+	assert.Equal(t, 1, strings.Count(actual, "</ac:structured-macro>"))
+	assert.Equal(t, 1, strings.Count(actual, "<blockquote>"))
+	assert.Equal(t, 1, strings.Count(actual, "</blockquote>"))
+}
+
+// TestGHAlertsInSuccessionEachGetTheirOwnMacro covers the renderer's one piece
+// of state: it remembers the blockquote it opened so that it closes the right
+// one. Two alerts in a row are what that has to survive.
+func TestGHAlertsInSuccessionEachGetTheirOwnMacro(t *testing.T) {
+	actual := render(t, "> [!NOTE]\n> First.\n\ntext\n\n> [!CAUTION]\n> Second.\n", ghAlertRenderers(), ghAlertParserOptions()...)
+	assertWellFormed(t, actual)
+
+	assert.Equal(t, 2, strings.Count(actual, "<ac:structured-macro"))
+	assert.Equal(t, 2, strings.Count(actual, "</ac:structured-macro>"))
+	assert.Contains(t, actual, `ac:name="info"`)
+	assert.Contains(t, actual, `ac:name="warning"`)
+}

--- a/renderer/heading_test.go
+++ b/renderer/heading_test.go
@@ -1,0 +1,71 @@
+package renderer_test
+
+import (
+	"testing"
+
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+)
+
+func headingRenderers(dropFirstH1 bool) []renderer.NodeRenderer {
+	return []renderer.NodeRenderer{
+		crenderer.NewConfluenceHeadingRenderer(dropFirstH1),
+		crenderer.NewConfluenceParagraphRenderer(),
+		crenderer.NewConfluenceTextLegacyRenderer(false),
+	}
+}
+
+const headingDocument = "# First\n\ntext\n\n## Second\n\n# Third\n"
+
+// TestHeadingDropFirstH1 covers --drop-h1, which exists because the page title
+// usually repeats the document's first heading and Confluence shows the title
+// above the body anyway.
+//
+// Only the first h1 goes. A later h1 is content, not a repeated title, and an
+// h2 is never a title -- dropping either would silently lose a section heading.
+func TestHeadingDropFirstH1(t *testing.T) {
+	actual := render(t, headingDocument, headingRenderers(true))
+	assertWellFormed(t, actual)
+
+	assert.NotContains(t, actual, "First", "the first h1 goes, text and all")
+	assert.Contains(t, actual, "<h2>Second</h2>")
+	assert.Contains(t, actual, "<h1>Third</h1>")
+}
+
+// TestHeadingKeepsEverythingByDefault is the same document with the flag off.
+func TestHeadingKeepsEverythingByDefault(t *testing.T) {
+	actual := render(t, headingDocument, headingRenderers(false))
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "<h1>First</h1>")
+	assert.Contains(t, actual, "<h2>Second</h2>")
+	assert.Contains(t, actual, "<h1>Third</h1>")
+}
+
+// TestHeadingKeepsItsID covers the attribute a heading anchor is built from.
+// mark links to headings by id, so a heading rendered without one is a link
+// target that silently does not exist. How the id is spelled is the ID
+// generator's business -- mark installs its own, which is what the
+// heading-anchor fixtures in markdown/ pin -- and this only asserts that the
+// renderer passes the attribute through.
+func TestHeadingKeepsItsID(t *testing.T) {
+	actual := render(t, "## A Section\n", headingRenderers(false), parser.WithAutoHeadingID())
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `id="a-section"`)
+	assert.Contains(t, actual, "A Section</h2>")
+}
+
+// TestHeadingDropsOnlyTheFirstH1EvenWhenItIsNotFirstInTheDocument covers a
+// document that opens with a paragraph: the flag drops the first h1 wherever it
+// appears, rather than only when it is the opening block.
+func TestHeadingDropsOnlyTheFirstH1EvenWhenItIsNotFirstInTheDocument(t *testing.T) {
+	actual := render(t, "intro\n\n# Title\n\n# Later\n", headingRenderers(true))
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "intro")
+	assert.NotContains(t, actual, ">Title<")
+	assert.Contains(t, actual, "<h1>Later</h1>")
+}

--- a/renderer/helpers_test.go
+++ b/renderer/helpers_test.go
@@ -1,0 +1,94 @@
+package renderer_test
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/util"
+)
+
+// render compiles source with the given Confluence renderers registered, and
+// returns what they wrote.
+//
+// The renderers go in at 100, which is what markdown/markdown.go uses and what
+// makes them win: goldmark's own html.Renderer registers at 1000 and claims
+// every core node kind, and the *smaller* number is the one that ends up
+// rendering (AGENTS.md, invariant 4). Registering at a larger number here would
+// quietly test goldmark's output instead of this repo's.
+func render(t *testing.T, source string, nodeRenderers []renderer.NodeRenderer, parserOpts ...parser.Option) string {
+	t.Helper()
+
+	return renderExtended(t, source, nil, nodeRenderers, parserOpts...)
+}
+
+// renderExtended is render for a renderer whose nodes exist only once a
+// goldmark extension has parsed them, footnotes being the one in this package.
+func renderExtended(t *testing.T, source string, extensions []goldmark.Extender, nodeRenderers []renderer.NodeRenderer, parserOpts ...parser.Option) string {
+	t.Helper()
+
+	prioritized := make([]util.PrioritizedValue, 0, len(nodeRenderers))
+	for _, nodeRenderer := range nodeRenderers {
+		prioritized = append(prioritized, util.Prioritized(nodeRenderer, 100))
+	}
+
+	converter := goldmark.New(
+		goldmark.WithExtensions(extensions...),
+		goldmark.WithParserOptions(parserOpts...),
+		goldmark.WithRendererOptions(
+			renderer.WithNodeRenderers(prioritized...),
+			html.WithUnsafe(),
+			html.WithXHTML(),
+		),
+	)
+
+	var buf bytes.Buffer
+	require.NoError(t, converter.Convert([]byte(source), &buf))
+
+	return buf.String()
+}
+
+// newStdlib builds the template set with no Confluence API behind it, which is
+// what every renderer that does not resolve a user needs.
+func newStdlib(t *testing.T) *stdlib.Lib {
+	t.Helper()
+
+	lib, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	return lib
+}
+
+// assertWellFormed parses a body the way Confluence does.
+//
+// Confluence answers a body that is not well-formed with BadRequestException
+// and rejects the whole page, so an unbalanced tag here is not one broken
+// element but a document that never uploads. Every renderer that emits a macro
+// pair is checked with this rather than by eye.
+func assertWellFormed(t *testing.T, body string) {
+	t.Helper()
+
+	decoder := xml.NewDecoder(strings.NewReader(`<root xmlns:ac="ac" xmlns:ri="ri">` + body + `</root>`))
+	decoder.Strict = true
+	decoder.Entity = xml.HTMLEntity
+
+	for {
+		_, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return
+		}
+		if !assert.NoError(t, err, "storage format must be well-formed XML") {
+			return
+		}
+	}
+}

--- a/renderer/image_render_test.go
+++ b/renderer/image_render_test.go
@@ -1,0 +1,83 @@
+package renderer_test
+
+import (
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/attachment"
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark/renderer"
+)
+
+// imageRenderers renders images as if the document were testdata/doc.md, which
+// is what makes "test.png" beside it resolvable as a local attachment.
+func imageRenderers(t *testing.T, attacher attachment.Attacher) []renderer.NodeRenderer {
+	t.Helper()
+
+	return []renderer.NodeRenderer{
+		crenderer.NewConfluenceImageRenderer(newStdlib(t), attacher, "../testdata/doc.md", ""),
+		crenderer.NewConfluenceParagraphRenderer(),
+		crenderer.NewConfluenceTextRenderer(false),
+	}
+}
+
+// TestImageFromURL covers an image mark cannot upload: a remote one stays a
+// remote one, referenced by ri:url rather than uploaded and referenced by name.
+func TestImageFromURL(t *testing.T) {
+	actual := render(t, "![alt](https://example.com/a.png \"Title\")\n", imageRenderers(t, &collectingAttacher{}))
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `<ac:image ac:title="Title" ac:alt="alt"><ri:url ri:value="https://example.com/a.png"/></ac:image>`)
+}
+
+// TestImageURLAmpersandIsEscaped covers the query string, which is where a URL
+// most often carries an "&" -- unescaped, it makes the whole body malformed and
+// Confluence rejects the page rather than the image.
+func TestImageURLAmpersandIsEscaped(t *testing.T) {
+	actual := render(t, "![alt](https://example.com/a.png?x=1&y=2)\n", imageRenderers(t, &collectingAttacher{}))
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `ri:value="https://example.com/a.png?x=1&amp;y=2"`)
+}
+
+// TestImageAltIsEscaped covers alt text carrying markup characters. The same
+// reasoning as the URL: it is an attribute value.
+func TestImageAltIsEscaped(t *testing.T) {
+	actual := render(t, "![a & b](https://example.com/a.png)\n", imageRenderers(t, &collectingAttacher{}))
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `ac:alt="a &amp; b"`)
+}
+
+// TestImageFromLocalFileBecomesAnAttachment covers the other half: a path that
+// resolves beside the document is uploaded, referenced by filename, and its
+// real pixel size is published so that Confluence lays the page out without
+// having to load the image first.
+func TestImageFromLocalFileBecomesAnAttachment(t *testing.T) {
+	attacher := &collectingAttacher{}
+
+	actual := render(t, "![local](test.png)\n", imageRenderers(t, attacher))
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `<ri:attachment ri:filename="test.png"/>`)
+	assert.Contains(t, actual, `ac:original-width="1000"`)
+	assert.Contains(t, actual, `ac:original-height="631"`)
+
+	require.Len(t, attacher.attachments, 1, "the file has to be queued for upload, or the page renders a broken image")
+	assert.Equal(t, "test.png", attacher.attachments[0].Filename)
+}
+
+// TestImageWithUnresolvablePathIsTreatedAsAURL records what happens to a local
+// path that does not exist: it is not an error, it falls through to the URL
+// branch and is published as a relative ri:url. A typo in an image path
+// therefore reaches the page as a broken image rather than stopping the run.
+func TestImageWithUnresolvablePathIsTreatedAsAURL(t *testing.T) {
+	attacher := &collectingAttacher{}
+
+	actual := render(t, "![missing](no-such-file.png)\n", imageRenderers(t, attacher))
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `<ri:url ri:value="no-such-file.png"/>`)
+	assert.Empty(t, attacher.attachments)
+}

--- a/renderer/internal_test.go
+++ b/renderer/internal_test.go
@@ -1,0 +1,68 @@
+package renderer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEmojiID covers the id Confluence Cloud identifies an emoji by. The
+// fallback attribute carries the character itself, so a wrong id is not fatal
+// -- but it is what Cloud reads first, and the sequences below are the ones
+// where "the codepoints in hex" is not the whole rule.
+func TestEmojiID(t *testing.T) {
+	tests := []struct {
+		name  string
+		runes []rune
+		want  string
+	}{
+		{"a single codepoint", []rune{0x1F604}, "1f604"},
+		{"the variation selector is left out", []rune{0x2764, 0xFE0F}, "2764"},
+		{"a skin tone modifier is part of the id", []rune{0x1F44D, 0x1F3FD}, "1f44d-1f3fd"},
+		{"a ZWJ sequence keeps every joiner", []rune{0x1F468, 0x200D, 0x1F469, 0x200D, 0x1F467}, "1f468-200d-1f469-200d-1f467"},
+		{"a flag is two regional indicators", []rune{0x1F1E9, 0x1F1EA}, "1f1e9-1f1ea"},
+		{"nothing", nil, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, emojiID(tt.runes))
+		})
+	}
+}
+
+// TestConfluenceEmoticonNames pins the values of the legacy mapping against the
+// names Confluence Data Center actually knows, from its storage format
+// reference.
+//
+// A name outside that list is not an error anywhere: Data Center renders an
+// unknown ac:emoticon as nothing at all, so a typo would silently delete the
+// emoji from the page for every Data Center reader while looking correct on
+// Cloud, which goes by ac:emoji-id instead.
+func TestConfluenceEmoticonNames(t *testing.T) {
+	known := map[string]bool{
+		"smile": true, "sad": true, "cheeky": true, "laugh": true, "wink": true,
+		"thumbs-up": true, "thumbs-down": true, "information": true, "tick": true,
+		"cross": true, "warning": true, "plus": true, "minus": true, "question": true,
+		"light-on": true, "light-off": true, "yellow-star": true, "red-star": true,
+		"green-star": true, "blue-star": true, "heart": true, "broken-heart": true,
+	}
+
+	for id, name := range confluenceEmoticons {
+		assert.True(t, known[name], "%q (id %s) is not a name Data Center knows", name, id)
+	}
+}
+
+// TestFootnoteAnchorNames pins the anchor names, which are also the fragment a
+// reader copies out of the address bar. They share one namespace with the
+// page's heading anchors, hence the prefix, and a note cited more than once
+// needs one anchor per citation for the way back to land where it started.
+func TestFootnoteAnchorNames(t *testing.T) {
+	assert.Equal(t, "footnote-1", footnoteAnchor(1))
+	assert.Equal(t, "footnote-12", footnoteAnchor(12))
+
+	assert.Equal(t, "footnote-ref-3", footnoteRefAnchor(3, 0),
+		"the first citation carries no suffix, so the common case stays readable")
+	assert.Equal(t, "footnote-ref-3-1", footnoteRefAnchor(3, 1))
+	assert.Equal(t, "footnote-ref-3-2", footnoteRefAnchor(3, 2))
+}

--- a/renderer/link_test.go
+++ b/renderer/link_test.go
@@ -1,0 +1,92 @@
+package renderer_test
+
+import (
+	"testing"
+
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark/renderer"
+)
+
+func linkRenderers() []renderer.NodeRenderer {
+	return []renderer.NodeRenderer{
+		crenderer.NewConfluenceLinkRenderer(),
+		crenderer.NewConfluenceParagraphRenderer(),
+		crenderer.NewConfluenceTextLegacyRenderer(false),
+	}
+}
+
+// TestLinkToConfluencePageByTitle covers the ac: destination, which is how a
+// document links to another Confluence page by title rather than by URL.
+func TestLinkToConfluencePageByTitle(t *testing.T) {
+	actual := render(t, "[Text](ac:Page)\n", linkRenderers())
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual,
+		`<ac:link><ri:page ri:content-title="Page"/><ac:plain-text-link-body><![CDATA[Text]]></ac:plain-text-link-body></ac:link>`)
+}
+
+// TestLinkTitleIsEscapedIntoTheAttribute covers the escaping that keeps a page
+// title from breaking the document. The title is interpolated into an XML
+// attribute, where an unescaped "&" makes the body malformed -- Confluence
+// rejects the whole page, not the one link -- and a quote closes the attribute
+// early, letting document text inject attributes of its own.
+func TestLinkTitleIsEscapedIntoTheAttribute(t *testing.T) {
+	amp := render(t, "[A & B](<ac:Q & A>)\n", linkRenderers())
+	assertWellFormed(t, amp)
+	assert.Contains(t, amp, `ri:content-title="Q &amp; A"`)
+
+	quoted := render(t, "[t](<ac:Say \"hi\">)\n", linkRenderers())
+	assertWellFormed(t, quoted)
+	assert.NotContains(t, quoted, `ri:content-title="Say "hi""`,
+		"a raw quote would close the attribute and let the rest inject more")
+	assert.Contains(t, quoted, `Say &#34;hi&#34;`)
+}
+
+// TestLinkBodyEscapesTheCDATATerminator covers the other half of the same
+// problem. The link text goes inside CDATA, where "]]>" ends the section early;
+// splitting it across two sections is the only legal way to carry it.
+func TestLinkBodyEscapesTheCDATATerminator(t *testing.T) {
+	// A code span is how the sequence gets into link text at all: a bare "]" in
+	// a label ends the label, and a backslash-escaped one stays backslashed
+	// (see TestLinkBodyKeepsBackslashEscapes).
+	actual := render(t, "[a `]]>` b](ac:Page)\n", linkRenderers())
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `<![CDATA[a ]]><![CDATA[]]]]><![CDATA[> b]]>`)
+}
+
+// TestLinkBodyKeepsBackslashEscapes records current behaviour rather than
+// intended behaviour. The body is built from the link's source text, so a
+// Markdown escape inside the label is never resolved and the backslash reaches
+// the page: "[foo \_bar\_](ac:Page)" publishes "foo \_bar\_". Inline markup
+// fares better -- emphasis is dropped to plain text, which is all
+// ac:plain-text-link-body can hold.
+func TestLinkBodyKeepsBackslashEscapes(t *testing.T) {
+	escaped := render(t, `[foo \_bar\_](ac:Page)`+"\n", linkRenderers())
+	assertWellFormed(t, escaped)
+	assert.Contains(t, escaped, `<![CDATA[foo \_bar\_]]>`)
+
+	emphasised := render(t, "[**bold** text](ac:Page)\n", linkRenderers())
+	assertWellFormed(t, emphasised)
+	assert.Contains(t, emphasised, `<![CDATA[bold text]]>`)
+}
+
+// TestLinkWithEmptyPageTitleFallsBackToTheText covers a bare "ac:" destination:
+// with no title after the prefix, the link text is the title.
+func TestLinkWithEmptyPageTitleFallsBackToTheText(t *testing.T) {
+	actual := render(t, "[bare](ac:)\n", linkRenderers())
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `ri:content-title="bare"`)
+}
+
+// TestOrdinaryLinkKeepsGoldmarkBehaviour covers the case the renderer does not
+// change: an ordinary URL is still an <a>, with the destination and title
+// escaped for HTML.
+func TestOrdinaryLinkKeepsGoldmarkBehaviour(t *testing.T) {
+	actual := render(t, "[ext](https://example.com/a?b=1&c=2 \"T & T\")\n", linkRenderers())
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `<a href="https://example.com/a?b=1&amp;c=2" title="T &amp; T">ext</a>`)
+}

--- a/renderer/mention_test.go
+++ b/renderer/mention_test.go
@@ -1,0 +1,33 @@
+package renderer_test
+
+import (
+	"testing"
+
+	cparser "github.com/kovetskiy/mark/v16/parser"
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+// TestMentionWithoutAnAPIFallsBackToTheName covers the path every offline run
+// takes, --compile-only included: the ac:link:user template asks Confluence for
+// the account behind the name, and with no API to ask it writes the name as
+// text.
+//
+// The alternative would be an ac:link with an empty ri:user, which Confluence
+// renders as a broken mention rather than as the word the author wrote.
+func TestMentionWithoutAnAPIFallsBackToTheName(t *testing.T) {
+	actual := render(t, "Hello @{username}!\n",
+		[]renderer.NodeRenderer{
+			crenderer.NewConfluenceMentionRenderer(newStdlib(t)),
+			crenderer.NewConfluenceParagraphRenderer(),
+			crenderer.NewConfluenceTextRenderer(false),
+		},
+		parser.WithInlineParsers(util.Prioritized(cparser.NewMentionParser(), 99)))
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "Hello username!")
+	assert.NotContains(t, actual, "ri:user")
+}

--- a/renderer/mkDocsAdmonition_test.go
+++ b/renderer/mkDocsAdmonition_test.go
@@ -1,0 +1,104 @@
+package renderer_test
+
+import (
+	"strings"
+	"testing"
+
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	mkDocsParser "github.com/stefanfritsch/goldmark-admonitions"
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+func admonitionRenderers() []renderer.NodeRenderer {
+	return []renderer.NodeRenderer{
+		crenderer.NewConfluenceMkDocsAdmonitionRenderer(),
+		crenderer.NewConfluenceParagraphRenderer(),
+		crenderer.NewConfluenceTextRenderer(false),
+	}
+}
+
+func admonitionParserOptions() []parser.Option {
+	return []parser.Option{
+		parser.WithBlockParsers(util.Prioritized(mkDocsParser.NewAdmonitionParser(), 100)),
+	}
+}
+
+// TestAdmonitionMacroMapping covers the four MkDocs classes that have a
+// Confluence macro. Unlike GitHub Alerts, the names line up one to one here --
+// except that MkDocs "warning" is Confluence's warning, where GitHub's
+// "warning" is Confluence's note.
+func TestAdmonitionMacroMapping(t *testing.T) {
+	tests := []struct {
+		class string
+		want  string
+	}{
+		{"info", "info"},
+		{"note", "note"},
+		{"warning", "warning"},
+		{"tip", "tip"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.class, func(t *testing.T) {
+			actual := render(t, "!!! "+tt.class+"\n    The body.\n", admonitionRenderers(), admonitionParserOptions()...)
+			assertWellFormed(t, actual)
+
+			assert.Contains(t, actual, `<ac:structured-macro ac:name="`+tt.want+`">`)
+			assert.Contains(t, actual, `<ac:parameter ac:name="icon">true</ac:parameter>`)
+			assert.Contains(t, actual, "The body.")
+		})
+	}
+}
+
+// TestAdmonitionUnknownClassStaysAQuote covers a class Confluence has no macro
+// for -- MkDocs has a dozen of them. It has to degrade to a blockquote rather
+// than pick a macro at random or drop the content.
+//
+// The quote keeps the attributes the admonition parser put on it, and one of
+// them is a randomly generated data-admonition id. That makes the published
+// body differ between two runs over an unchanged document, so an unknown class
+// is worth avoiding for anything published repeatedly.
+func TestAdmonitionUnknownClassStaysAQuote(t *testing.T) {
+	actual := render(t, "!!! danger\n    Mind the gap.\n", admonitionRenderers(), admonitionParserOptions()...)
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "<blockquote")
+	assert.Contains(t, actual, `class="admonition adm-danger"`)
+	assert.Contains(t, actual, "Mind the gap.")
+	assert.NotContains(t, actual, "ac:structured-macro")
+}
+
+// TestAdmonitionTitle covers the quoted title, which Confluence's macros have
+// no parameter for and which is therefore written as a bold first paragraph
+// inside the body.
+func TestAdmonitionTitle(t *testing.T) {
+	actual := render(t, "!!! note \"NOTES:\"\n    The body.\n", admonitionRenderers(), admonitionParserOptions()...)
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "<p><strong>NOTES:</strong></p>")
+}
+
+// TestAdmonitionTitleIsEscaped covers a title carrying markup characters. It is
+// written into the body as markup, so an unescaped "&" or "<" would make the
+// document malformed and cost the whole page.
+func TestAdmonitionTitleIsEscaped(t *testing.T) {
+	actual := render(t, "!!! note \"A & B <script>\"\n    The body.\n", admonitionRenderers(), admonitionParserOptions()...)
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "A &amp; B &lt;script&gt;")
+}
+
+// TestAdmonitionNested covers an admonition inside an admonition, which MkDocs
+// documents and which the fixtures in testdata/ use. Both become macros: unlike
+// blockquotes, the inner one is not degraded.
+func TestAdmonitionNested(t *testing.T) {
+	actual := render(t, "!!! note \"Outer\"\n    Text.\n\n    !!! tip\n        Inner.\n", admonitionRenderers(), admonitionParserOptions()...)
+	assertWellFormed(t, actual)
+
+	assert.Equal(t, 2, strings.Count(actual, "<ac:structured-macro"))
+	assert.Equal(t, 2, strings.Count(actual, "</ac:structured-macro>"))
+	assert.Contains(t, actual, `ac:name="tip"`)
+}

--- a/renderer/paragraph_test.go
+++ b/renderer/paragraph_test.go
@@ -1,0 +1,56 @@
+package renderer_test
+
+import (
+	"testing"
+
+	cparser "github.com/kovetskiy/mark/v16/parser"
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+func paragraphRenderers() []renderer.NodeRenderer {
+	return []renderer.NodeRenderer{
+		crenderer.NewConfluenceParagraphRenderer(),
+		crenderer.NewConfluenceTextLegacyRenderer(false),
+	}
+}
+
+// TestParagraphWrapsProse is the ordinary case.
+func TestParagraphWrapsProse(t *testing.T) {
+	actual := render(t, "Some prose.\n", paragraphRenderers())
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "<p>Some prose.</p>")
+}
+
+// TestParagraphOpeningWithRawHTMLIsNotWrapped covers why this renderer exists
+// at all.
+//
+// A line that starts with a raw tag is a macro the author wrote by hand --
+// <ac:structured-macro>, <ac:link>, an <ac:image> -- and several of those are
+// not valid inside a <p>. Wrapping them produces storage format the editor
+// normalises on the next save, moving or dropping the macro, so a paragraph
+// whose first child is raw HTML is written without the wrapper.
+func TestParagraphOpeningWithRawHTMLIsNotWrapped(t *testing.T) {
+	actual := render(t, "<ac:structured-macro ac:name=\"toc\"/>\n",
+		paragraphRenderers(),
+		parser.WithInlineParsers(util.Prioritized(cparser.NewConfluenceTagParser(), 199)))
+
+	assert.NotContains(t, actual, "<p>", "the macro must not be wrapped")
+	assert.Contains(t, actual, `<ac:structured-macro ac:name="toc"/>`)
+}
+
+// TestParagraphWithRawHTMLLaterIsStillWrapped is the boundary of that rule:
+// only a paragraph that *opens* with a tag skips the wrapper, so prose with a
+// macro in the middle keeps its <p> and stays a paragraph.
+func TestParagraphWithRawHTMLLaterIsStillWrapped(t *testing.T) {
+	actual := render(t, "text <ac:structured-macro ac:name=\"toc\"/>\n",
+		paragraphRenderers(),
+		parser.WithInlineParsers(util.Prioritized(cparser.NewConfluenceTagParser(), 199)))
+
+	assert.Contains(t, actual, "<p>text ")
+	assert.Contains(t, actual, "</p>")
+}

--- a/renderer/tasklist_test.go
+++ b/renderer/tasklist_test.go
@@ -61,3 +61,76 @@ func TestConfluenceTaskListRendererIDsAreUniquePerDocument(t *testing.T) {
 		})
 	}
 }
+
+// TestTaskListRendererLeavesOrdinaryListsAlone covers the other half of this
+// renderer's job. It claims List and ListItem for the whole document, not only
+// for lists with checkboxes, so an ordinary bullet or numbered list has to come
+// out as one -- an <ul> turned into an ac:task-list would put a checkbox beside
+// every line of prose.
+func TestTaskListRendererLeavesOrdinaryListsAlone(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "bullets",
+			input: "- one\n- two\n",
+			want:  []string{"<ul>", "<li>one</li>", "</ul>"},
+		},
+		{
+			name:  "numbers keep their start",
+			input: "5. five\n6. six\n",
+			want:  []string{`<ol start="5">`, "<li>five</li>", "</ol>"},
+		},
+		{
+			name:  "nesting",
+			input: "- outer\n    - inner\n",
+			want:  []string{"<ul>", "<li>outer", "<li>inner</li>"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gm := goldmark.New(
+				goldmark.WithExtensions(extension.TaskList),
+				goldmark.WithRendererOptions(
+					renderer.WithNodeRenderers(
+						util.Prioritized(crenderer.NewConfluenceTaskListRenderer(), 100),
+					),
+				),
+			)
+
+			var buf bytes.Buffer
+			require.NoError(t, gm.Convert([]byte(tt.input), &buf))
+			got := buf.String()
+
+			assert.NotContains(t, got, "ac:task", "an ordinary list is not a task list")
+			for _, want := range tt.want {
+				assert.Contains(t, got, want)
+			}
+		})
+	}
+}
+
+// TestTaskListCheckedState covers the state Confluence reads: a task list that
+// loses the difference between a done and an open item is worse than no task
+// list at all.
+func TestTaskListCheckedState(t *testing.T) {
+	gm := goldmark.New(
+		goldmark.WithExtensions(extension.TaskList),
+		goldmark.WithRendererOptions(
+			renderer.WithNodeRenderers(
+				util.Prioritized(crenderer.NewConfluenceTaskListRenderer(), 100),
+			),
+		),
+	)
+
+	var buf bytes.Buffer
+	require.NoError(t, gm.Convert([]byte("- [x] done\n- [ ] open\n"), &buf))
+	got := buf.String()
+
+	assert.Contains(t, got, "<ac:task-status>complete</ac:task-status>")
+	assert.Contains(t, got, "<ac:task-status>incomplete</ac:task-status>")
+	assert.Equal(t, 1, strings.Count(got, "<ac:task-list>"))
+}

--- a/renderer/text_test.go
+++ b/renderer/text_test.go
@@ -1,0 +1,96 @@
+package renderer_test
+
+import (
+	"testing"
+
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark/renderer"
+)
+
+// TestTextSoftBreak covers --strip-linebreaks, which exists because Confluence
+// turns a newline in the body into a visible line break.
+//
+// A document written one-sentence-per-line therefore publishes as a ragged
+// column unless the soft breaks are flattened to spaces. Both text renderers
+// have to agree on this: the legacy one and the GitHub Alerts one are separate
+// implementations of the same rule.
+func TestTextSoftBreak(t *testing.T) {
+	const source = "first line\nsecond line\n"
+
+	tests := []struct {
+		name      string
+		renderers []renderer.NodeRenderer
+		want      string
+	}{
+		{
+			name: "legacy keeps the newline",
+			renderers: []renderer.NodeRenderer{
+				crenderer.NewConfluenceTextLegacyRenderer(false),
+				crenderer.NewConfluenceParagraphRenderer(),
+			},
+			want: "<p>first line\nsecond line</p>",
+		},
+		{
+			name: "legacy strips the newline",
+			renderers: []renderer.NodeRenderer{
+				crenderer.NewConfluenceTextLegacyRenderer(true),
+				crenderer.NewConfluenceParagraphRenderer(),
+			},
+			want: "<p>first line second line</p>",
+		},
+		{
+			name: "alerts renderer keeps the newline",
+			renderers: []renderer.NodeRenderer{
+				crenderer.NewConfluenceTextRenderer(false),
+				crenderer.NewConfluenceParagraphRenderer(),
+			},
+			want: "<p>first line\nsecond line</p>",
+		},
+		{
+			name: "alerts renderer strips the newline",
+			renderers: []renderer.NodeRenderer{
+				crenderer.NewConfluenceTextRenderer(true),
+				crenderer.NewConfluenceParagraphRenderer(),
+			},
+			want: "<p>first line second line</p>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Contains(t, render(t, source, tt.renderers), tt.want)
+		})
+	}
+}
+
+// TestTextHardBreakSurvivesStripping covers the line break the author asked for
+// with two trailing spaces. Stripping soft breaks must not take it: it is the
+// only way to get a line break inside a paragraph on purpose.
+func TestTextHardBreakSurvivesStripping(t *testing.T) {
+	const source = "first line  \nsecond line\n"
+
+	for _, strip := range []bool{false, true} {
+		actual := render(t, source, []renderer.NodeRenderer{
+			crenderer.NewConfluenceTextRenderer(strip),
+			crenderer.NewConfluenceParagraphRenderer(),
+		})
+		assertWellFormed(t, actual)
+
+		assert.Contains(t, actual, "<br />", "strip-linebreaks=%v must keep a hard break", strip)
+	}
+}
+
+// TestTextEscapesMarkupCharacters covers the escaping every other renderer
+// relies on: prose reaches the page through this one, and an unescaped "&" or
+// "<" makes the whole body malformed, which Confluence rejects outright.
+func TestTextEscapesMarkupCharacters(t *testing.T) {
+	actual := render(t, "A & B, 3 < 4, \"quoted\"\n", []renderer.NodeRenderer{
+		crenderer.NewConfluenceTextRenderer(false),
+		crenderer.NewConfluenceParagraphRenderer(),
+	})
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "A &amp; B")
+	assert.Contains(t, actual, "3 &lt; 4")
+}

--- a/renderer/util_test.go
+++ b/renderer/util_test.go
@@ -1,0 +1,39 @@
+package renderer_test
+
+import (
+	"testing"
+
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetLineCol covers the position arithmetic behind the one error message a
+// user is likely to see from a diagram block: "line 12, col 3: mermaid
+// rendering failed". A position computed from the wrong offset sends the author
+// to the wrong block, which is worse than no position at all.
+func TestGetLineCol(t *testing.T) {
+	source := []byte("first\nsecond\n\nfourth")
+
+	tests := []struct {
+		name     string
+		offset   int
+		wantLine int
+		wantCol  int
+	}{
+		{"start of the document", 0, 1, 1},
+		{"inside the first line", 3, 1, 4},
+		{"the newline itself", 5, 1, 6},
+		{"start of the second line", 6, 2, 1},
+		{"an empty line", 13, 3, 1},
+		{"the first character of the last line", 14, 4, 1},
+		{"past the end clamps to the end", 1000, 4, 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			line, col := crenderer.GetLineCol(source, tt.offset)
+			assert.Equal(t, tt.wantLine, line, "line")
+			assert.Equal(t, tt.wantCol, col, "col")
+		})
+	}
+}

--- a/util/auth_test.go
+++ b/util/auth_test.go
@@ -1,0 +1,119 @@
+package util
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetCredentialsBaseURLFromTargetURL covers the shortest way to publish:
+// paste the URL of an existing page and let mark take the instance and the page
+// id out of it.
+func TestGetCredentialsBaseURLFromTargetURL(t *testing.T) {
+	creds, err := GetCredentials("user", "secret",
+		"https://confluence.example.com/pages/viewpage.action?pageId=12345", "", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://confluence.example.com", creds.BaseURL)
+	assert.Equal(t, "12345", creds.PageID)
+	assert.Equal(t, "user", creds.Username)
+	assert.Equal(t, "secret", creds.Password)
+}
+
+// TestGetCredentialsExplicitBaseURLWins covers -l beside a target URL: the flag
+// is the instance, and the URL only supplies the page id.
+func TestGetCredentialsExplicitBaseURLWins(t *testing.T) {
+	creds, err := GetCredentials("user", "secret",
+		"https://old.example.com/pages/viewpage.action?pageId=7", "https://new.example.com/wiki", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://new.example.com/wiki", creds.BaseURL)
+	assert.Equal(t, "7", creds.PageID)
+}
+
+// TestGetCredentialsTrimsTrailingSlashes covers the base URL as people actually
+// write it in a config file. Every request path is appended to this value, so a
+// trailing slash would produce "//rest/api" and a 404 that says nothing about
+// its cause.
+func TestGetCredentialsTrimsTrailingSlashes(t *testing.T) {
+	creds, err := GetCredentials("user", "secret", "", "https://confluence.example.com/wiki///", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://confluence.example.com/wiki", creds.BaseURL)
+}
+
+// TestGetCredentialsRequiresAPassword covers the message people see most often.
+// It names the flag, because the alternative -- a 401 from Confluence -- sends
+// them looking at their account instead of at their invocation.
+func TestGetCredentialsRequiresAPassword(t *testing.T) {
+	_, err := GetCredentials("user", "", "", "https://confluence.example.com", false)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "-p")
+}
+
+// TestGetCredentialsRequiresABaseURL covers the same for the instance: with
+// neither a target URL to derive it from nor -l, there is nothing to talk to.
+func TestGetCredentialsRequiresABaseURL(t *testing.T) {
+	_, err := GetCredentials("user", "secret", "", "", false)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "-l")
+}
+
+// TestGetCredentialsCompileOnlyNeedsNothing covers --compile-only, which never
+// reaches Confluence. Requiring credentials to render Markdown locally would
+// make the flag useless in CI, so both are filled in with placeholders.
+func TestGetCredentialsCompileOnlyNeedsNothing(t *testing.T) {
+	creds, err := GetCredentials("", "", "", "", true)
+	require.NoError(t, err)
+
+	assert.Equal(t, "none", creds.Password)
+	assert.Equal(t, "http://localhost", creds.BaseURL)
+	assert.Empty(t, creds.PageID)
+}
+
+// TestGetCredentialsCompileOnlyKeepsRealValues is the boundary of that rule:
+// the placeholders fill gaps, they do not override what was given.
+func TestGetCredentialsCompileOnlyKeepsRealValues(t *testing.T) {
+	creds, err := GetCredentials("user", "secret", "", "https://confluence.example.com", true)
+	require.NoError(t, err)
+
+	assert.Equal(t, "secret", creds.Password)
+	assert.Equal(t, "https://confluence.example.com", creds.BaseURL)
+}
+
+// TestGetCredentialsPasswordFromStdin covers "-p -", which is how a token gets
+// in without appearing in the process list or in shell history. The trailing
+// newline a pipe or a heredoc adds has to go: it would be sent as part of the
+// token and answered with a 401.
+func TestGetCredentialsPasswordFromStdin(t *testing.T) {
+	read, write, err := os.Pipe()
+	require.NoError(t, err)
+
+	original := os.Stdin
+	os.Stdin = read
+	defer func() { os.Stdin = original }()
+
+	go func() {
+		defer write.Close()
+		_, _ = write.WriteString("token-from-stdin\n")
+	}()
+
+	creds, err := GetCredentials("user", "-", "", "https://confluence.example.com", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "token-from-stdin", creds.Password)
+}
+
+// TestGetCredentialsRejectsAnUnparseableURL covers the target URL that is not
+// one at all, which is worth an error naming the value rather than a request to
+// an empty host.
+func TestGetCredentialsRejectsAnUnparseableURL(t *testing.T) {
+	_, err := GetCredentials("user", "secret", "https://exam ple.com/x", "", false)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "as url")
+}


### PR DESCRIPTION
`renderer/` produces the storage format with four test files against eighteen sources, and it is the package where a mistake is expensive: Confluence answers a body that is not well-formed with `BadRequestException` and rejects the **document**, not the element. Everything in it was reached only indirectly, through the golden files in `markdown/`, which compare whole documents and say nothing about which renderer was wrong.

**renderer 11% → 74%, util 25% → 52%.**

## What the tests check

Not lines — the things that actually break pages:

- **Escaping at every boundary.** A page title in an XML attribute, link text and code samples in CDATA, an admonition title written as markup, an image URL carrying a query string. Every macro-producing test then parses its own output as XML, which is what Confluence does with it.
- **The mappings that have no error case.** GitHub's five alert types onto Confluence's four macros — GitHub's `warning` is the amber one and its `caution` the red one, so `warning` maps to `note` and `caution` to `warning`. Get it backwards and the page renders perfectly while telling the reader the opposite about how dangerous something is. Same for MkDocs' admonition classes.
- **The flags that change output.** `--drop-h1` taking the first h1 and never an h2 or a later h1; `--strip-linebreaks` flattening soft breaks while leaving hard ones alone, across both text renderers.
- **The code block info string.** Including the language names that are not word characters (`c#`, `c++`, `.NET`, `html/xml`) that a `\w`-only class used to truncate, and the numeric option that sets two parameters at once.
- Images as attachment vs URL, footnote anchors at both ends of a jump, the emoji split between macro and plain character, `GetLineCol` behind the diagram error messages.

`util/` gets the same treatment for `GetCredentials`, which decides what mark connects to and had no tests at all: base URL derived from a page URL, `-l` overriding it, `--compile-only` filling in placeholders, a password read from stdin (with the trailing newline trimmed, or it is sent as part of the token), and the two errors that name the flag rather than letting the run fail later as a 401.

## Three things documented rather than asserted as correct

Each is a test with a comment saying so — candidates for a fix, not fixed here:

1. A backslash escape inside an `ac:` link body reaches the page as written: `[foo \_bar\_](ac:Page)` publishes `foo \_bar\_`. The body is built from the link's source text, so the escape is never resolved.
2. ` ```- ` publishes `language="-"`, where the README offers `-` as the way to write a block with *no* language. The regex means to allow it — its comment reads `(<Lang>|-)` — but `-` is also in the language character class, so the first alternative matches and the sentinel is unreachable.
3. An admonition class Confluence has no macro for keeps the parser's randomly generated `data-admonition` id, so the same unchanged document publishes differently on every run.

Also worth a decision, untouched here: `ParseLanguage` and `ParseTitle` in `fencedcodeblock.go` are exported, called by nothing, and disagree with the regex the renderer actually uses (`ParseLanguage("collapse")` returns no language; the renderer takes `collapse` as the language name). They are a trap for anyone who "fixes" the renderer to match them.

## AGENTS.md

Its coverage figures predate `confluence/confluencetest` and it tells the reader there is no fake Confluence server. Both corrected, with measured numbers and a note that `make test` passes no `-coverpkg` — so a package's figure counts only what its *own* tests exercise, which is why `renderer/`'s number understated how much the `markdown/` golden tests were already driving.

## Not covered, on purpose

`cmd/mark/`, `vfs/` and `chrome/` stay at 0%: a thin `main`, a 19-line `os.Open` wrapper, and a package that needs a browser and is already exercised through `d2/` and `mermaid/`. Testing those moves the number without moving the risk.

## Testing

`go test ./... -count=1`, `golangci-lint run ./...` and `markdownlint-cli2` all pass. No production code changed — this PR is tests and one documentation paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
