### PR TITLE
fix(renderer): an admonition marker has to open the line

### DIFF
--- a/renderer/blockquote.go
+++ b/renderer/blockquote.go
@@ -3,6 +3,7 @@ package renderer
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/renderer"
@@ -53,15 +54,54 @@ type BlockQuoteClassifier struct {
 	patternMap map[string]*regexp.Regexp
 }
 
+// blockQuoteMarker matches a line that opens with an admonition marker.
+//
+// Anchored, and requiring the marker to end on a word boundary, because the
+// unanchored version this replaces matched the word anywhere in the line:
+// "Information about pricing is below." became an info macro and "Please note
+// that the API changed." became a note, since `info` and `note` are substrings
+// of both. Four of the commonest words in English documentation silently
+// rewrote the paragraphs that used them, and the author's only recourse was to
+// reword the sentence.
+//
+// Everything the documented syntax allows still matches -- "Info: text",
+// "**Note:** text", "NOTES:", a bare "Warn" -- because the marker is written
+// at the front of the line in every one of them. Emphasis is not in the text
+// this sees, goldmark having already made a node of it, so "**Warn**" arrives
+// as "Warn".
+var blockQuoteMarker = regexp.MustCompile(
+	`^(?i)(info|infos|note|notes|warn|warns|warning|warnings|tip|tips)\b[[:punct:]]*(\s|$)`,
+)
+
 func LegacyBlockQuoteClassifier() BlockQuoteClassifier {
 	return BlockQuoteClassifier{
 		patternMap: map[string]*regexp.Regexp{
-			"info": regexp.MustCompile(`(?i)info`),
-			"note": regexp.MustCompile(`(?i)note`),
-			"warn": regexp.MustCompile(`(?i)warn`),
-			"tip":  regexp.MustCompile(`(?i)tip`),
+			"info": regexp.MustCompile(`(?i)^info`),
+			"note": regexp.MustCompile(`(?i)^note`),
+			"warn": regexp.MustCompile(`(?i)^warn`),
+			"tip":  regexp.MustCompile(`(?i)^tip`),
 		},
 	}
+}
+
+// markerOf returns the admonition marker a line opens with, or "" if the line
+// is ordinary prose.
+//
+// The comment form is stripped first: "<!-- Info -->" is a marker written in a
+// way that keeps it out of the rendered page, and testdata/quotes.md has
+// carried one since long before this was written.
+func markerOf(literal string) string {
+	marker := strings.TrimSpace(literal)
+	marker = strings.TrimPrefix(marker, "<!--")
+	marker = strings.TrimSuffix(marker, "-->")
+	marker = strings.TrimSpace(marker)
+
+	found := blockQuoteMarker.FindString(marker)
+	if found == "" {
+		return ""
+	}
+
+	return found
 }
 
 // ClassifyingBlockQuote compares a string against a set of patterns and returns a BlockQuoteType
@@ -69,15 +109,20 @@ func LegacyBlockQuoteClassifier() BlockQuoteClassifier {
 // in the GitHub Alerts extension, not by this legacy blockquote renderer
 func (classifier BlockQuoteClassifier) ClassifyingBlockQuote(literal string) BlockQuoteType {
 
+	marker := markerOf(literal)
+	if marker == "" {
+		return None
+	}
+
 	var t = None
 	switch {
-	case classifier.patternMap["info"].MatchString(literal):
+	case classifier.patternMap["info"].MatchString(marker):
 		t = Info
-	case classifier.patternMap["note"].MatchString(literal):
+	case classifier.patternMap["note"].MatchString(marker):
 		t = Note
-	case classifier.patternMap["warn"].MatchString(literal):
+	case classifier.patternMap["warn"].MatchString(marker):
 		t = Warn
-	case classifier.patternMap["tip"].MatchString(literal):
+	case classifier.patternMap["tip"].MatchString(marker):
 		t = Tip
 	}
 	return t

--- a/renderer/blockquote_test.go
+++ b/renderer/blockquote_test.go
@@ -63,18 +63,61 @@ func TestBlockQuoteUnclassifiedStaysAQuote(t *testing.T) {
 	assert.NotContains(t, actual, "ac:structured-macro")
 }
 
-// TestBlockQuoteClassifierMatchesAnywhereInTheFirstLine records a trap in the
-// legacy syntax rather than an intention: the classifier looks for the word
-// anywhere in the first line, unanchored and case-insensitively, so a quote that
-// merely mentions the word becomes a macro. Authors who want a plain quotation
-// of a sentence containing "note" have to reword it or use a different
-// construct.
-func TestBlockQuoteClassifierMatchesAnywhereInTheFirstLine(t *testing.T) {
-	actual := render(t, "> Nothing here was noteworthy.\n", legacyBlockQuoteRenderers())
-	assertWellFormed(t, actual)
+// TestBlockQuoteMarkerMustOpenTheLine covers the trap this syntax used to set.
+// The classifier looked for the word anywhere in the first line, so a quotation
+// that merely mentioned one of four very common words became an admonition
+// macro -- and the author's only recourse was to reword the sentence. The
+// marker now has to open the line, which is where every documented form of it
+// is written anyway.
+func TestBlockQuoteMarkerMustOpenTheLine(t *testing.T) {
+	prose := []struct {
+		name  string
+		input string
+	}{
+		{"word inside another word", "> Nothing here was noteworthy.\n"},
+		{"info inside information", "> Information about pricing is below.\n"},
+		{"note mid-sentence", "> Please note that the API changed.\n"},
+		{"tip inside multiple", "> There are multiple ways to do this.\n"},
+		{"warn inside a sentence", "> We should warn them first.\n"},
+	}
 
-	assert.Contains(t, actual, `ac:name="note"`,
-		"the word inside another word still classifies the quote")
+	for _, tt := range prose {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := render(t, tt.input, legacyBlockQuoteRenderers())
+			assertWellFormed(t, actual)
+
+			assert.Contains(t, actual, "<blockquote>",
+				"ordinary prose stays a quotation")
+			assert.NotContains(t, actual, "ac:structured-macro")
+		})
+	}
+}
+
+// TestBlockQuoteMarkerFormsStillClassify is the other half: everything the
+// syntax has always accepted has to keep working, or the fix above would be a
+// removal rather than a repair.
+func TestBlockQuoteMarkerFormsStillClassify(t *testing.T) {
+	forms := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"marker with a colon and text", "> Info: the build is nightly.\n", `ac:name="info"`},
+		{"marker alone", "> Warn\n", `ac:name="warning"`},
+		{"plural with a colon", "> **NOTES:**\n>\n> One.\n", `ac:name="note"`},
+		{"emphasised marker", "> **Tip:** use the cache.\n", `ac:name="tip"`},
+		{"shouting", "> NOTE: shouting.\n", `ac:name="note"`},
+		{"warning spelled out", "> Warning: this deletes data.\n", `ac:name="warning"`},
+	}
+
+	for _, tt := range forms {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := render(t, tt.input, legacyBlockQuoteRenderers())
+			assertWellFormed(t, actual)
+
+			assert.Contains(t, actual, tt.want)
+		})
+	}
 }
 
 // TestBlockQuoteTypeComesFromTheFirstParagraphOnly pins the scope of the


### PR DESCRIPTION
The classifier looked for info, note, warn and tip anywhere in a blockquote's
first line, unanchored and case-insensitively. So

    > Information about pricing is below.

published as an info macro, and

    > Please note that the API changed.

as a note. "multiple" contains tip; "warning signs" contains warn. Four of the
commonest words in English documentation silently rewrote the paragraphs that
used them, and the author's only recourse was to reword the sentence.

The marker now has to open the line and end on a word boundary, which is where
every documented form of it is written anyway: "Info: text", "**Note:** text",
"NOTES:", a bare "Warn", and the "<!-- Info -->" comment form that
testdata/quotes.md has carried for years. All of those still classify; the
sentences above no longer do.

Position already handled the other half of this -- only the first paragraph of a
quote is consulted, which is why the "Warn (Should not be picked...)" line in
the fixtures is ignored -- and that is unchanged.

TestBlockQuoteClassifierMatchesAnywhereInTheFirstLine recorded the old
behaviour as a trap rather than an intention, in those words. It is replaced by
a test that the trap is gone, and by one asserting every marker form still
works, so the repair cannot quietly become a removal.
