### PR TITLE
fix(macro): a directive inside a code block is an example, not an instruction

### DIFF
--- a/macro/macro.go
+++ b/macro/macro.go
@@ -256,6 +256,15 @@ func ExtractMacros(
 	var extracted []Macro
 	remaining := contents
 
+	// A macro directive written inside a fenced or indented code block is an
+	// example of one, not one to obey -- which is how any document about mark
+	// shows the syntax, this repository's own README included. Include
+	// directives have always been skipped there, and Macro.Apply already
+	// refuses to rewrite matches inside code; only this pass was missing it, so
+	// the example was hoisted out of the block, registered as a real macro, and
+	// the code block left empty.
+	codeRegions := metadata.CodeRegions(remaining)
+
 	searchOffset := 0
 	for searchOffset < len(remaining) {
 		relStart := bytes.Index(remaining[searchOffset:], []byte("<!--"))
@@ -271,6 +280,11 @@ func ExtractMacros(
 		if macroIdx == -1 || firstEndIdx == -1 || macroIdx > firstEndIdx {
 			// Not a macro directive comment, move past this comment
 			searchOffset = startIdx + firstEndIdx + 3
+			continue
+		}
+
+		if metadata.InCode(codeRegions, startIdx) {
+			searchOffset = startIdx + 4
 			continue
 		}
 
@@ -362,6 +376,11 @@ func ExtractMacros(
 
 		remaining = append(remaining[:startIdx], remaining[endIdx:]...)
 		searchOffset = startIdx
+
+		// Every offset after the splice has moved, so the regions have to be
+		// found again rather than adjusted -- a directive removed from between
+		// two code blocks changes where both of them start.
+		codeRegions = metadata.CodeRegions(remaining)
 	}
 
 	return extracted, remaining, nil

--- a/macro/macro_test.go
+++ b/macro/macro_test.go
@@ -114,3 +114,55 @@ func TestExtractMacros_InlineTemplateUsesDefaultDelims(t *testing.T) {
 	assert.Equal(t, "Hello world", out.String(),
 		"an inline macro must use {{ }} regardless of any Delims: an include declared")
 }
+
+// TestExtractMacros_SkipsDirectivesInsideCodeBlocks: a macro directive inside a
+// fence is an example of the syntax, not an instruction. Extracting it hoisted
+// the example out of the block, registered it as a live macro, and left the
+// block empty -- which is what happened to every document that documented mark,
+// this repository's own README included. Include directives were always skipped
+// there; only this pass was not.
+func TestExtractMacros_SkipsDirectivesInsideCodeBlocks(t *testing.T) {
+	contents := []byte("Here is how a macro is written:\n\n" +
+		"```markdown\n" +
+		"<!-- Macro: MYJIRA-\\d+\n" +
+		"     Template: #inline\n" +
+		"     inline: \"ticket ${0}\" -->\n" +
+		"```\n\nAnd some prose after it.\n")
+
+	macros, remaining, err := ExtractMacros("", "", contents, template.New("test"))
+	require.NoError(t, err)
+
+	assert.Empty(t, macros, "a directive inside a fence must not be registered")
+	assert.Contains(t, string(remaining), "<!-- Macro: MYJIRA-",
+		"the example must stay in the code block, verbatim")
+	assert.Contains(t, string(remaining), "And some prose after it.")
+}
+
+// TestExtractMacros_StillTakesDirectivesOutsideCode is the control: skipping
+// code must not turn into skipping everything.
+func TestExtractMacros_StillTakesDirectivesOutsideCode(t *testing.T) {
+	contents := []byte("<!-- Macro: TICKET-(\\d+)\n" +
+		"     Template: #inline\n" +
+		"     inline: \"ticket ${1}\" -->\n\n" +
+		"```markdown\n<!-- Macro: EXAMPLE -->\n```\n\nSee TICKET-42.\n")
+
+	macros, remaining, err := ExtractMacros("", "", contents, template.New("test"))
+	require.NoError(t, err)
+
+	require.Len(t, macros, 1, "the real directive is still extracted")
+	rest := string(remaining)
+	assert.NotContains(t, rest, "Macro: TICKET-", "the real one is stripped")
+	assert.Contains(t, rest, "<!-- Macro: EXAMPLE -->", "the example one is not")
+}
+
+// TestExtractMacros_SkipsDirectivesInIndentedCode covers the other code form,
+// since CodeRegions reports both and a fence is the easy half.
+func TestExtractMacros_SkipsDirectivesInIndentedCode(t *testing.T) {
+	contents := []byte("Written like this:\n\n    <!-- Macro: X\n         Template: #inline\n         inline: \"y\" -->\n\nDone.\n")
+
+	macros, remaining, err := ExtractMacros("", "", contents, template.New("test"))
+	require.NoError(t, err)
+
+	assert.Empty(t, macros)
+	assert.Contains(t, string(remaining), "<!-- Macro: X")
+}


### PR DESCRIPTION
ExtractMacros scanned raw bytes for "<!-- Macro:" with no notion of where the
document was showing code. A directive inside a fence was therefore hoisted out
of it, registered as a live macro, and applied to the rest of the file -- and
the fence was left empty, since the extraction removes what it takes.

Any document that documents mark hits this. This repository's README shows five
macro directives inside fences; mark cannot publish its own README.

The two neighbouring passes already knew better: findIncludeDirective takes a
skip callback backed by metadata.InCode, and Macro.Apply calls
metadata.CodeRegions before rewriting anything. Only extraction was missing it,
which made it an inconsistency rather than a decision.

The regions are recomputed after each directive is spliced out. Every offset
after the splice has moved, and a directive removed from between two code blocks
changes where both of them start.
