### PR TITLE
fix(confluence): a parent folder that has vanished is not a panic

### DIFF
--- a/confluence/api.go
+++ b/confluence/api.go
@@ -1271,7 +1271,12 @@ func (api *API) CreateFolder(spaceID, title string, parentID *string, parentType
 			return nil, fmt.Errorf("failed to get parent folder info for space consistency: %w", err)
 		}
 
-		if parentFolder.SpaceID != "" {
+		// A folder that is not there answers (nil, nil), not an error, and the
+		// id reaching here came from a cache or from the manifest -- so it names
+		// a folder that existed when it was recorded and may not now. Every
+		// other caller of GetFolderByID checks this; only here did a folder
+		// deleted between runs panic instead of falling back to the space.
+		if parentFolder != nil && parentFolder.SpaceID != "" {
 			actualSpaceID = parentFolder.SpaceID
 		}
 	}

--- a/confluence/folder_test.go
+++ b/confluence/folder_test.go
@@ -1,0 +1,35 @@
+package confluence_test
+
+import (
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateFolderUnderAVanishedParent: GetFolderByID answers (nil, nil) for a
+// folder that is not there, not an error, and CreateFolder checked only the
+// error before reading the parent's space id -- so it panicked rather than
+// failed.
+//
+// The id reaching it comes from the folder cache or from the manifest, meaning
+// it names a folder that existed when it was recorded. A folder deleted in
+// Confluence between two runs is exactly the case folder tracking exists to
+// survive, so this crashed on the recovery path.
+func TestCreateFolderUnderAVanishedParent(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	space := server.AddSpace("DOCS")
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+
+	gone := "no-such-folder"
+	folder, err := api.CreateFolder(space.ID, "Guides", &gone, "folder")
+
+	require.NoError(t, err, "a missing parent must not fail the call")
+	require.NotNil(t, folder)
+	assert.Equal(t, "Guides", folder.Title)
+}


### PR DESCRIPTION
GetFolderByID answers (nil, nil) for a folder that is not there rather than an
error, and CreateFolder checked only the error before reading the parent's space
id. The result was a nil dereference: a crash, with a stack trace, in place of a
publish.

The id it dereferences comes from the process-wide folder cache or from the
manifest, so it always names a folder that existed when it was recorded and may
not exist now. A folder deleted in Confluence between two runs is precisely the
case folder tracking exists to survive, so the crash was on the recovery path.

Every other caller of GetFolderByID already nil-checks, which is what makes this
an omission rather than a contract. With the check the call falls back to the
space id, as it does when no parent is given at all.
