### PR TITLE
feat: refuse a body Confluence would reject, before uploading it

### DIFF
--- a/mark.go
+++ b/mark.go
@@ -902,6 +902,13 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	})
 
 	if shouldUpdatePage {
+		// Checked here rather than anywhere earlier because this is the body
+		// that is actually sent: after the layout wrap, and after any inline
+		// comments have been merged back into it.
+		if err := markmd.CheckWellFormed(html); err != nil {
+			return nil, nil, err
+		}
+
 		err = api.UpdatePage(
 			target,
 			html,

--- a/mark_wellformed_test.go
+++ b/mark_wellformed_test.go
@@ -1,0 +1,130 @@
+package mark
+
+import (
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// publishConfig is a plain publish with no tracking, for tests about what
+// reaches Confluence rather than about what mark remembers.
+func publishConfig(url, files string) Config {
+	return Config{
+		BaseURL:  url,
+		Username: "user",
+		Password: "token",
+		Files:    files,
+		Features: []string{"mention"},
+		Output:   io.Discard,
+	}
+}
+
+// TestMalformedBodyIsRefusedBeforeUpload: storage format is XML, and Confluence
+// answers a body that is not well-formed by rejecting the whole page with a
+// BadRequestException that names nothing. Catching it here is the difference
+// between a complaint the author can act on and one they cannot.
+func TestMalformedBodyIsRefusedBeforeUpload(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	// An unbalanced tag the document wrote itself. Nothing downstream can
+	// repair this one -- it is the author's to fix -- which is what makes it
+	// the right shape for this test.
+	file := writeFile(t, dir, "doc.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Malformed -->
+
+Some text with an <span>unclosed tag.
+`)
+
+	err := Run(publishConfig(server.URL, file))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not well-formed XML")
+	assert.Contains(t, err.Error(), "unclosed tag")
+
+	// The page itself is created during ancestry resolution, before the body is
+	// compiled, so what the gate protects is the content: the page is left
+	// empty rather than filled with markup Confluence would reject.
+	assert.Empty(t, bodyOfPageTitled(t, server, "Malformed"),
+		"no body should have been uploaded")
+}
+
+// bodyOfPageTitled returns what is actually stored on the page carrying a
+// title, or "" if no page carries it.
+func bodyOfPageTitled(t *testing.T, server *confluencetest.Server, title string) string {
+	t.Helper()
+	fresh := confluence.NewAPI(server.URL, "user", "token", false)
+	found, err := fresh.FindPage("DOCS", title, "page")
+	require.NoError(t, err)
+	if found == nil {
+		return ""
+	}
+	return server.Page(found.ID).Body
+}
+
+// TestWellFormedBodyPublishes is the control: the gate must not stand in the
+// way of the markup mark itself emits.
+func TestWellFormedBodyPublishes(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	// Deliberately busy: entities, a macro, a code block holding markup, and a
+	// footnote -- the constructs whose output the check is most likely to
+	// misread.
+	file := writeFile(t, dir, "doc.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Well Formed -->
+
+A & B, "quoted", 3 < 4, and a non-breaking&nbsp;space.
+
+| a | b |
+|---|---|
+| 1 | 2 |
+
+`+"```go\nif a < b && c > d {}\n```"+`
+
+A claim[^why].
+
+[^why]: Because.
+`)
+
+	require.NoError(t, Run(publishConfig(server.URL, file)))
+	assert.Equal(t, 1, countPagesTitled(t, server, "Well Formed"))
+}
+
+// TestMalformedBodyIsRefusedAcrossAFileSet: one bad document must not take the
+// good ones with it, and must not be silently skipped either.
+func TestMalformedBodyIsRefusedAcrossAFileSet(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "a-good.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Good -->
+
+Fine.
+`)
+	writeFile(t, dir, "b-bad.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Bad -->
+
+An <span>unclosed tag.
+`)
+
+	config := publishConfig(server.URL, filepath.Join(dir, "*.md"))
+	config.ContinueOnError = true
+
+	err := Run(config)
+	require.Error(t, err)
+
+	assert.NotEmpty(t, bodyOfPageTitled(t, server, "Good"),
+		"the well-formed document should still publish")
+	assert.Empty(t, bodyOfPageTitled(t, server, "Bad"),
+		"the malformed one should have uploaded no body")
+}

--- a/markdown/wellformed.go
+++ b/markdown/wellformed.go
@@ -1,0 +1,81 @@
+package mark
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// wellFormedPrologue supplies the two namespace prefixes a compiled body uses
+// but never declares -- the page it becomes is what declares them. It is
+// deliberately free of newlines so that the line numbers the parser reports are
+// the body's own.
+const wellFormedPrologue = `<root xmlns:ac="ac" xmlns:ri="ri">`
+
+// CheckWellFormed reports whether a compiled body is XML that Confluence will
+// accept.
+//
+// Storage format is an XML dialect, and Confluence answers a body that is not
+// well-formed with BadRequestException: it rejects the whole page rather than
+// the element at fault, and says nothing about which element that was. Every
+// way of producing invalid markup therefore surfaces to the author as one
+// opaque server error, whatever caused it -- an unescaped ampersand in a macro
+// parameter, a void <br> written by hand, an HTML comment containing a double
+// hyphen.
+//
+// Running the same parse here turns all of that into one local complaint that
+// names the line, before anything is uploaded.
+func CheckWellFormed(body string) error {
+	decoder := xml.NewDecoder(strings.NewReader(wellFormedPrologue + body + `</root>`))
+	decoder.Strict = true
+
+	// Confluence accepts the named HTML entities, and mark's own templates emit
+	// them -- &#160; between a footnote and its backlink, &nbsp; from a
+	// document. A bare encoding/xml decoder knows only the five XML ones and
+	// would report every one of those as an error.
+	decoder.Entity = xml.HTMLEntity
+
+	for {
+		_, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err == nil {
+			continue
+		}
+
+		var syntax *xml.SyntaxError
+		if !errors.As(err, &syntax) {
+			return err
+		}
+
+		return fmt.Errorf(
+			"the rendered page is not well-formed XML, which Confluence rejects "+
+				"in its entirety: line %d: %s%s",
+			syntax.Line, syntax.Msg, quoteLine(body, syntax.Line),
+		)
+	}
+}
+
+// quoteLine returns the offending line of the rendered body, so the complaint
+// points at something recognisable rather than at a line number in output the
+// author never sees.
+func quoteLine(body string, line int) string {
+	lines := strings.Split(body, "\n")
+	if line < 1 || line > len(lines) {
+		return ""
+	}
+
+	text := strings.TrimSpace(lines[line-1])
+	const limit = 160
+	if len(text) > limit {
+		text = text[:limit] + "..."
+	}
+	if text == "" {
+		return ""
+	}
+
+	return "\n  " + text
+}


### PR DESCRIPTION
Storage format is an XML dialect, and Confluence answers a body that is not
well-formed with BadRequestException: it rejects the whole page rather than the
element at fault, and says nothing about which element that was. Every way of
producing invalid markup therefore reaches the author as one opaque server
error, whatever caused it -- an unescaped ampersand in a macro parameter, a void
<br> written by hand in a table cell, an HTML comment containing a double
hyphen.

CheckWellFormed runs the same parse locally and names the line and the text on
it, so the complaint arrives in the terminal, before anything is published,
instead of arriving from the server with nothing to act on.

Checked at the point the body is actually sent -- after the layout wrap, and
after any inline comments have been merged back in -- because anything earlier
would leave the two stages that follow it unchecked.

The parse is the one renderer/helpers_test.go has been using to hold individual
renderers to this standard; this puts the whole page under it. The entity table
is HTML's rather than XML's five, because mark's own templates emit &#160;
between a footnote and its backlink and documents write &nbsp; freely -- a bare
decoder would reject every one of those.

The page itself is created during ancestry resolution, before the body is
compiled, so what this protects is the content: a page whose body would be
rejected is left empty rather than filled with markup that cannot be stored.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
