### PR TITLE
fix: save the page manifest however the run ends

### DIFF
--- a/mark.go
+++ b/mark.go
@@ -221,6 +221,26 @@ func Run(config Config) error {
 		}
 	}
 
+	// What has been recorded has already been published, so the mapping is
+	// worth keeping however the run ends -- including when it ends early.
+	// Returning on the first failing file used to skip the save entirely,
+	// throwing away the mapping for every page that had published perfectly
+	// well, and the next run then resolved all of them by title alone: no
+	// rename detection, and no version baseline for --no-overwrite.
+	//
+	// Deferred rather than repeated before each return, because there are five
+	// of them and the next one added would miss it too. The explicit save at
+	// the end stays: it is the one whose failure the caller hears about, and
+	// once it succeeds this becomes a no-op.
+	defer func() {
+		if tracker == nil {
+			return
+		}
+		if err := tracker.Save(); err != nil {
+			log.Error().Err(err).Msg("unable to save page manifest")
+		}
+	}()
+
 	// A nil *manifest.Store put into a non-nil interface is still a non-nil
 	// interface, so page would see tracking as enabled and call through a nil
 	// receiver. Build the interface value only when there is a store behind it.

--- a/mark_manifest_save_test.go
+++ b/mark_manifest_save_test.go
@@ -1,0 +1,41 @@
+package mark
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestManifestIsSavedWhenAFileFailsHard: the mapping records pages that have
+// already been published. Returning on the first bad file skipped the save
+// entirely, so one malformed document threw away the identity of every page
+// that had published before it -- and the next run resolved all of them by
+// title alone, with no rename detection and no --no-overwrite baseline.
+//
+// The sibling case, --continue-on-error, was fixed long ago and its comment
+// explains exactly why. This is the path that comment did not cover.
+func TestManifestIsSavedWhenAFileFailsHard(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	// Named so the good one is processed first and the run then fails.
+	writeFile(t, dir, "a-good.md", markdownWithTitle("Published"))
+	writeFile(t, dir, "b-bad.md", "no metadata here at all\n")
+
+	config := trackingConfig(server, filepath.Join(dir, "*.md"))
+	require.Error(t, Run(config), "the run must still report the failure")
+
+	published, err := api.FindPage("DOCS", "Published", "page")
+	require.NoError(t, err)
+	require.NotNil(t, published, "the good file published")
+
+	store := manifest.NewStore(confluence.NewAPI(server.URL, "user", "token", false))
+	entry, ok, err := store.Lookup("DOCS", filepath.Join(dir, "a-good.md"))
+	require.NoError(t, err)
+	require.True(t, ok, "the page that published must still be in the manifest")
+	assert.Equal(t, published.ID, entry.PageID)
+}


### PR DESCRIPTION
The comment above the save says a single bad file must not throw away the
mapping for every page that published perfectly well, and explains why: what was
recorded actually happened. Only the --continue-on-error branch was ever made to
honour it. The hard-error return -- the default, since --continue-on-error is
opt-in -- still returned before the save, as do the deferred second pass, the
missing-pages check and the ordering step.

So one malformed document in a directory of five hundred discarded the identity
of every page that had already published. The next run then resolved all of them
by title alone: no rename detection, no --no-overwrite version baseline, and a
retitle would have published a second page beside the first.

Deferred rather than repeated before each return, because there are five of them
and the next one added would miss it too. The explicit save at the end stays: it
is the one whose failure the caller hears about, and once it succeeds the
deferred one writes nothing, since a saved shard is no longer dirty.

Orphan handling is deliberately not moved with it. That runs only on the
existing path, where the run is known to have processed every file it meant to
-- a run that stopped early cannot tell a deleted document from one it never
reached.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
