### PR TITLE
feat(track-pages): follow a renamed parent by the chain it resolved to

### DIFF
--- a/README.md
+++ b/README.md
@@ -1717,7 +1717,7 @@ file, no commit. The record lives in Confluence.
 | `Title` header edited | the path is the key, so the lookup still hits |
 | leading H1 edited | the same |
 | file renamed | content fingerprint, matched against paths that stopped appearing |
-| parent page renamed | the title it was published under, followed to the page holding it now |
+| parent page renamed | the page the declared parent chain resolved to last run, whatever it is called now |
 | folder renamed in Confluence | the recorded folder ID, reused rather than duplicated |
 | source file deleted | a recorded path absent from a run whose pattern covered it |
 | two files claiming one page | the reverse index, when the second one is recorded |
@@ -1774,7 +1774,7 @@ writes nothing at all -- neither to Confluence nor to the mapping.
 
 | | storage |
 | --- | --- |
-| Cloud | space properties `mark.manifest.0` … `mark.manifest.15`, and `mark.manifest.folders` |
+| Cloud | space properties `mark.manifest.0` … `mark.manifest.15`, `mark.manifest.folders` and `mark.manifest.parents` |
 | Server / Data Center | content properties of the same names, on the space homepage |
 
 Space properties exist only in the v2 API, so Server and Data Center anchor to
@@ -1786,6 +1786,12 @@ It is split over sixteen properties rather than held in one because Confluence
 bounds how large a single property value may be, and one blob would cap how many
 files a repository may have. Each path is assigned a shard by hash; all of them
 are read in a single request and only the ones that changed are written back.
+
+Folders and parents live in properties of their own rather than among the
+shards. They are keyed by the chain of titles a document declares rather than by
+a source path, there are few enough of them that splitting them buys nothing,
+and a key of theirs among the page keys would be reported as a source file that
+had gone missing.
 
 ### Removing pages whose files are gone
 

--- a/README.md
+++ b/README.md
@@ -1743,7 +1743,7 @@ recovers a rename after the fact rather than being told about it.
 | anything in the first run | nothing is recorded until a file publishes with the flag set, so the first run only adopts |
 | a rename across two `--files` patterns | matching and reporting are both scoped to the pattern that recorded the entry, so the file is a deletion in one and a new page in the other. That scoping is what lets several Mark invocations publish different folders into one space without reaching into each other's pages |
 | whether a deletion was intended | it reports; it never deletes |
-| a `Parent:` header change | still fails the run with an ancestry error rather than moving the page |
+| a page nested deeper than its headers declare | every parent it declares is still somewhere in its ancestry, so there is nothing to find wrong, and moving it would tear up a hierarchy nobody asked to change. A `Parent:` change that does contradict the ancestry moves the page, with tracking or without it |
 | a moved space homepage (Server/DC) | the mapping is anchored to it, so tracking starts over |
 
 A page renamed by hand in Confluence is found by its ID and renamed back to what

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -348,6 +348,18 @@ func (s *Server) Page(id string) *Page {
 	return nil
 }
 
+// RenamePage retitles a page, as somebody doing it in the Confluence UI would
+// -- which is the case mark cannot see coming, and the one that strands every
+// document declaring the old title as its parent.
+func (s *Server) RenamePage(id, title string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if p, ok := s.pages[id]; ok {
+		p.Title = title
+	}
+}
+
 // AddLabel stands in for somebody labelling a page in the Confluence web UI.
 func (s *Server) AddLabel(id, label string) {
 	s.mu.Lock()

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -116,6 +116,15 @@ const PropertyKeyPrefix = "mark.manifest"
 // page keys would be reported as a source file that had gone missing.
 const FolderPropertyKey = PropertyKeyPrefix + ".folders"
 
+// ParentPropertyKey holds the parent mapping.
+//
+// Kept apart from the page shards for the reasons the folder mapping is: it is
+// keyed by the chain of titles a document declares rather than by a source
+// path, there are few enough of them that splitting them buys nothing, and a
+// parent key among the page keys would be reported as a source file that had
+// gone missing.
+const ParentPropertyKey = PropertyKeyPrefix + ".parents"
+
 // ShardCount is how many properties the mapping is spread over.
 //
 // Fixed rather than grown on demand: the shard a path belongs to is derived
@@ -210,6 +219,12 @@ type folderDocument struct {
 	Folders map[string]string `json:"folders"`
 }
 
+// parentDocument is the parent mapping as stored.
+type parentDocument struct {
+	Version int               `json:"version"`
+	Parents map[string]string `json:"parents"`
+}
+
 // document is one shard as stored.
 type document struct {
 	Version int              `json:"version"`
@@ -275,6 +290,18 @@ type spaceState struct {
 	folders        map[string]string
 	folderProperty *confluence.Property
 	foldersDirty   bool
+
+	// parents maps a declared parent chain to the page it resolved to, so a
+	// parent renamed in Confluence is found again instead of a second page
+	// being created under the title the document still declares.
+	//
+	// Distinct from titles, which only knows pages mark published from a source
+	// file. Most parents are not that: they are pages somebody made in the UI,
+	// or the empty ones mark created to hold a hierarchy, and neither has ever
+	// been in the title index.
+	parents        map[string]string
+	parentProperty *confluence.Property
+	parentsDirty   bool
 
 	// titles maps the title each path was published under *as read*, and is
 	// deliberately never updated during a run. Resolving a stale reference asks
@@ -416,6 +443,33 @@ func (state *spaceState) writeProperty(
 	return api.SetContentProperty(state.contentID, key, value, existing)
 }
 
+// writeMapping stores one of the mappings that covers the whole space -- the
+// folders or the parents -- and reports whether it was written.
+//
+// A conflict is warned about rather than failed on, as it is for a shard:
+// another run wrote between this run's read and its write, the two are not
+// mergeable from here, and losing the mapping is not worth failing a publish
+// that has already succeeded.
+func (state *spaceState) writeMapping(
+	api *confluence.API,
+	spaceKey, key string,
+	value []byte,
+	existing *confluence.Property,
+	what string,
+) (bool, error) {
+	if err := state.writeProperty(api, key, value, existing); err != nil {
+		if errors.Is(err, confluence.ErrPropertyConflict) {
+			log.Warn().Msgf(
+				"%s for space %q was updated by a concurrent run; it was not saved",
+				what, spaceKey,
+			)
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 // load returns the state for a space, reading it from Confluence on first use.
 func (s *Store) load(spaceKey string) (*spaceState, error) {
 	if state, ok := s.spaces[spaceKey]; ok {
@@ -427,6 +481,7 @@ func (s *Store) load(spaceKey string) (*spaceState, error) {
 		byPage:  map[string]string{},
 		titles:  map[string]string{},
 		folders: map[string]string{},
+		parents: map[string]string{},
 		seen:    map[string]bool{},
 		claimed: map[string]bool{},
 	}
@@ -464,6 +519,20 @@ func (s *Store) load(spaceKey string) (*spaceState, error) {
 				)
 			} else if doc.Version <= formatVersion && doc.Folders != nil {
 				state.folders = doc.Folders
+			}
+			continue
+		}
+
+		if properties[i].Key == ParentPropertyKey {
+			state.parentProperty = &properties[i]
+			var doc parentDocument
+			if err := json.Unmarshal(properties[i].Value, &doc); err != nil {
+				log.Warn().Err(err).Msgf(
+					"ignoring unreadable %s property of space %q; parents are no longer tracked",
+					ParentPropertyKey, spaceKey,
+				)
+			} else if doc.Version <= formatVersion && doc.Parents != nil {
+				state.parents = doc.Parents
 			}
 			continue
 		}
@@ -774,6 +843,46 @@ func (s *Store) LookupFolder(spaceKey, folderPath string) (string, bool, error) 
 	return folderID, ok, nil
 }
 
+// RecordParent notes which Confluence page a declared parent chain resolved to.
+// The path is the chain of titles from the document's headers, joined so that
+// the same title at a different depth is a different key.
+func (s *Store) RecordParent(spaceKey, parentPath, pageID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, err := s.load(spaceKey)
+	if err != nil {
+		return err
+	}
+
+	if existing, ok := state.parents[parentPath]; ok && existing == pageID {
+		return nil
+	}
+
+	state.parents[parentPath] = pageID
+	state.parentsDirty = true
+	return nil
+}
+
+// LookupParent returns the page a declared parent chain resolved to last time.
+//
+// A chain is never forgotten, including after the parent has been renamed and
+// the new title recorded alongside it. The old key still names the same page,
+// and a document that has not been updated to the new title is exactly the one
+// this exists for.
+func (s *Store) LookupParent(spaceKey, parentPath string) (string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, err := s.load(spaceKey)
+	if err != nil {
+		return "", false, err
+	}
+
+	pageID, ok := state.parents[parentPath]
+	return pageID, ok, nil
+}
+
 // Orphans returns the recorded paths this run was looking for and did not find.
 //
 // Only entries published by the same --files pattern count. A run narrowed to
@@ -921,19 +1030,31 @@ func (s *Store) Save() error {
 				return fmt.Errorf("unable to encode folder mapping for space %q: %w", spaceKey, err)
 			}
 
-			err = state.writeProperty(s.api, FolderPropertyKey, value, state.folderProperty)
+			written, err := state.writeMapping(
+				s.api, spaceKey, FolderPropertyKey, value, state.folderProperty, "folder mapping",
+			)
 			if err != nil {
-				if errors.Is(err, confluence.ErrPropertyConflict) {
-					log.Warn().Msgf(
-						"folder mapping for space %q was updated by a concurrent run; it was not saved",
-						spaceKey,
-					)
-				} else {
-					return err
-				}
-			} else {
-				state.foldersDirty = false
+				return err
 			}
+			state.foldersDirty = !written
+		}
+
+		if state.parentsDirty {
+			value, err := json.Marshal(parentDocument{
+				Version: formatVersion,
+				Parents: state.parents,
+			})
+			if err != nil {
+				return fmt.Errorf("unable to encode parent mapping for space %q: %w", spaceKey, err)
+			}
+
+			written, err := state.writeMapping(
+				s.api, spaceKey, ParentPropertyKey, value, state.parentProperty, "parent mapping",
+			)
+			if err != nil {
+				return err
+			}
+			state.parentsDirty = !written
 		}
 
 		for i := range state.shards {

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -579,6 +579,65 @@ func TestFolderMappingIsKeptOutOfThePageShards(t *testing.T) {
 		"a folder key must never be reported as a missing file")
 }
 
+// TestParentMappingRoundTrip covers the parent half. Parents are found by title
+// too, so one renamed in Confluence stops matching the header that declares it
+// and mark creates an empty page under the old name.
+func TestParentMappingRoundTrip(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+
+	require.NoError(t, store.RecordParent("DOCS", "Docs\x00Team", "page-1"))
+	require.NoError(t, store.Save())
+
+	next := newStoreOn(t, server)
+	id, ok, err := next.LookupParent("DOCS", "Docs\x00Team")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "page-1", id)
+}
+
+// TestParentMappingIsKeptOutOfThePageShards: a parent key among the page keys
+// would be reported as a source file that had gone missing, and most parents
+// have no source file at all.
+func TestParentMappingIsKeptOutOfThePageShards(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	id := spaceID(t, server, "DOCS")
+
+	require.NoError(t, store.Record("DOCS", "a.md", "1", "A", ""))
+	require.NoError(t, store.RecordParent("DOCS", "Docs", "page-1"))
+	require.NoError(t, store.Save())
+
+	assert.Equal(t, map[string]string{"a.md": "1"}, manifestPages(t, server, id),
+		"parents must not appear among the tracked source paths")
+	assert.NotNil(t, server.SpaceProperty(id, manifest.ParentPropertyKey),
+		"they live in their own property")
+
+	next := newStoreOn(t, server)
+	require.NoError(t, next.Record("DOCS", "a.md", "1", "A", ""))
+	assert.Empty(t, next.Orphans("DOCS"),
+		"a parent key must never be reported as a missing file")
+}
+
+// TestParentMappingSkippedWhenUnchanged: parents move even less than folders do,
+// so a run that resolves the same chain must not rewrite the property.
+func TestParentMappingSkippedWhenUnchanged(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	id := spaceID(t, server, "DOCS")
+
+	require.NoError(t, store.RecordParent("DOCS", "Docs", "page-1"))
+	require.NoError(t, store.Save())
+	require.Equal(t, 1, server.SpaceProperty(id, manifest.ParentPropertyKey).Version)
+
+	next := newStoreOn(t, server)
+	require.NoError(t, next.RecordParent("DOCS", "Docs", "page-1"))
+	require.NoError(t, next.Save())
+
+	assert.Equal(t, 1, server.SpaceProperty(id, manifest.ParentPropertyKey).Version,
+		"an unchanged parent mapping must not be rewritten")
+}
+
 // TestFolderMappingSkippedWhenUnchanged: folders rarely move, so a run that
 // resolves the same ones must not rewrite the property.
 func TestFolderMappingSkippedWhenUnchanged(t *testing.T) {

--- a/mark.go
+++ b/mark.go
@@ -224,9 +224,9 @@ func Run(config Config) error {
 	// A nil *manifest.Store put into a non-nil interface is still a non-nil
 	// interface, so page would see tracking as enabled and call through a nil
 	// receiver. Build the interface value only when there is a store behind it.
-	var folders page.FolderTracker
+	var ancestryTracker page.AncestryTracker
 	if tracker != nil {
-		folders = tracker
+		ancestryTracker = tracker
 		// The whole file set is known before any of it is processed, which is
 		// what lets a recorded path missing from the run be read as a rename
 		// rather than a guess made one document at a time.
@@ -256,7 +256,7 @@ func Run(config Config) error {
 	for _, file := range files {
 		log.Info().Msgf("processing %s", file)
 
-		target, placement, err := processFile(file, api, config, std, tracker, folders, checker, globalProperties, deferrals, results)
+		target, placement, err := processFile(file, api, config, std, tracker, ancestryTracker, checker, globalProperties, deferrals, results)
 		if placement != nil {
 			ordered = append(ordered, *placement)
 		}
@@ -305,7 +305,7 @@ func Run(config Config) error {
 			// Nil deferrals: this is the last look, so a link that still does
 			// not resolve is reported rather than waited on again.
 			if _, _, err := processFile(
-				file, api, config, std, tracker, folders, checker, globalProperties, nil, results,
+				file, api, config, std, tracker, ancestryTracker, checker, globalProperties, nil, results,
 			); err != nil {
 				if config.ContinueOnError {
 					log.Error().Err(err).Msgf("processing %s", file)
@@ -422,7 +422,7 @@ func ProcessFile(file string, api *confluence.API, config Config) (*confluence.P
 	return target, nil
 }
 
-func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, folders page.FolderTracker, checker *page.LinkChecker, globalProperties map[string]any, deferrals *page.Deferrals, results *report.Report) (*confluence.PageInfo, *page.Ordered, error) {
+func processFile(file string, api *confluence.API, config Config, std *stdlib.Lib, tracker *manifest.Store, ancestryTracker page.AncestryTracker, checker *page.LinkChecker, globalProperties map[string]any, deferrals *page.Deferrals, results *report.Report) (*confluence.PageInfo, *page.Ordered, error) {
 	markdown, err := os.ReadFile(file)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to read file %q: %w", file, err)
@@ -545,7 +545,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 
 	if config.DryRun {
 		if meta != nil {
-			if _, pg, err := page.ResolvePage(true, api, meta, folders); err != nil {
+			if _, pg, err := page.ResolvePage(true, api, meta, ancestryTracker); err != nil {
 				return nil, nil, fmt.Errorf("unable to resolve page location: %w", err)
 			} else if pg == nil {
 				// The title found nothing, which is where a real run consults
@@ -608,7 +608,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 			return nil, nil, err
 		}
 
-		parent, pg, err := page.ResolvePage(false, api, meta, folders)
+		parent, pg, err := page.ResolvePage(false, api, meta, ancestryTracker)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error resolving page %q: %w", meta.Title, err)
 		}
@@ -1073,16 +1073,31 @@ func resolveTrackedPage(
 // beneath it. Tracking makes that more likely rather than less, because the
 // parent is now renamed in place instead of being duplicated somewhere visible.
 //
-// Only titles mark itself published are followed, and only when exactly one
-// page was published under the title. Anything ambiguous, or any title mark has
-// never seen, is left exactly as written -- a parent that is genuinely meant to
+// Two records are consulted, in order of how precisely each answers the
+// question. The chain a document declares was recorded when it last resolved,
+// so it names the page that held this exact position -- including a parent
+// nobody publishes from the repository, which is what most parents are. Failing
+// that, a title mark itself published is followed, and only when exactly one
+// page was published under it. Anything ambiguous, or a title neither record
+// has seen, is left exactly as written -- a parent that is genuinely meant to
 // be created still is.
+//
+// The rewrite happens here rather than inside ancestry resolution because
+// everything downstream compares titles: validation, the decision that a page
+// is misplaced, and the lookup that walks the chain. Repairing the title once,
+// before any of them run, leaves them all agreeing.
 func refreshStaleParents(tracker *manifest.Store, api *confluence.API, meta *metadata.Meta) error {
 	if tracker == nil {
 		return nil
 	}
 
-	for i, title := range meta.Parents {
+	// Keys name the chain as the document declares it, which is not what
+	// meta.Parents holds once an earlier entry has been rewritten. A chain
+	// whose first parent was also renamed would otherwise be looked up under a
+	// name it was never recorded under.
+	declared := slices.Clone(meta.Parents)
+
+	for i, title := range declared {
 		// FindPage is memoised, and ancestry resolution is about to ask the
 		// same question, so this costs nothing on the common path where the
 		// parent is exactly where it says it is.
@@ -1091,12 +1106,18 @@ func refreshStaleParents(tracker *manifest.Store, api *confluence.API, meta *met
 			continue
 		}
 
-		pageID, ok, err := tracker.ResolveStaleTitle(meta.Space, title)
+		pageID, ok, err := tracker.LookupParent(meta.Space, page.ParentPathKey(declared[:i+1]))
 		if err != nil {
 			return fmt.Errorf("unable to check whether parent %q was renamed: %w", title, err)
 		}
 		if !ok {
-			continue
+			pageID, ok, err = tracker.ResolveStaleTitle(meta.Space, title)
+			if err != nil {
+				return fmt.Errorf("unable to check whether parent %q was renamed: %w", title, err)
+			}
+			if !ok {
+				continue
+			}
 		}
 
 		renamed, err := api.GetPageByID(pageID)

--- a/mark_process_test.go
+++ b/mark_process_test.go
@@ -483,6 +483,131 @@ func TestUnknownParentTitleIsStillCreated(t *testing.T) {
 		"an unknown parent title is not stale and should still be created")
 }
 
+// handMadeParent puts a page under DOCS > Parent the way somebody would in the
+// Confluence UI, and returns it. No document in the repository publishes it,
+// which is what a parent usually is and what the title index cannot know about.
+func handMadeParent(t *testing.T, server *confluencetest.Server, title string) *confluencetest.Page {
+	t.Helper()
+	under, err := confluence.NewAPI(server.URL, "user", "token", false).
+		FindPage("DOCS", "Parent", "page")
+	require.NoError(t, err)
+	require.NotNil(t, under)
+	return server.AddPage("DOCS", title, "page", under.ID)
+}
+
+// TestRenamedHandMadeParentIsFollowedNotRecreated is the case the title index
+// could never answer. Following a stale parent used to mean asking which page
+// mark had published under that title, and a parent nobody publishes -- made by
+// hand, or created empty by mark to hold a hierarchy -- has never been in that
+// index. The chain each document declares is recorded when it resolves, so the
+// position is what is followed rather than the title.
+func TestRenamedHandMadeParentIsFollowedNotRecreated(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	guide := handMadeParent(t, server, "Guide")
+
+	file := writeFile(t, dir, "child.md", markdownUnder("Guide", "Child"))
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	// Somebody renames it in the UI. The document still says "Guide".
+	server.RenamePage(guide.ID, "Guide Renamed")
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	assert.Equal(t, 0, countPagesTitled(t, server, "Guide"),
+		"no empty page should have been created under the old title")
+
+	child, err := confluence.NewAPI(server.URL, "user", "token", false).
+		FindPage("DOCS", "Child", "page")
+	require.NoError(t, err)
+	require.NotNil(t, child)
+	assert.Equal(t, guide.ID, server.Page(child.ID).ParentID,
+		"the child should still sit under the page it always did")
+}
+
+// TestRenamedHandMadeParentDuplicatesWithoutTracking is the control: without
+// the flag the old behaviour stands, which is what makes the test above mean
+// anything.
+func TestRenamedHandMadeParentDuplicatesWithoutTracking(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	guide := handMadeParent(t, server, "Guide")
+
+	config := trackingConfig(server, writeFile(t, dir, "child.md", markdownUnder("Guide", "Child")))
+	config.TrackPages = false
+	require.NoError(t, Run(config))
+
+	server.RenamePage(guide.ID, "Guide Renamed")
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, 1, countPagesTitled(t, server, "Guide"),
+		"without tracking an empty page appears under the old title")
+
+	child, err := confluence.NewAPI(server.URL, "user", "token", false).
+		FindPage("DOCS", "Child", "page")
+	require.NoError(t, err)
+	require.NotNil(t, child)
+	assert.NotEqual(t, guide.ID, server.Page(child.ID).ParentID,
+		"and the child is moved beneath it")
+}
+
+// TestParentCreatedByMarkIsFollowedAfterRename covers the other half of the
+// recording: a parent mark created itself to hold the hierarchy is remembered
+// at the moment it is created, not only when it is found again.
+func TestParentCreatedByMarkIsFollowedAfterRename(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	file := writeFile(t, dir, "child.md", markdownUnder("Brand New Parent", "Child"))
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	created, err := confluence.NewAPI(server.URL, "user", "token", false).
+		FindPage("DOCS", "Brand New Parent", "page")
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	server.RenamePage(created.ID, "Brand New Parent Renamed")
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	assert.Equal(t, 0, countPagesTitled(t, server, "Brand New Parent"),
+		"the parent mark created should have been followed, not made again")
+}
+
+// TestRenamedParentChainIsFollowedAtEveryLevel: the keys name the chain as the
+// document declares it. Rewriting one level and then keying the next off the
+// rewritten title would look up a chain that was never recorded, so a run where
+// two levels were renamed at once would repair the first and recreate the
+// second.
+func TestRenamedParentChainIsFollowedAtEveryLevel(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	top, err := confluence.NewAPI(server.URL, "user", "token", false).
+		FindPage("DOCS", "Parent", "page")
+	require.NoError(t, err)
+	guide := handMadeParent(t, server, "Guide")
+
+	file := writeFile(t, dir, "child.md", markdownUnder("Guide", "Child"))
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	server.RenamePage(top.ID, "Parent Renamed")
+	server.RenamePage(guide.ID, "Guide Renamed")
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	assert.Equal(t, 0, countPagesTitled(t, server, "Parent"),
+		"the top of the chain should have been followed")
+	assert.Equal(t, 0, countPagesTitled(t, server, "Guide"),
+		"and so should the level below it, whose key is unaffected by the rewrite above")
+
+	child, err := confluence.NewAPI(server.URL, "user", "token", false).
+		FindPage("DOCS", "Child", "page")
+	require.NoError(t, err)
+	require.NotNil(t, child)
+	assert.Equal(t, guide.ID, server.Page(child.ID).ParentID,
+		"the child should not have moved")
+}
+
 // TestTwoFilesClaimingOnePageIsReported: nothing stops two documents resolving
 // to the same page by title, and then a rename of either moves a page the other
 // also believes is its own. mark cannot tell which was meant, so it says so.

--- a/page/ancestry.go
+++ b/page/ancestry.go
@@ -125,9 +125,44 @@ type FolderTracker interface {
 	LookupFolder(space, folderPath string) (string, bool, error)
 }
 
+// ParentTracker remembers which Confluence page a declared parent chain
+// resolved to.
+//
+// Parents are found by title too, so renaming one leaves every document that
+// declares it pointing at a name nothing carries: mark creates an empty page
+// under the old title and the real one's children end up beneath it.
+// Remembering what the chain resolved to makes the rename survivable for any
+// parent -- including the ones no document in the repository publishes, which
+// is most of them.
+//
+// An interface for the reason FolderTracker is one, and a nil tracker disables
+// it just the same.
+type ParentTracker interface {
+	RecordParent(space, parentPath, pageID string) error
+	LookupParent(space, parentPath string) (string, bool, error)
+}
+
+// AncestryTracker is everything the resolver can remember about where a
+// document was put.
+type AncestryTracker interface {
+	FolderTracker
+	ParentTracker
+}
+
 // folderPathKey names a folder by the chain of titles leading to it, under the
 // anchor it hangs from. The anchor is part of the key because the same chain of
 // titles under a different anchor is a different folder.
+// ParentPathKey names a parent by the chain of titles leading to it.
+//
+// No anchor, unlike folderPathKey: a parent chain is resolved from the space
+// root, and the mapping is already per space, so the titles alone identify it.
+//
+// Exported because the chain is recorded here and consulted where a stale
+// parent title is repaired, which is a decision made before resolution starts.
+func ParentPathKey(chain []string) string {
+	return strings.Join(chain, "\x00")
+}
+
 func folderPathKey(anchorPageID *string, folders []string, upto int) string {
 	anchor := ""
 	if anchorPageID != nil {
@@ -334,7 +369,7 @@ func EnsureFolderAncestry(
 func EnsureMixedAncestry(
 	dryRun bool,
 	api *confluence.API,
-	tracker FolderTracker,
+	tracker AncestryTracker,
 	space string,
 	folders []string,
 	pages []string,
@@ -342,7 +377,7 @@ func EnsureMixedAncestry(
 	var anchorPageID *string
 
 	if len(pages) > 0 {
-		anchor, err := EnsureAncestry(dryRun, api, space, pages)
+		anchor, err := EnsureAncestry(dryRun, api, space, pages, tracker)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve MARK_PARENTS page ancestry: %w", err)
 		}
@@ -356,7 +391,7 @@ func EnsureMixedAncestry(
 		if len(pages) == 0 {
 			return nil, nil
 		}
-		return EnsureAncestry(dryRun, api, space, pages)
+		return EnsureAncestry(dryRun, api, space, pages, tracker)
 	}
 
 	folderParent, err := EnsureFolderAncestry(dryRun, api, space, folders, anchorPageID, tracker)
@@ -383,6 +418,7 @@ func EnsureAncestry(
 	api *confluence.API,
 	space string,
 	ancestry []string,
+	tracker ParentTracker,
 ) (*confluence.PageInfo, error) {
 	var parent *confluence.PageInfo
 
@@ -399,6 +435,12 @@ func EnsureAncestry(
 		}
 
 		log.Debug().Msgf("parent page %q exists: %s", title, page.Links.Full)
+
+		if tracker != nil {
+			if err := tracker.RecordParent(space, ParentPathKey(ancestry[:i+1]), page.ID); err != nil {
+				return nil, err
+			}
+		}
 
 		rest = ancestry[i:]
 		parent = page
@@ -426,10 +468,20 @@ func EnsureAncestry(
 		)
 
 	if !dryRun {
-		for _, title := range rest {
+		// rest is the tail of ancestry that does not exist yet, so its offset
+		// within ancestry is what makes a recorded key match on the next run.
+		firstNew := len(ancestry) - len(rest)
+		for offset, title := range rest {
 			page, err := api.CreatePage(space, "page", parent, title, ``)
 			if err != nil {
 				return nil, fmt.Errorf("error during creating parent page with title %q: %w", title, err)
+			}
+
+			if tracker != nil {
+				key := ParentPathKey(ancestry[:firstNew+offset+1])
+				if err := tracker.RecordParent(space, key, page.ID); err != nil {
+					return nil, err
+				}
 			}
 
 			parent = page

--- a/page/ancestry_server_test.go
+++ b/page/ancestry_server_test.go
@@ -33,7 +33,7 @@ func TestEnsureAncestryAllParentsExist(t *testing.T) {
 	team := server.AddPage("DOCS", "Team", "page", root.ID)
 	server.AddPage("DOCS", "Guides", "page", team.ID)
 
-	parent, err := page.EnsureAncestry(false, api, "DOCS", []string{"Root", "Team", "Guides"})
+	parent, err := page.EnsureAncestry(false, api, "DOCS", []string{"Root", "Team", "Guides"}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, parent)
 	assert.Equal(t, "Guides", parent.Title)
@@ -46,7 +46,7 @@ func TestEnsureAncestryCreatesMissingParents(t *testing.T) {
 	api, server := newAPI(t)
 	server.AddPage("DOCS", "Root", "page", "")
 
-	parent, err := page.EnsureAncestry(false, api, "DOCS", []string{"Root", "Team", "Guides"})
+	parent, err := page.EnsureAncestry(false, api, "DOCS", []string{"Root", "Team", "Guides"}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, parent)
 	assert.Equal(t, "Guides", parent.Title)
@@ -69,7 +69,7 @@ func TestEnsureAncestryDryRunCreatesNothing(t *testing.T) {
 	api, server := newAPI(t)
 	server.AddPage("DOCS", "Root", "page", "")
 
-	_, err := page.EnsureAncestry(true, api, "DOCS", []string{"Root", "Team", "Guides"})
+	_, err := page.EnsureAncestry(true, api, "DOCS", []string{"Root", "Team", "Guides"}, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, server.CountRequests("POST", "/rest/api/content"),
@@ -84,7 +84,7 @@ func TestEnsureAncestryFallsBackToRootPage(t *testing.T) {
 	api, server := newAPI(t)
 	existing := server.AddPage("DOCS", "Existing", "page", "")
 
-	parent, err := page.EnsureAncestry(false, api, "DOCS", []string{"Brand New"})
+	parent, err := page.EnsureAncestry(false, api, "DOCS", []string{"Brand New"}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, parent)
 	assert.Equal(t, "Brand New", parent.Title)

--- a/page/page.go
+++ b/page/page.go
@@ -14,7 +14,7 @@ func ResolvePage(
 	dryRun bool,
 	api *confluence.API,
 	meta *metadata.Meta,
-	tracker FolderTracker,
+	tracker AncestryTracker,
 ) (*confluence.PageInfo, *confluence.PageInfo, error) {
 	if meta == nil {
 		return nil, nil, fmt.Errorf("metadata is empty")
@@ -145,6 +145,7 @@ func ResolvePage(
 			api,
 			meta.Space,
 			meta.Parents,
+			tracker,
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("can't create ancestry tree %q: %w", strings.Join(meta.Parents, ` > `), err)


### PR DESCRIPTION
Closes #644, closes #523 without a page ID anywhere in the repository — the follow-up to #726, which took the header route.

## The problem

Renaming a parent page in Confluence strands every document that declares it: the title lookup misses, mark creates an empty page under the old name, and the real parent's children end up beneath it.

`--track-pages` already tried to repair this, but only by asking which page mark had published under the old title — an index built solely from the manifest's own document entries. Most parents are not documents. They are pages somebody made in the UI, or the empty ones mark creates to hold a hierarchy, and neither has ever been in that index, so the common case was the one it could not answer. It was also refused whenever two files had shared a title, since a title index cannot say which of them was meant.

## What this does

Records the parent chain each document declares, the way folder chains already are recorded. `EnsureAncestry` notes `titles-chain → page id` for every level, both the ones it finds and the ones it creates. A stale title then resolves to the page that held that exact position last run, whatever it is called now, for any parent at all.

The title index stays as the second answer: it still knows chains that were never recorded — the first run after an upgrade, or a parent reached by another route.

Keys name the chain as the document declares it, not as `meta.Parents` holds it once an earlier level has been repaired, so `refreshStaleParents` clones the slice before rewriting. Without that, a run where two levels were renamed at once fixes the first and looks the second up under a chain that was never recorded.

The repair stays in `refreshStaleParents` rather than moving into resolution, because everything downstream compares titles: validation, the misplaced-page decision, and the walk that resolves the chain. Fixing the title once, before any of them run, leaves them agreeing.

## Storage

A `mark.manifest.parents` space property beside the folder one (a content property on Server/DC), and out of the page shards for the reason folders are: a key of theirs among the page keys is reported as a source file that has gone missing, and a parent has no source file to miss. Folder and parent writes now share one helper instead of repeating the conflict handling.

Nothing new is written to the repository. No new header, no new flag.

## Testing

`go test ./...`, `golangci-lint run ./...` and `markdownlint-cli2` all clean.

Four end-to-end tests: a hand-made parent renamed, its no-tracking control, a parent mark created itself renamed (the creation-branch recording), and a two-level chain renamed at once (the clone). Three manifest round-trip tests mirroring the folder ones, plus `RenamePage` on the fake server. All three new tracking tests were confirmed to fail with the lookup disabled, and the existing `TestRenamedParentIsFollowedNotRecreated` still passes on the title-index path alone.

The second commit is a docs fix: the tracking section still claimed a `Parent:` header change "fails the run with an ancestry error rather than moving the page", which stopped being true when #430 was fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)