### PR TITLE
fix: the five ways a publish silently produced the wrong page

### DIFF
--- a/confluence/api.go
+++ b/confluence/api.go
@@ -1271,7 +1271,12 @@ func (api *API) CreateFolder(spaceID, title string, parentID *string, parentType
 			return nil, fmt.Errorf("failed to get parent folder info for space consistency: %w", err)
 		}
 
-		if parentFolder.SpaceID != "" {
+		// A folder that is not there answers (nil, nil), not an error, and the
+		// id reaching here came from a cache or from the manifest -- so it names
+		// a folder that existed when it was recorded and may not now. Every
+		// other caller of GetFolderByID checks this; only here did a folder
+		// deleted between runs panic instead of falling back to the space.
+		if parentFolder != nil && parentFolder.SpaceID != "" {
 			actualSpaceID = parentFolder.SpaceID
 		}
 	}

--- a/confluence/folder_test.go
+++ b/confluence/folder_test.go
@@ -1,0 +1,35 @@
+package confluence_test
+
+import (
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateFolderUnderAVanishedParent: GetFolderByID answers (nil, nil) for a
+// folder that is not there, not an error, and CreateFolder checked only the
+// error before reading the parent's space id -- so it panicked rather than
+// failed.
+//
+// The id reaching it comes from the folder cache or from the manifest, meaning
+// it names a folder that existed when it was recorded. A folder deleted in
+// Confluence between two runs is exactly the case folder tracking exists to
+// survive, so this crashed on the recovery path.
+func TestCreateFolderUnderAVanishedParent(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	space := server.AddSpace("DOCS")
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+
+	gone := "no-such-folder"
+	folder, err := api.CreateFolder(space.ID, "Guides", &gone, "folder")
+
+	require.NoError(t, err, "a missing parent must not fail the call")
+	require.NotNil(t, folder)
+	assert.Equal(t, "Guides", folder.Title)
+}

--- a/macro/macro.go
+++ b/macro/macro.go
@@ -256,6 +256,15 @@ func ExtractMacros(
 	var extracted []Macro
 	remaining := contents
 
+	// A macro directive written inside a fenced or indented code block is an
+	// example of one, not one to obey -- which is how any document about mark
+	// shows the syntax, this repository's own README included. Include
+	// directives have always been skipped there, and Macro.Apply already
+	// refuses to rewrite matches inside code; only this pass was missing it, so
+	// the example was hoisted out of the block, registered as a real macro, and
+	// the code block left empty.
+	codeRegions := metadata.CodeRegions(remaining)
+
 	searchOffset := 0
 	for searchOffset < len(remaining) {
 		relStart := bytes.Index(remaining[searchOffset:], []byte("<!--"))
@@ -271,6 +280,11 @@ func ExtractMacros(
 		if macroIdx == -1 || firstEndIdx == -1 || macroIdx > firstEndIdx {
 			// Not a macro directive comment, move past this comment
 			searchOffset = startIdx + firstEndIdx + 3
+			continue
+		}
+
+		if metadata.InCode(codeRegions, startIdx) {
+			searchOffset = startIdx + 4
 			continue
 		}
 
@@ -362,6 +376,11 @@ func ExtractMacros(
 
 		remaining = append(remaining[:startIdx], remaining[endIdx:]...)
 		searchOffset = startIdx
+
+		// Every offset after the splice has moved, so the regions have to be
+		// found again rather than adjusted -- a directive removed from between
+		// two code blocks changes where both of them start.
+		codeRegions = metadata.CodeRegions(remaining)
 	}
 
 	return extracted, remaining, nil

--- a/macro/macro_test.go
+++ b/macro/macro_test.go
@@ -114,3 +114,55 @@ func TestExtractMacros_InlineTemplateUsesDefaultDelims(t *testing.T) {
 	assert.Equal(t, "Hello world", out.String(),
 		"an inline macro must use {{ }} regardless of any Delims: an include declared")
 }
+
+// TestExtractMacros_SkipsDirectivesInsideCodeBlocks: a macro directive inside a
+// fence is an example of the syntax, not an instruction. Extracting it hoisted
+// the example out of the block, registered it as a live macro, and left the
+// block empty -- which is what happened to every document that documented mark,
+// this repository's own README included. Include directives were always skipped
+// there; only this pass was not.
+func TestExtractMacros_SkipsDirectivesInsideCodeBlocks(t *testing.T) {
+	contents := []byte("Here is how a macro is written:\n\n" +
+		"```markdown\n" +
+		"<!-- Macro: MYJIRA-\\d+\n" +
+		"     Template: #inline\n" +
+		"     inline: \"ticket ${0}\" -->\n" +
+		"```\n\nAnd some prose after it.\n")
+
+	macros, remaining, err := ExtractMacros("", "", contents, template.New("test"))
+	require.NoError(t, err)
+
+	assert.Empty(t, macros, "a directive inside a fence must not be registered")
+	assert.Contains(t, string(remaining), "<!-- Macro: MYJIRA-",
+		"the example must stay in the code block, verbatim")
+	assert.Contains(t, string(remaining), "And some prose after it.")
+}
+
+// TestExtractMacros_StillTakesDirectivesOutsideCode is the control: skipping
+// code must not turn into skipping everything.
+func TestExtractMacros_StillTakesDirectivesOutsideCode(t *testing.T) {
+	contents := []byte("<!-- Macro: TICKET-(\\d+)\n" +
+		"     Template: #inline\n" +
+		"     inline: \"ticket ${1}\" -->\n\n" +
+		"```markdown\n<!-- Macro: EXAMPLE -->\n```\n\nSee TICKET-42.\n")
+
+	macros, remaining, err := ExtractMacros("", "", contents, template.New("test"))
+	require.NoError(t, err)
+
+	require.Len(t, macros, 1, "the real directive is still extracted")
+	rest := string(remaining)
+	assert.NotContains(t, rest, "Macro: TICKET-", "the real one is stripped")
+	assert.Contains(t, rest, "<!-- Macro: EXAMPLE -->", "the example one is not")
+}
+
+// TestExtractMacros_SkipsDirectivesInIndentedCode covers the other code form,
+// since CodeRegions reports both and a fence is the easy half.
+func TestExtractMacros_SkipsDirectivesInIndentedCode(t *testing.T) {
+	contents := []byte("Written like this:\n\n    <!-- Macro: X\n         Template: #inline\n         inline: \"y\" -->\n\nDone.\n")
+
+	macros, remaining, err := ExtractMacros("", "", contents, template.New("test"))
+	require.NoError(t, err)
+
+	assert.Empty(t, macros)
+	assert.Contains(t, string(remaining), "<!-- Macro: X")
+}

--- a/mark.go
+++ b/mark.go
@@ -221,6 +221,26 @@ func Run(config Config) error {
 		}
 	}
 
+	// What has been recorded has already been published, so the mapping is
+	// worth keeping however the run ends -- including when it ends early.
+	// Returning on the first failing file used to skip the save entirely,
+	// throwing away the mapping for every page that had published perfectly
+	// well, and the next run then resolved all of them by title alone: no
+	// rename detection, and no version baseline for --no-overwrite.
+	//
+	// Deferred rather than repeated before each return, because there are five
+	// of them and the next one added would miss it too. The explicit save at
+	// the end stays: it is the one whose failure the caller hears about, and
+	// once it succeeds this becomes a no-op.
+	defer func() {
+		if tracker == nil {
+			return
+		}
+		if err := tracker.Save(); err != nil {
+			log.Error().Err(err).Msg("unable to save page manifest")
+		}
+	}()
+
 	// A nil *manifest.Store put into a non-nil interface is still a non-nil
 	// interface, so page would see tracking as enabled and call through a nil
 	// receiver. Build the interface value only when there is a store behind it.
@@ -429,6 +449,12 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	}
 
 	markdown = bytes.ReplaceAll(markdown, []byte("\r\n"), []byte("\n"))
+
+	// A byte-order mark is not content, and leaving it in front of the first
+	// header comment makes the file look to every parser here like one with no
+	// metadata at all -- reported as "doesn't contain metadata", which is not
+	// where the author would look. Windows editors write one routinely.
+	markdown = bytes.TrimPrefix(markdown, []byte{0xEF, 0xBB, 0xBF})
 
 	// Fingerprint the source as read, before metadata is stripped and links are
 	// substituted. Both of those depend on state outside the file -- what is
@@ -874,6 +900,16 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		}
 		target = pg
 
+		// The refetch carries the title Confluence holds now, which is the old
+		// one whenever this run is renaming the page: the new title is staged
+		// on the object that was just replaced and is not published until the
+		// update below. Without this the rename is dropped silently, and the
+		// manifest goes on to record a title the page does not carry -- which
+		// then misresolves every parent that names it.
+		if titleChanged && meta != nil {
+			target.Title = meta.Title
+		}
+
 		comments, err := api.GetInlineComments(target.ID)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to retrieve inline comments: %w", err)
@@ -902,6 +938,13 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	})
 
 	if shouldUpdatePage {
+		// Checked here rather than anywhere earlier because this is the body
+		// that is actually sent: after the layout wrap, and after any inline
+		// comments have been merged back into it.
+		if err := markmd.CheckWellFormed(html); err != nil {
+			return nil, nil, err
+		}
+
 		err = api.UpdatePage(
 			target,
 			html,

--- a/mark_encoding_test.go
+++ b/mark_encoding_test.go
@@ -1,0 +1,50 @@
+package mark
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestByteOrderMarkDoesNotHideMetadata: a BOM in front of the first header
+// comment made every parser here see a file with no metadata at all, and the
+// run failed with "doesn't contain metadata" -- pointing at the headers, which
+// are present and correct. Windows editors write a BOM routinely, and "UTF-8
+// with BOM" is a one-click setting in VS Code.
+func TestByteOrderMarkDoesNotHideMetadata(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	path := filepath.Join(dir, "doc.md")
+	body := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: With BOM -->\n\nBody text.\n"
+	require.NoError(t, os.WriteFile(path, append([]byte{0xEF, 0xBB, 0xBF}, body...), 0o600))
+
+	require.NoError(t, Run(publishConfig(server.URL, path)))
+
+	assert.Equal(t, 1, countPagesTitled(t, server, "With BOM"))
+	assert.NotContains(t, bodyOfPageTitled(t, server, "With BOM"), "\ufeff",
+		"the mark itself must not reach the page")
+}
+
+// TestByteOrderMarkDoesNotHideFrontMatter covers the other metadata form. The
+// BOM sits in front of the opening "---", so it stops being a front-matter
+// fence and becomes a horizontal rule followed by the YAML as body text.
+func TestByteOrderMarkDoesNotHideFrontMatter(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	path := filepath.Join(dir, "doc.md")
+	body := "---\nspace: DOCS\ntitle: BOM Front Matter\nparents: [ Parent ]\n---\n\nBody text.\n"
+	require.NoError(t, os.WriteFile(path, append([]byte{0xEF, 0xBB, 0xBF}, body...), 0o600))
+
+	config := publishConfig(server.URL, path)
+	config.Features = append(config.Features, "frontmatter")
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, 1, countPagesTitled(t, server, "BOM Front Matter"))
+	assert.NotContains(t, bodyOfPageTitled(t, server, "BOM Front Matter"), "space: DOCS",
+		"the front matter must be read as metadata, not published as text")
+}

--- a/mark_state_test.go
+++ b/mark_state_test.go
@@ -1,0 +1,84 @@
+package mark
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestManifestIsSavedWhenAFileFailsHard: the mapping records pages that have
+// already been published. Returning on the first bad file used to skip the save
+// entirely, so one malformed document threw away the identity of every page
+// that had published before it -- and the next run resolved all of them by
+// title alone, with no rename detection and no --no-overwrite baseline.
+//
+// The sibling case, --continue-on-error, was fixed long ago; this is the path
+// that was missed.
+func TestManifestIsSavedWhenAFileFailsHard(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	// Named so the good one is processed first and the run then fails.
+	writeFile(t, dir, "a-good.md", markdownWithTitle("Published"))
+	writeFile(t, dir, "b-bad.md", "no metadata here at all\n")
+
+	config := trackingConfig(server, filepath.Join(dir, "*.md"))
+	require.Error(t, Run(config), "the run must still report the failure")
+
+	published, err := api.FindPage("DOCS", "Published", "page")
+	require.NoError(t, err)
+	require.NotNil(t, published, "the good file published")
+
+	store := manifest.NewStore(confluence.NewAPI(server.URL, "user", "token", false))
+	entry, ok, err := store.Lookup("DOCS", filepath.Join(dir, "a-good.md"))
+	require.NoError(t, err)
+	require.True(t, ok, "the page that published must still be in the manifest")
+	assert.Equal(t, published.ID, entry.PageID)
+}
+
+// TestPreserveCommentsKeepsARetitle: the retitle is staged on the page object
+// and published by the update. --preserve-comments refetches the page in
+// between, which brought back the title Confluence still held, and the rename
+// was dropped without a word. It compounded: the manifest went on to record the
+// new title against a page carrying the old one, so every parent named by that
+// title resolved to the wrong place from then on.
+func TestPreserveCommentsKeepsARetitle(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	config := trackingConfig(server, writeFile(t, dir, "doc.md", markdownWithTitle("Original Title")))
+	config.PreserveComments = true
+	require.NoError(t, Run(config))
+
+	original, err := confluence.NewAPI(server.URL, "user", "token", false).
+		FindPage("DOCS", "Original Title", "page")
+	require.NoError(t, err)
+	require.NotNil(t, original)
+
+	writeFile(t, dir, "doc.md", markdownWithTitle("Renamed Title"))
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, "Renamed Title", server.Page(original.ID).Title,
+		"the page should have been renamed in place")
+	assert.Equal(t, 0, countPagesTitled(t, server, "Original Title"))
+}
+
+// TestPreserveCommentsLeavesAnUnchangedTitleAlone is the control: the fix must
+// restore the staged title, not stamp the document's title onto every page it
+// touches.
+func TestPreserveCommentsLeavesAnUnchangedTitleAlone(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	config := trackingConfig(server, writeFile(t, dir, "doc.md", markdownWithTitle("Steady")))
+	config.PreserveComments = true
+
+	require.NoError(t, Run(config))
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, 1, countPagesTitled(t, server, "Steady"))
+}

--- a/mark_wellformed_test.go
+++ b/mark_wellformed_test.go
@@ -1,0 +1,130 @@
+package mark
+
+import (
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// publishConfig is a plain publish with no tracking, for tests about what
+// reaches Confluence rather than about what mark remembers.
+func publishConfig(url, files string) Config {
+	return Config{
+		BaseURL:  url,
+		Username: "user",
+		Password: "token",
+		Files:    files,
+		Features: []string{"mention"},
+		Output:   io.Discard,
+	}
+}
+
+// TestMalformedBodyIsRefusedBeforeUpload: storage format is XML, and Confluence
+// answers a body that is not well-formed by rejecting the whole page with a
+// BadRequestException that names nothing. Catching it here is the difference
+// between a complaint the author can act on and one they cannot.
+func TestMalformedBodyIsRefusedBeforeUpload(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	// An unbalanced tag the document wrote itself. Nothing downstream can
+	// repair this one -- it is the author's to fix -- which is what makes it
+	// the right shape for this test.
+	file := writeFile(t, dir, "doc.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Malformed -->
+
+Some text with an <span>unclosed tag.
+`)
+
+	err := Run(publishConfig(server.URL, file))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not well-formed XML")
+	assert.Contains(t, err.Error(), "unclosed tag")
+
+	// The page itself is created during ancestry resolution, before the body is
+	// compiled, so what the gate protects is the content: the page is left
+	// empty rather than filled with markup Confluence would reject.
+	assert.Empty(t, bodyOfPageTitled(t, server, "Malformed"),
+		"no body should have been uploaded")
+}
+
+// bodyOfPageTitled returns what is actually stored on the page carrying a
+// title, or "" if no page carries it.
+func bodyOfPageTitled(t *testing.T, server *confluencetest.Server, title string) string {
+	t.Helper()
+	fresh := confluence.NewAPI(server.URL, "user", "token", false)
+	found, err := fresh.FindPage("DOCS", title, "page")
+	require.NoError(t, err)
+	if found == nil {
+		return ""
+	}
+	return server.Page(found.ID).Body
+}
+
+// TestWellFormedBodyPublishes is the control: the gate must not stand in the
+// way of the markup mark itself emits.
+func TestWellFormedBodyPublishes(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	// Deliberately busy: entities, a macro, a code block holding markup, and a
+	// footnote -- the constructs whose output the check is most likely to
+	// misread.
+	file := writeFile(t, dir, "doc.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Well Formed -->
+
+A & B, "quoted", 3 < 4, and a non-breaking&nbsp;space.
+
+| a | b |
+|---|---|
+| 1 | 2 |
+
+`+"```go\nif a < b && c > d {}\n```"+`
+
+A claim[^why].
+
+[^why]: Because.
+`)
+
+	require.NoError(t, Run(publishConfig(server.URL, file)))
+	assert.Equal(t, 1, countPagesTitled(t, server, "Well Formed"))
+}
+
+// TestMalformedBodyIsRefusedAcrossAFileSet: one bad document must not take the
+// good ones with it, and must not be silently skipped either.
+func TestMalformedBodyIsRefusedAcrossAFileSet(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "a-good.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Good -->
+
+Fine.
+`)
+	writeFile(t, dir, "b-bad.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Bad -->
+
+An <span>unclosed tag.
+`)
+
+	config := publishConfig(server.URL, filepath.Join(dir, "*.md"))
+	config.ContinueOnError = true
+
+	err := Run(config)
+	require.Error(t, err)
+
+	assert.NotEmpty(t, bodyOfPageTitled(t, server, "Good"),
+		"the well-formed document should still publish")
+	assert.Empty(t, bodyOfPageTitled(t, server, "Bad"),
+		"the malformed one should have uploaded no body")
+}

--- a/markdown/wellformed.go
+++ b/markdown/wellformed.go
@@ -1,0 +1,81 @@
+package mark
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// wellFormedPrologue supplies the two namespace prefixes a compiled body uses
+// but never declares -- the page it becomes is what declares them. It is
+// deliberately free of newlines so that the line numbers the parser reports are
+// the body's own.
+const wellFormedPrologue = `<root xmlns:ac="ac" xmlns:ri="ri">`
+
+// CheckWellFormed reports whether a compiled body is XML that Confluence will
+// accept.
+//
+// Storage format is an XML dialect, and Confluence answers a body that is not
+// well-formed with BadRequestException: it rejects the whole page rather than
+// the element at fault, and says nothing about which element that was. Every
+// way of producing invalid markup therefore surfaces to the author as one
+// opaque server error, whatever caused it -- an unescaped ampersand in a macro
+// parameter, a void <br> written by hand, an HTML comment containing a double
+// hyphen.
+//
+// Running the same parse here turns all of that into one local complaint that
+// names the line, before anything is uploaded.
+func CheckWellFormed(body string) error {
+	decoder := xml.NewDecoder(strings.NewReader(wellFormedPrologue + body + `</root>`))
+	decoder.Strict = true
+
+	// Confluence accepts the named HTML entities, and mark's own templates emit
+	// them -- &#160; between a footnote and its backlink, &nbsp; from a
+	// document. A bare encoding/xml decoder knows only the five XML ones and
+	// would report every one of those as an error.
+	decoder.Entity = xml.HTMLEntity
+
+	for {
+		_, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err == nil {
+			continue
+		}
+
+		var syntax *xml.SyntaxError
+		if !errors.As(err, &syntax) {
+			return err
+		}
+
+		return fmt.Errorf(
+			"the rendered page is not well-formed XML, which Confluence rejects "+
+				"in its entirety: line %d: %s%s",
+			syntax.Line, syntax.Msg, quoteLine(body, syntax.Line),
+		)
+	}
+}
+
+// quoteLine returns the offending line of the rendered body, so the complaint
+// points at something recognisable rather than at a line number in output the
+// author never sees.
+func quoteLine(body string, line int) string {
+	lines := strings.Split(body, "\n")
+	if line < 1 || line > len(lines) {
+		return ""
+	}
+
+	text := strings.TrimSpace(lines[line-1])
+	const limit = 160
+	if len(text) > limit {
+		text = text[:limit] + "..."
+	}
+	if text == "" {
+		return ""
+	}
+
+	return "\n  " + text
+}

--- a/renderer/blockquote.go
+++ b/renderer/blockquote.go
@@ -3,6 +3,7 @@ package renderer
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/renderer"
@@ -53,15 +54,54 @@ type BlockQuoteClassifier struct {
 	patternMap map[string]*regexp.Regexp
 }
 
+// blockQuoteMarker matches a line that opens with an admonition marker.
+//
+// Anchored, and requiring the marker to end on a word boundary, because the
+// unanchored version this replaces matched the word anywhere in the line:
+// "Information about pricing is below." became an info macro and "Please note
+// that the API changed." became a note, since `info` and `note` are substrings
+// of both. Four of the commonest words in English documentation silently
+// rewrote the paragraphs that used them, and the author's only recourse was to
+// reword the sentence.
+//
+// Everything the documented syntax allows still matches -- "Info: text",
+// "**Note:** text", "NOTES:", a bare "Warn" -- because the marker is written
+// at the front of the line in every one of them. Emphasis is not in the text
+// this sees, goldmark having already made a node of it, so "**Warn**" arrives
+// as "Warn".
+var blockQuoteMarker = regexp.MustCompile(
+	`^(?i)(info|infos|note|notes|warn|warns|warning|warnings|tip|tips)\b[[:punct:]]*(\s|$)`,
+)
+
 func LegacyBlockQuoteClassifier() BlockQuoteClassifier {
 	return BlockQuoteClassifier{
 		patternMap: map[string]*regexp.Regexp{
-			"info": regexp.MustCompile(`(?i)info`),
-			"note": regexp.MustCompile(`(?i)note`),
-			"warn": regexp.MustCompile(`(?i)warn`),
-			"tip":  regexp.MustCompile(`(?i)tip`),
+			"info": regexp.MustCompile(`(?i)^info`),
+			"note": regexp.MustCompile(`(?i)^note`),
+			"warn": regexp.MustCompile(`(?i)^warn`),
+			"tip":  regexp.MustCompile(`(?i)^tip`),
 		},
 	}
+}
+
+// markerOf returns the admonition marker a line opens with, or "" if the line
+// is ordinary prose.
+//
+// The comment form is stripped first: "<!-- Info -->" is a marker written in a
+// way that keeps it out of the rendered page, and testdata/quotes.md has
+// carried one since long before this was written.
+func markerOf(literal string) string {
+	marker := strings.TrimSpace(literal)
+	marker = strings.TrimPrefix(marker, "<!--")
+	marker = strings.TrimSuffix(marker, "-->")
+	marker = strings.TrimSpace(marker)
+
+	found := blockQuoteMarker.FindString(marker)
+	if found == "" {
+		return ""
+	}
+
+	return found
 }
 
 // ClassifyingBlockQuote compares a string against a set of patterns and returns a BlockQuoteType
@@ -69,15 +109,20 @@ func LegacyBlockQuoteClassifier() BlockQuoteClassifier {
 // in the GitHub Alerts extension, not by this legacy blockquote renderer
 func (classifier BlockQuoteClassifier) ClassifyingBlockQuote(literal string) BlockQuoteType {
 
+	marker := markerOf(literal)
+	if marker == "" {
+		return None
+	}
+
 	var t = None
 	switch {
-	case classifier.patternMap["info"].MatchString(literal):
+	case classifier.patternMap["info"].MatchString(marker):
 		t = Info
-	case classifier.patternMap["note"].MatchString(literal):
+	case classifier.patternMap["note"].MatchString(marker):
 		t = Note
-	case classifier.patternMap["warn"].MatchString(literal):
+	case classifier.patternMap["warn"].MatchString(marker):
 		t = Warn
-	case classifier.patternMap["tip"].MatchString(literal):
+	case classifier.patternMap["tip"].MatchString(marker):
 		t = Tip
 	}
 	return t

--- a/renderer/blockquote_test.go
+++ b/renderer/blockquote_test.go
@@ -63,18 +63,61 @@ func TestBlockQuoteUnclassifiedStaysAQuote(t *testing.T) {
 	assert.NotContains(t, actual, "ac:structured-macro")
 }
 
-// TestBlockQuoteClassifierMatchesAnywhereInTheFirstLine records a trap in the
-// legacy syntax rather than an intention: the classifier looks for the word
-// anywhere in the first line, unanchored and case-insensitively, so a quote that
-// merely mentions the word becomes a macro. Authors who want a plain quotation
-// of a sentence containing "note" have to reword it or use a different
-// construct.
-func TestBlockQuoteClassifierMatchesAnywhereInTheFirstLine(t *testing.T) {
-	actual := render(t, "> Nothing here was noteworthy.\n", legacyBlockQuoteRenderers())
-	assertWellFormed(t, actual)
+// TestBlockQuoteMarkerMustOpenTheLine covers the trap this syntax used to set.
+// The classifier looked for the word anywhere in the first line, so a quotation
+// that merely mentioned one of four very common words became an admonition
+// macro -- and the author's only recourse was to reword the sentence. The
+// marker now has to open the line, which is where every documented form of it
+// is written anyway.
+func TestBlockQuoteMarkerMustOpenTheLine(t *testing.T) {
+	prose := []struct {
+		name  string
+		input string
+	}{
+		{"word inside another word", "> Nothing here was noteworthy.\n"},
+		{"info inside information", "> Information about pricing is below.\n"},
+		{"note mid-sentence", "> Please note that the API changed.\n"},
+		{"tip inside multiple", "> There are multiple ways to do this.\n"},
+		{"warn inside a sentence", "> We should warn them first.\n"},
+	}
 
-	assert.Contains(t, actual, `ac:name="note"`,
-		"the word inside another word still classifies the quote")
+	for _, tt := range prose {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := render(t, tt.input, legacyBlockQuoteRenderers())
+			assertWellFormed(t, actual)
+
+			assert.Contains(t, actual, "<blockquote>",
+				"ordinary prose stays a quotation")
+			assert.NotContains(t, actual, "ac:structured-macro")
+		})
+	}
+}
+
+// TestBlockQuoteMarkerFormsStillClassify is the other half: everything the
+// syntax has always accepted has to keep working, or the fix above would be a
+// removal rather than a repair.
+func TestBlockQuoteMarkerFormsStillClassify(t *testing.T) {
+	forms := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"marker with a colon and text", "> Info: the build is nightly.\n", `ac:name="info"`},
+		{"marker alone", "> Warn\n", `ac:name="warning"`},
+		{"plural with a colon", "> **NOTES:**\n>\n> One.\n", `ac:name="note"`},
+		{"emphasised marker", "> **Tip:** use the cache.\n", `ac:name="tip"`},
+		{"shouting", "> NOTE: shouting.\n", `ac:name="note"`},
+		{"warning spelled out", "> Warning: this deletes data.\n", `ac:name="warning"`},
+	}
+
+	for _, tt := range forms {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := render(t, tt.input, legacyBlockQuoteRenderers())
+			assertWellFormed(t, actual)
+
+			assert.Contains(t, actual, tt.want)
+		})
+	}
 }
 
 // TestBlockQuoteTypeComesFromTheFirstParagraphOnly pins the scope of the

--- a/renderer/image.go
+++ b/renderer/image.go
@@ -155,9 +155,6 @@ func (r *ConfluenceImageRenderer) renderImage(writer util.BufWriter, source []by
 
 	// We were unable to resolve it locally, treat as URL
 	if err != nil {
-		escapedURL := string(n.Destination)
-		escapedURL = strings.ReplaceAll(escapedURL, "&", "&amp;")
-
 		effectiveAlign := calculateAlign(align, explicitWidth)
 		effectiveLayout := calculateLayout(effectiveAlign, explicitWidth)
 		displayWidth := calculateDisplayWidth(explicitWidth, effectiveLayout)
@@ -186,7 +183,7 @@ func (r *ConfluenceImageRenderer) renderImage(writer util.BufWriter, source []by
 				string(n.Title),
 				string(nodeToHTMLText(n, source)),
 				"",
-				escapedURL,
+				string(n.Destination),
 			},
 		)
 	} else {
@@ -245,7 +242,10 @@ func nodeToHTMLText(n ast.Node, source []byte) []byte {
 		if s, ok := c.(*ast.String); ok && s.IsCode() {
 			buf.Write(s.Value)
 		} else if t, ok := c.(*ast.Text); ok {
-			buf.Write(util.EscapeHTML(t.Value(source)))
+			// Not escaped here: every consumer interpolates the result into an
+			// attribute through a template that escapes, and escaping twice
+			// puts a literal &amp;amp; on the page.
+			buf.Write(t.Value(source))
 		} else {
 			buf.Write(nodeToHTMLText(c, source))
 		}

--- a/renderer/math.go
+++ b/renderer/math.go
@@ -87,11 +87,7 @@ func (r *ConfluenceMathRenderer) renderMath(writer util.BufWriter, source []byte
 			rendered.Width,
 			rendered.Height,
 			"",
-			// Escaped here rather than by the template, which leaves ac:alt
-			// alone because its other caller escapes too. The formula is the
-			// one attribute value on this element that comes straight out of
-			// the document, and TeX is full of the characters that would end it.
-			string(util.EscapeHTML(n.Equation)),
+			string(n.Equation),
 			rendered.Filename,
 			"",
 		},

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -69,8 +69,13 @@ func templates(api *confluence.API) (*template.Template, error) {
 					),
 				)
 			},
-			"xmlesc": func(s string) string {
-				return html.EscapeString(s)
+			// Takes any so that a template may pipe a parameter with a
+			// non-string default through it. A bool or a number reaching
+			// html.EscapeString directly is a template execution error, which
+			// would make escaping those parameters impossible without
+			// rewriting every default as a string.
+			"xmlesc": func(v any) string {
+				return html.EscapeString(fmt.Sprint(v))
 			},
 		},
 	)
@@ -96,10 +101,10 @@ func templates(api *confluence.API) (*template.Template, error) {
 		`ac:code`: text(
 			`<ac:structured-macro ac:name="code">`,
 			/**/ `<ac:parameter ac:name="language">{{ .Language | xmlesc }}</ac:parameter>`,
-			/**/ `<ac:parameter ac:name="collapse">{{ .Collapse }}</ac:parameter>`,
+			/**/ `<ac:parameter ac:name="collapse">{{ .Collapse | xmlesc }}</ac:parameter>`,
 			/**/ `{{ if .Theme }}<ac:parameter ac:name="theme">{{ .Theme | xmlesc }}</ac:parameter>{{ end }}`,
-			/**/ `{{ if .Linenumbers }}<ac:parameter ac:name="linenumbers">{{ .Linenumbers }}</ac:parameter>{{ end }}`,
-			/**/ `{{ if .Firstline }}<ac:parameter ac:name="firstline">{{ .Firstline }}</ac:parameter>{{ end }}`,
+			/**/ `{{ if .Linenumbers }}<ac:parameter ac:name="linenumbers">{{ .Linenumbers | xmlesc }}</ac:parameter>{{ end }}`,
+			/**/ `{{ if .Firstline }}<ac:parameter ac:name="firstline">{{ .Firstline | xmlesc }}</ac:parameter>{{ end }}`,
 			/**/ `{{ if .Title }}<ac:parameter ac:name="title">{{ .Title | xmlesc }}</ac:parameter>{{ end }}`,
 			/**/ `<ac:plain-text-body><![CDATA[{{ .Text | cdata }}]]></ac:plain-text-body>`,
 			`</ac:structured-macro>`,
@@ -109,7 +114,7 @@ func templates(api *confluence.API) (*template.Template, error) {
 			`<ac:structured-macro ac:name="status">`,
 			`<ac:parameter ac:name="colour">{{ or .Color "Grey" | xmlesc }}</ac:parameter>`,
 			`<ac:parameter ac:name="title">{{ or .Title .Color | xmlesc }}</ac:parameter>`,
-			`<ac:parameter ac:name="subtle">{{ or .Subtle false }}</ac:parameter>`,
+			`<ac:parameter ac:name="subtle">{{ or .Subtle false | xmlesc }}</ac:parameter>`,
 			`</ac:structured-macro>`,
 		),
 
@@ -117,21 +122,21 @@ func templates(api *confluence.API) (*template.Template, error) {
 			`{{ with .Name | user }}`,
 			/**/ `<ac:link>`,
 			/**/ `{{ if .AccountID }}`,
-			/****/ `<ri:user ri:account-id="{{ .AccountID }}" />`,
+			/****/ `<ri:user ri:account-id="{{ .AccountID | xmlesc }}" />`,
 			/**/ `{{ else }}`,
-			/****/ `<ri:user ri:userkey="{{ .UserKey }}" />`,
+			/****/ `<ri:user ri:userkey="{{ .UserKey | xmlesc }}" />`,
 			/**/ `{{ end }}`,
 			/**/ `</ac:link>`,
 			`{{ else }}`,
-			/**/ `{{ .Name }}`,
+			/**/ `{{ .Name | xmlesc }}`,
 			`{{ end }}`,
 		),
 
 		`ac:jira:ticket`: text(
 			`<ac:structured-macro ac:name="jira">`,
-			`<ac:parameter ac:name="key">{{ .Ticket }}</ac:parameter>`,
+			`<ac:parameter ac:name="key">{{ .Ticket | xmlesc }}</ac:parameter>`,
 			`{{ if .Server }}`,
-			`<ac:parameter ac:name="server">{{ .Server }}</ac:parameter>`,
+			`<ac:parameter ac:name="server">{{ .Server | xmlesc }}</ac:parameter>`,
 			`{{ end }}`,
 			`</ac:structured-macro>`,
 		),
@@ -140,24 +145,24 @@ func templates(api *confluence.API) (*template.Template, error) {
 
 		`ac:jira:filter`: text(
 			`<ac:structured-macro ac:name="jira">`,
-			`<ac:parameter ac:name="server">{{ or .Server "System JIRA" }}</ac:parameter>`,
-			`<ac:parameter ac:name="jqlQuery">{{ .JQL }}</ac:parameter>`,
+			`<ac:parameter ac:name="server">{{ or .Server "System JIRA" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="jqlQuery">{{ .JQL | xmlesc }}</ac:parameter>`,
 			`</ac:structured-macro>`,
 		),
 
 		/* https://confluence.atlassian.com/doc/jira-issues-macro-139380.html */
 		`ac:jiraissues`: text(
 			`<ac:structured-macro ac:name="jiraissues">`,
-			`<ac:parameter ac:name="anonymous">{{ or .Anonymous false }}</ac:parameter>`,
-			`<ac:parameter ac:name="baseurl"><ri:url ri:value="{{ or .BaseURL .URL }}" /></ac:parameter>`,
-			`<ac:parameter ac:name="columns">{{ or .Columns "type;key;summary;assignee;reporter;priority;status;resolution;created;updated;due" }}</ac:parameter>`,
-			`<ac:parameter ac:name="count">{{ or .Count false }}</ac:parameter>`,
-			`<ac:parameter ac:name="cache">{{ or .Cache "on" }}</ac:parameter>`,
-			`<ac:parameter ac:name="height">{{ or .Height 480 }}</ac:parameter>`,
-			`<ac:parameter ac:name="renderMode">{{ or .RenderMode "static" }}</ac:parameter>`,
-			`<ac:parameter ac:name="title">{{ or .Title "Jira Issues" }}</ac:parameter>`,
-			`<ac:parameter ac:name="url"><ri:url ri:value="{{ .URL }}" /></ac:parameter>`,
-			`<ac:parameter ac:name="width">{{ or .Width "100%" }}</ac:parameter>`,
+			`<ac:parameter ac:name="anonymous">{{ or .Anonymous false | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="baseurl"><ri:url ri:value="{{ or .BaseURL .URL | xmlesc }}" /></ac:parameter>`,
+			`<ac:parameter ac:name="columns">{{ or .Columns "type;key;summary;assignee;reporter;priority;status;resolution;created;updated;due" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="count">{{ or .Count false | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="cache">{{ or .Cache "on" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="height">{{ or .Height 480 | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="renderMode">{{ or .RenderMode "static" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="title">{{ or .Title "Jira Issues" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="url"><ri:url ri:value="{{ .URL | xmlesc }}" /></ac:parameter>`,
+			`<ac:parameter ac:name="width">{{ or .Width "100%" | xmlesc }}</ac:parameter>`,
 			`</ac:structured-macro>`,
 		),
 
@@ -167,8 +172,8 @@ func templates(api *confluence.API) (*template.Template, error) {
 		// ac:details. A body ending in a list or table would otherwise absorb
 		// the closing tags as content.
 		`ac:box`: text(
-			`<ac:structured-macro ac:name="{{ .Name }}">`,
-			`<ac:parameter ac:name="icon">{{ or .Icon "false" }}</ac:parameter>`,
+			`<ac:structured-macro ac:name="{{ .Name | xmlesc }}">`,
+			`<ac:parameter ac:name="icon">{{ or .Icon "false" | xmlesc }}</ac:parameter>`,
 			`{{ if .Title }}<ac:parameter ac:name="title">{{ .Title | xmlesc }}</ac:parameter>{{ end }}`,
 			"<ac:rich-text-body>\n\n{{ .Body }}\n\n</ac:rich-text-body>",
 			`</ac:structured-macro>`,
@@ -178,15 +183,15 @@ func templates(api *confluence.API) (*template.Template, error) {
 
 		`ac:toc`: text(
 			`<ac:structured-macro ac:name="toc">`,
-			`<ac:parameter ac:name="printable">{{ or .Printable "true" }}</ac:parameter>`,
-			`<ac:parameter ac:name="style">{{ or .Style "disc" }}</ac:parameter>`,
-			`<ac:parameter ac:name="maxLevel">{{ or .MaxLevel "7" }}</ac:parameter>`,
-			`<ac:parameter ac:name="indent">{{ or .Indent "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="minLevel">{{ or .MinLevel "1" }}</ac:parameter>`,
-			`<ac:parameter ac:name="exclude">{{ or .Exclude "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="type">{{ or .Type "list" }}</ac:parameter>`,
-			`<ac:parameter ac:name="outline">{{ or .Outline "clear" }}</ac:parameter>`,
-			`<ac:parameter ac:name="include">{{ or .Include "" }}</ac:parameter>`,
+			`<ac:parameter ac:name="printable">{{ or .Printable "true" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="style">{{ or .Style "disc" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="maxLevel">{{ or .MaxLevel "7" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="indent">{{ or .Indent "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="minLevel">{{ or .MinLevel "1" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="exclude">{{ or .Exclude "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="type">{{ or .Type "list" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="outline">{{ or .Outline "clear" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="include">{{ or .Include "" | xmlesc }}</ac:parameter>`,
 			`</ac:structured-macro>`,
 		),
 
@@ -194,20 +199,20 @@ func templates(api *confluence.API) (*template.Template, error) {
 
 		`ac:children`: text(
 			`<ac:structured-macro ac:name="children">`,
-			`{{ if .Reverse }}<ac:parameter ac:name="reverse">{{ or .Reverse }}</ac:parameter>{{ end }}`,
-			`{{ if .Sort }}<ac:parameter ac:name="sort">{{ .Sort }}</ac:parameter>{{ end }}`,
-			`{{ if .Style }}<ac:parameter ac:name="style">{{ .Style }}</ac:parameter>{{ end }}`,
+			`{{ if .Reverse }}<ac:parameter ac:name="reverse">{{ or .Reverse | xmlesc }}</ac:parameter>{{ end }}`,
+			`{{ if .Sort }}<ac:parameter ac:name="sort">{{ .Sort | xmlesc }}</ac:parameter>{{ end }}`,
+			`{{ if .Style }}<ac:parameter ac:name="style">{{ .Style | xmlesc }}</ac:parameter>{{ end }}`,
 			`{{ if .Page }}`,
 			/**/ `<ac:parameter ac:name="page">`,
 			/**/ `<ac:link>`,
-			/**/ `<ri:page ri:content-title="{{ .Page }}"/>`,
+			/**/ `<ri:page ri:content-title="{{ .Page | xmlesc }}"/>`,
 			/**/ `</ac:link>`,
 			/**/ `</ac:parameter>`,
 			`{{ end }}`,
-			`{{ if .Excerpt }}<ac:parameter ac:name="excerptType">{{ .Excerpt }}</ac:parameter>{{ end }}`,
-			`{{ if .First }}<ac:parameter ac:name="first">{{ .First }}</ac:parameter>{{ end }}`,
-			`{{ if .Depth }}<ac:parameter ac:name="depth">{{ .Depth }}</ac:parameter>{{ end }}`,
-			`{{ if .All }}<ac:parameter ac:name="all">{{ .All }}</ac:parameter>{{ end }}`,
+			`{{ if .Excerpt }}<ac:parameter ac:name="excerptType">{{ .Excerpt | xmlesc }}</ac:parameter>{{ end }}`,
+			`{{ if .First }}<ac:parameter ac:name="first">{{ .First | xmlesc }}</ac:parameter>{{ end }}`,
+			`{{ if .Depth }}<ac:parameter ac:name="depth">{{ .Depth | xmlesc }}</ac:parameter>{{ end }}`,
+			`{{ if .All }}<ac:parameter ac:name="all">{{ .All | xmlesc }}</ac:parameter>{{ end }}`,
 			`</ac:structured-macro>`,
 		),
 
@@ -228,17 +233,17 @@ func templates(api *confluence.API) (*template.Template, error) {
 
 		`ac:image`: text(
 			`<ac:image`,
-			`{{ if .Align }} ac:align="{{ .Align }}"{{ end }}`,
-			`{{ if .Layout }} ac:layout="{{ .Layout }}"{{ end }}`,
-			`{{ if .OriginalWidth }} ac:original-width="{{ .OriginalWidth }}"{{ end }}`,
-			`{{ if .OriginalHeight }} ac:original-height="{{ .OriginalHeight }}"{{ end }}`,
+			`{{ if .Align }} ac:align="{{ .Align | xmlesc }}"{{ end }}`,
+			`{{ if .Layout }} ac:layout="{{ .Layout | xmlesc }}"{{ end }}`,
+			`{{ if .OriginalWidth }} ac:original-width="{{ .OriginalWidth | xmlesc }}"{{ end }}`,
+			`{{ if .OriginalHeight }} ac:original-height="{{ .OriginalHeight | xmlesc }}"{{ end }}`,
 			`{{ if .Width }} ac:custom-width="true"{{ end }}`,
-			`{{ if .Width }} ac:width="{{ .Width }}"{{ end }}`,
-			`{{ if .Height }} ac:height="{{ .Height }}"{{ end }}`,
+			`{{ if .Width }} ac:width="{{ .Width | xmlesc }}"{{ end }}`,
+			`{{ if .Height }} ac:height="{{ .Height | xmlesc }}"{{ end }}`,
 			`{{ if .Title }} ac:title="{{ .Title | xmlesc }}"{{ end }}`,
-			`{{ if .Alt }} ac:alt="{{ .Alt }}"{{ end }}>`,
+			`{{ if .Alt }} ac:alt="{{ .Alt | xmlesc }}"{{ end }}>`,
 			`{{ if .Attachment }}<ri:attachment ri:filename="{{ .Attachment | convertAttachment }}"/>{{ end }}`,
-			`{{ if .Url }}<ri:url ri:value="{{ .Url }}"/>{{ end }}`,
+			`{{ if .Url }}<ri:url ri:value="{{ .Url | xmlesc }}"/>{{ end }}`,
 			`</ac:image>`,
 		),
 
@@ -248,9 +253,9 @@ func templates(api *confluence.API) (*template.Template, error) {
 			`<ac:structured-macro ac:name="widget">`,
 			`<ac:parameter ac:name="overlay">youtube</ac:parameter>`,
 			`<ac:parameter ac:name="_template">com/atlassian/confluence/extra/widgetconnector/templates/youtube.vm</ac:parameter>`,
-			`<ac:parameter ac:name="width">{{ or .Width "640px" }}</ac:parameter>`,
-			`<ac:parameter ac:name="height">{{ or .Height "360px" }}</ac:parameter>`,
-			`<ac:parameter ac:name="url"><ri:url ri:value="{{ .URL }}" /></ac:parameter>`,
+			`<ac:parameter ac:name="width">{{ or .Width "640px" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="height">{{ or .Height "360px" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="url"><ri:url ri:value="{{ .URL | xmlesc }}" /></ac:parameter>`,
 			`</ac:structured-macro>`,
 		),
 
@@ -258,12 +263,12 @@ func templates(api *confluence.API) (*template.Template, error) {
 
 		`ac:iframe`: text(
 			`<ac:structured-macro ac:name="iframe">`,
-			`<ac:parameter ac:name="src"><ri:url ri:value="{{ .URL }}" /></ac:parameter>`,
-			`{{ if .Frameborder }}<ac:parameter ac:name="frameborder">{{ .Frameborder }}</ac:parameter>{{ end }}`,
-			`{{ if .Scrolling }}<ac:parameter ac:name="id">{{ .Scrolling }}</ac:parameter>{{ end }}`,
-			`{{ if .Align }}<ac:parameter ac:name="align">{{ .Align }}</ac:parameter>{{ end }}`,
-			`<ac:parameter ac:name="width">{{ or .Width "640px" }}</ac:parameter>`,
-			`<ac:parameter ac:name="height">{{ or .Height "360px" }}</ac:parameter>`,
+			`<ac:parameter ac:name="src"><ri:url ri:value="{{ .URL | xmlesc }}" /></ac:parameter>`,
+			`{{ if .Frameborder }}<ac:parameter ac:name="frameborder">{{ .Frameborder | xmlesc }}</ac:parameter>{{ end }}`,
+			`{{ if .Scrolling }}<ac:parameter ac:name="id">{{ .Scrolling | xmlesc }}</ac:parameter>{{ end }}`,
+			`{{ if .Align }}<ac:parameter ac:name="align">{{ .Align | xmlesc }}</ac:parameter>{{ end }}`,
+			`<ac:parameter ac:name="width">{{ or .Width "640px" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="height">{{ or .Height "360px" | xmlesc }}</ac:parameter>`,
 			`</ac:structured-macro>`,
 		),
 
@@ -271,14 +276,14 @@ func templates(api *confluence.API) (*template.Template, error) {
 
 		`ac:blog-posts`: text(
 			`<ac:structured-macro ac:name="blog-posts">`,
-			`{{ if .Content }}<ac:parameter ac:name="content">{{ .Content }}</ac:parameter>{{ end }}`,
-			`{{ if .Spaces }}<ac:parameter ac:name="spaces">{{ .Spaces }}</ac:parameter>{{ end }}`,
-			`{{ if .Author }}<ac:parameter ac:name="author">{{ .Author }}</ac:parameter>{{ end }}`,
-			`{{ if .Time }}<ac:parameter ac:name="time">{{ .Time }}</ac:parameter>{{ end }}`,
-			`{{ if .Reverse }}<ac:parameter ac:name="reverse">{{ .Reverse }}</ac:parameter>{{ end }}`,
-			`{{ if .Sort }}<ac:parameter ac:name="sort">{{ .Sort }}</ac:parameter>{{ end }}`,
-			`{{ if .Max }}<ac:parameter ac:name="max">{{ .Max }}</ac:parameter>{{ end }}`,
-			`{{ if .Label }}<ac:parameter ac:name="label">{{ .Label }}</ac:parameter>{{ end }}`,
+			`{{ if .Content }}<ac:parameter ac:name="content">{{ .Content | xmlesc }}</ac:parameter>{{ end }}`,
+			`{{ if .Spaces }}<ac:parameter ac:name="spaces">{{ .Spaces | xmlesc }}</ac:parameter>{{ end }}`,
+			`{{ if .Author }}<ac:parameter ac:name="author">{{ .Author | xmlesc }}</ac:parameter>{{ end }}`,
+			`{{ if .Time }}<ac:parameter ac:name="time">{{ .Time | xmlesc }}</ac:parameter>{{ end }}`,
+			`{{ if .Reverse }}<ac:parameter ac:name="reverse">{{ .Reverse | xmlesc }}</ac:parameter>{{ end }}`,
+			`{{ if .Sort }}<ac:parameter ac:name="sort">{{ .Sort | xmlesc }}</ac:parameter>{{ end }}`,
+			`{{ if .Max }}<ac:parameter ac:name="max">{{ .Max | xmlesc }}</ac:parameter>{{ end }}`,
+			`{{ if .Label }}<ac:parameter ac:name="label">{{ .Label | xmlesc }}</ac:parameter>{{ end }}`,
 			`</ac:structured-macro>`,
 		),
 
@@ -288,7 +293,7 @@ func templates(api *confluence.API) (*template.Template, error) {
 			`<ac:structured-macro ac:name="include">`,
 			`<ac:parameter ac:name="">`,
 			`<ac:link>`,
-			`<ri:page ri:content-title="{{ .Page }}" {{if .Space }}ri:space-key="{{ .Space }}"{{ end }}/>`,
+			`<ri:page ri:content-title="{{ .Page | xmlesc }}" {{if .Space }}ri:space-key="{{ .Space | xmlesc }}"{{ end }}/>`,
 			`</ac:link>`,
 			`</ac:parameter>`,
 			`</ac:structured-macro>`,
@@ -299,9 +304,9 @@ func templates(api *confluence.API) (*template.Template, error) {
 
 		`ac:excerpt-include`: text(
 			`<ac:macro ac:name="excerpt-include">`,
-			`{{ if .Name }}<ac:parameter ac:name="name">{{ .Name }}</ac:parameter>{{ end }}`,
-			`<ac:parameter ac:name="nopanel">{{ if .NoPanel }}{{ .NoPanel }}{{ else }}false{{ end }}</ac:parameter>`,
-			`<ac:default-parameter>{{ .Page }}</ac:default-parameter>`,
+			`{{ if .Name }}<ac:parameter ac:name="name">{{ .Name | xmlesc }}</ac:parameter>{{ end }}`,
+			`<ac:parameter ac:name="nopanel">{{ if .NoPanel }}{{ .NoPanel | xmlesc }}{{ else }}false{{ end }}</ac:parameter>`,
+			`<ac:default-parameter>{{ .Page | xmlesc }}</ac:default-parameter>`,
 			`</ac:macro>`,
 		),
 
@@ -310,11 +315,11 @@ func templates(api *confluence.API) (*template.Template, error) {
 
 		`ac:excerpt`: text(
 			`<ac:structured-macro ac:name="excerpt">`,
-			`{{ if .Name }}<ac:parameter ac:name="name">{{ .Name }}</ac:parameter>{{ end }}`,
-			`<ac:parameter ac:name="hidden">{{ if .Hidden }}{{ .Hidden }}{{ else }}false{{ end }}</ac:parameter>`,
-			`<ac:parameter ac:name="atlassian-macro-output-type">{{ if .OutputType }}{{ .OutputType }}{{ else }}BLOCK{{ end }}</ac:parameter>`,
+			`{{ if .Name }}<ac:parameter ac:name="name">{{ .Name | xmlesc }}</ac:parameter>{{ end }}`,
+			`<ac:parameter ac:name="hidden">{{ if .Hidden }}{{ .Hidden | xmlesc }}{{ else }}false{{ end }}</ac:parameter>`,
+			`<ac:parameter ac:name="atlassian-macro-output-type">{{ if .OutputType }}{{ .OutputType | xmlesc }}{{ else }}BLOCK{{ end }}</ac:parameter>`,
 			`<ac:rich-text-body>`,
-			`{{ .Excerpt }}`,
+			`{{ .Excerpt | xmlesc }}`,
 			`</ac:rich-text-body>`,
 			`</ac:structured-macro>`,
 		),
@@ -323,7 +328,7 @@ func templates(api *confluence.API) (*template.Template, error) {
 
 		`ac:anchor`: text(
 			`<ac:structured-macro ac:name="anchor">`,
-			`<ac:parameter ac:name="">{{ .Anchor }}</ac:parameter>`,
+			`<ac:parameter ac:name="">{{ .Anchor | xmlesc }}</ac:parameter>`,
 			`</ac:structured-macro>`,
 		),
 
@@ -356,7 +361,7 @@ func templates(api *confluence.API) (*template.Template, error) {
 		// to normalise what it was not promised.
 		`ac:footnote:ref`: text(
 			`<ac:link ac:anchor="{{ .Anchor | xmlesc }}">`,
-			`<ac:link-body><sup>[{{ .Number }}]</sup></ac:link-body>`,
+			`<ac:link-body><sup>[{{ .Number | xmlesc }}]</sup></ac:link-body>`,
 			`</ac:link>`,
 		),
 
@@ -366,7 +371,7 @@ func templates(api *confluence.API) (*template.Template, error) {
 		// case each way back has to be told apart.
 		`ac:footnote:backref`: text(
 			`&#160;<ac:link ac:anchor="{{ .Anchor | xmlesc }}">`,
-			`<ac:link-body>&#x21a9;&#xfe0e;{{ if .Number }}<sup>{{ .Number }}</sup>{{ end }}</ac:link-body>`,
+			`<ac:link-body>&#x21a9;&#xfe0e;{{ if .Number }}<sup>{{ .Number | xmlesc }}</sup>{{ end }}</ac:link-body>`,
 			`</ac:link>`,
 		),
 
@@ -377,7 +382,7 @@ func templates(api *confluence.API) (*template.Template, error) {
 		// the closing tags as content.
 		`ac:expand`: text(
 			`<ac:structured-macro ac:name="expand">`,
-			`<ac:parameter ac:name="title">{{ .Title }}</ac:parameter>`,
+			`<ac:parameter ac:name="title">{{ .Title | xmlesc }}</ac:parameter>`,
 			"<ac:rich-text-body>\n\n{{ .Body }}\n\n</ac:rich-text-body>",
 			`</ac:structured-macro>`,
 		),
@@ -389,9 +394,9 @@ func templates(api *confluence.API) (*template.Template, error) {
 			`<ac:structured-macro ac:name="profile">`,
 			`<ac:parameter ac:name="user">`,
 			`{{ if .AccountID }}`,
-			/**/ `<ri:user ri:account-id="{{ .AccountID }}" />`,
+			/**/ `<ri:user ri:account-id="{{ .AccountID | xmlesc }}" />`,
 			`{{ else }}`,
-			/**/ `<ri:user ri:userkey="{{ .UserKey }}" />`,
+			/**/ `<ri:user ri:userkey="{{ .UserKey | xmlesc }}" />`,
 			`{{ end }}`,
 			`</ac:parameter>`,
 			`</ac:structured-macro>`,
@@ -402,7 +407,7 @@ func templates(api *confluence.API) (*template.Template, error) {
 
 		`ac:contentbylabel`: text(
 			`<ac:structured-macro ac:name="contentbylabel" ac:schema-version="3">`,
-			`<ac:parameter ac:name="cql">{{ .CQL }}</ac:parameter>`,
+			`<ac:parameter ac:name="cql">{{ .CQL | xmlesc }}</ac:parameter>`,
 			`</ac:structured-macro>`,
 		),
 
@@ -410,10 +415,10 @@ func templates(api *confluence.API) (*template.Template, error) {
 
 		`ac:detailssummary`: text(
 			`<ac:structured-macro ac:name="detailssummary" ac:schema-version="2">`,
-			`<ac:parameter ac:name="headings">{{ .Headings }}</ac:parameter>`,
-			`<ac:parameter ac:name="firstcolumn">{{ .FirstColumn }}</ac:parameter>`,
-			`<ac:parameter ac:name="sortBy">{{ .SortBy }}</ac:parameter>`,
-			`<ac:parameter ac:name="cql">{{ .CQL }}</ac:parameter>`,
+			`<ac:parameter ac:name="headings">{{ .Headings | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="firstcolumn">{{ .FirstColumn | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="sortBy">{{ .SortBy | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="cql">{{ .CQL | xmlesc }}</ac:parameter>`,
 			`</ac:structured-macro>`,
 		),
 
@@ -435,15 +440,15 @@ func templates(api *confluence.API) (*template.Template, error) {
 			`<ac:structured-macro ac:name="pagetree" ac:schema-version="1">`,
 			`<ac:parameter ac:name="root">`,
 			`<ac:link>`,
-			`<ri:page ri:content-title="{{ or .Title "@self" }}"/>`,
+			`<ri:page ri:content-title="{{ or .Title "@self" | xmlesc }}"/>`,
 			`</ac:link>`,
 			`</ac:parameter>`,
-			`<ac:parameter ac:name="sort">{{ or .Sort "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="excerpt">{{ or .Excerpt "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="reverse">{{ or .Reverse "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="searchBox">{{ or .SearchBox "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="expandCollapseAll">{{ or .ExpandCollapseAll "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="startDepth">{{ or .StartDepth "" }}</ac:parameter>`,
+			`<ac:parameter ac:name="sort">{{ or .Sort "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="excerpt">{{ or .Excerpt "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="reverse">{{ or .Reverse "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="searchBox">{{ or .SearchBox "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="expandCollapseAll">{{ or .ExpandCollapseAll "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="startDepth">{{ or .StartDepth "" | xmlesc }}</ac:parameter>`,
 			`</ac:structured-macro>`,
 		),
 
@@ -451,7 +456,7 @@ func templates(api *confluence.API) (*template.Template, error) {
 
 		`ac:pagetreesearch`: text(
 			`<ac:structured-macro ac:name="pagetreesearch">`,
-			`{{ if .Root }}<ac:parameter ac:name="root">{{ .Root }}</ac:parameter>{{ end }}`,
+			`{{ if .Root }}<ac:parameter ac:name="root">{{ .Root | xmlesc }}</ac:parameter>{{ end }}`,
 			`</ac:structured-macro>`,
 		),
 
@@ -462,12 +467,12 @@ func templates(api *confluence.API) (*template.Template, error) {
 		// the closing tags as content.
 		`ac:panel`: text(
 			`<ac:structured-macro ac:name="panel">`,
-			`<ac:parameter ac:name="bgColor">{{ or .BGColor "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="titleBGColor">{{ or .TitleBGColor "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="title">{{ or .Title "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="borderStyle">{{ or .BorderStyle "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="borderColor">{{ or .BorderColor "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="titleColor">{{ or .TitleColor "" }}</ac:parameter>`,
+			`<ac:parameter ac:name="bgColor">{{ or .BGColor "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="titleBGColor">{{ or .TitleBGColor "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="title">{{ or .Title "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="borderStyle">{{ or .BorderStyle "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="borderColor">{{ or .BorderColor "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="titleColor">{{ or .TitleColor "" | xmlesc }}</ac:parameter>`,
 			"<ac:rich-text-body>\n\n{{ .Body }}\n\n</ac:rich-text-body>",
 			`</ac:structured-macro>`,
 		),
@@ -475,13 +480,13 @@ func templates(api *confluence.API) (*template.Template, error) {
 		/* https://confluence.atlassian.com/conf59/recently-updated-macro-792499187.html */
 		`ac:recently-updated`: text(
 			`<ac:structured-macro ac:name="recently-updated">`,
-			`{{ if .Spaces }}<ac:parameter ac:name="spaces"><ri:space ri:space-key={{ .Spaces }}/></ac:parameter>{{ end }}`,
-			`<ac:parameter ac:name="showProfilePic">{{ or .ShowProfilePic "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="types">{{ or .Types "page, comment, blogpost" }}</ac:parameter>`,
-			`<ac:parameter ac:name="max">{{ or .Max "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="labels">{{ or .Labels "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="hideHeading">{{ or .HideHeading "" }}</ac:parameter>`,
-			`<ac:parameter ac:name="theme">{{ or .Theme "" }}</ac:parameter>`,
+			`{{ if .Spaces }}<ac:parameter ac:name="spaces"><ri:space ri:space-key="{{ .Spaces | xmlesc }}"/></ac:parameter>{{ end }}`,
+			`<ac:parameter ac:name="showProfilePic">{{ or .ShowProfilePic "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="types">{{ or .Types "page, comment, blogpost" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="max">{{ or .Max "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="labels">{{ or .Labels "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="hideHeading">{{ or .HideHeading "" | xmlesc }}</ac:parameter>`,
+			`<ac:parameter ac:name="theme">{{ or .Theme "" | xmlesc }}</ac:parameter>`,
 			`</ac:structured-macro>`,
 		),
 		/* https://confluence.atlassian.com/conf59/column-macro-792499085.html */
@@ -490,18 +495,18 @@ func templates(api *confluence.API) (*template.Template, error) {
 		// the closing tags as content.
 		`ac:column`: text(
 			`<ac:structured-macro ac:name="column">`,
-			`<ac:parameter ac:name="width">{{ or .Width "" }}</ac:parameter>`,
-			"<ac:rich-text-body>\n\n{{ or .Body \"\" }}\n\n</ac:rich-text-body>",
+			`<ac:parameter ac:name="width">{{ or .Width "" | xmlesc }}</ac:parameter>`,
+			"<ac:rich-text-body>\n\n{{ or .Body \"\" | xmlesc }}\n\n</ac:rich-text-body>",
 			`</ac:structured-macro>`,
 		),
 		/* https://confluence.atlassian.com/conf59/multimedia-macro-792499140.html */
 		`ac:multimedia`: text(
 			`<ac:structured-macro ac:name="multimedia">`,
-			`<ac:parameter ac:name="width">{{ or .Width 500 }}</ac:parameter>`,
+			`<ac:parameter ac:name="width">{{ or .Width 500 | xmlesc }}</ac:parameter>`,
 			`<ac:parameter ac:name="name">`,
 			`<ri:attachment ri:filename="{{ .Name | convertAttachment }}"/>`,
 			`</ac:parameter>`,
-			`<ac:parameter ac:name="autoplay">{{ or .AutoPlay "false"}}</ac:parameter>`,
+			`<ac:parameter ac:name="autoplay">{{ or .AutoPlay "false" | xmlesc }}</ac:parameter>`,
 			`</ac:structured-macro>`,
 		),
 		/* https://confluence.atlassian.com/conf59/view-file-macro-792499226.html */
@@ -510,7 +515,7 @@ func templates(api *confluence.API) (*template.Template, error) {
 			`<ac:parameter ac:name="name">`,
 			`<ri:attachment ri:filename="{{ .Name | convertAttachment }}"/>`,
 			`</ac:parameter>`,
-			`<ac:parameter ac:name="height">{{ or .Height 250 }}</ac:parameter>`,
+			`<ac:parameter ac:name="height">{{ or .Height 250 | xmlesc }}</ac:parameter>`,
 			`</ac:structured-macro>`,
 		),
 


### PR DESCRIPTION
Five verified bugs from a code audit, each with a test that fails without the fix. The through-line for the first two: **storage format is XML, and a malformed body makes Confluence reject the whole page** — so every one of these reached the author as an opaque `BadRequestException`, or as nothing at all.

## What is fixed

**Every macro parameter is escaped, in one place.** Fourteen templates interpolated user text straight into the storage format, and `ac:recently-updated` emitted an attribute with *no quotes around it at all* (`stdlib/stdlib.go:478`). A page title containing `&`, or a URL with two query parameters, was enough to break the upload. AGENTS.md invariant 2 has always said to escape through the stdlib funcs — the fix had been applied to `ac:code`, `ac:box`, `ac:status` and the footnotes as each of those broke a page, and never propagated. `xmlesc` now takes `any` so a parameter with a non-string default can pipe through it, and the two call sites that were escaping by hand (`renderer/image.go`, `renderer/math.go`) hand over raw values instead of escaping twice.

**A body Confluence would reject is refused locally.** `CheckWellFormed` parses the finished body — after the layout wrap and after inline comments are merged, since that is what actually gets sent — and fails with the line and the text on it. The parse is the one `renderer/helpers_test.go` has been using; the entity table is HTML's, because the templates emit `&#160;` and documents write `&nbsp;`.

**An admonition marker has to open the line.** `> Information about pricing is below.` published as an `info` macro, and `> Please note that the API changed.` as a `note`, because the classifier matched the word anywhere in the first line. "multiple" contains `tip`; "warning signs" contains `warn`. Everything the documented syntax allows still classifies — `Info: text`, `**Note:**`, `NOTES:`, a bare `Warn`, the `<!-- Info -->` comment form in `testdata/quotes.md`.

**A macro directive inside a code block is an example, not an instruction.** `ExtractMacros` hoisted it out of the fence, registered it as a live macro, and left the fence empty — so mark could not publish its own README, which shows five of them. `findIncludeDirective` and `Macro.Apply` both already skip code regions; only extraction did not.

**Three ways a run lost state**, plus a BOM fix:
- The page manifest was discarded whenever a file failed without `--continue-on-error`. The comment above the save says a single bad file must not throw away the mapping for pages that published fine — but only the continue-on-error branch was fixed. Now deferred, because there are five return paths and the next one added would miss it too.
- `--preserve-comments` silently discarded a retitle: the refetch replaced the page object carrying the staged title. It compounded — the manifest then recorded a title the page did not carry, misresolving every parent named by it.
- `CreateFolder` panicked when a remembered parent folder had been deleted; `GetFolderByID` answers `(nil, nil)`, and this was the only one of its four call sites not checking.
- A UTF-8 BOM made every parser see a file with no metadata, failing with "doesn't contain metadata" — pointing away from the headers, which were present.

## Testing

`go test ./...`, `golangci-lint run ./...` clean. Every fix has a test, and each was confirmed to fail with the fix reverted.

Independent of #925 and #926; all three branch from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)