### PR TITLE
build(ci): run the unit tests on ubuntu-latest again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
   # Executes Unit Tests
   ci-unit-tests:
     name: ci-unit-tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v7


### PR DESCRIPTION
`ci-unit-tests` is the one job pinned to `ubuntu-22.04`. This unpins it.

## Why it was pinned

From #546: on 24.04 Chrome aborted in `ZygoteHostImpl::Init`. Ubuntu 23.10 and later restrict unprivileged user namespaces through AppArmor (`kernel.apparmor_restrict_unprivileged_userns=1`), and Chrome refuses to start without a usable sandbox. The workaround recorded in that issue was "run tests on 22.04".

## Why the pin is no longer doing anything

mark now disables the sandbox itself. `chrome.AllocatorOptions` passes `--no-sandbox` and `--disable-setuid-sandbox` unconditionally, with a comment naming this exact class of environment — restricted containers, hardened seccomp profiles, and Ubuntu 23.10+. That code landed on 2026-08-08, more than a year after the pin went in, and nobody revisited the runner label afterwards.

Evidence beyond reading the code:

- The d2, mermaid and manifest suites pass on a 26.04 workstation with `kernel.apparmor_restrict_unprivileged_userns=1` — the same restriction the 24.04 runner has.
- This PR's own `ci-unit-tests` run is the real test: it drives headless Chrome through the d2 and mermaid suites on `ubuntu-latest`. If Chrome still could not start, this job is where it would show.

## Why it is worth doing now rather than later

The pin is the more fragile half of the arrangement. `ubuntu-22.04` is on its way out as a hosted runner label, and when it goes this job does not start failing — it stops running, which is a quieter failure than the one the pin was protecting against.

Every other job in the workflow already uses `ubuntu-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
