### PR TITLE
fix: keep a retitle across the --preserve-comments refetch

### DIFF
--- a/mark.go
+++ b/mark.go
@@ -874,6 +874,16 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		}
 		target = pg
 
+		// The refetch carries the title Confluence holds now, which is the old
+		// one whenever this run is renaming the page: the new title is staged
+		// on the object that was just replaced and is not published until the
+		// update below. Without this the rename is dropped silently, and the
+		// manifest goes on to record a title the page does not carry -- which
+		// then misresolves every parent that names it.
+		if titleChanged && meta != nil {
+			target.Title = meta.Title
+		}
+
 		comments, err := api.GetInlineComments(target.ID)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to retrieve inline comments: %w", err)

--- a/mark_retitle_test.go
+++ b/mark_retitle_test.go
@@ -1,0 +1,55 @@
+package mark
+
+import (
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPreserveCommentsKeepsARetitle: the new title is staged on the page object
+// and published by the update. --preserve-comments refetches the page in
+// between, which brought back the title Confluence still held, and the rename
+// was dropped without a word.
+//
+// It compounded: the manifest went on to record the new title against a page
+// carrying the old one, so every parent named by that title resolved to the
+// wrong place from then on, and under --changes-only the page was stuck under
+// its old name for good.
+func TestPreserveCommentsKeepsARetitle(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	config := trackingConfig(server, writeFile(t, dir, "doc.md", markdownWithTitle("Original Title")))
+	config.PreserveComments = true
+	require.NoError(t, Run(config))
+
+	original, err := confluence.NewAPI(server.URL, "user", "token", false).
+		FindPage("DOCS", "Original Title", "page")
+	require.NoError(t, err)
+	require.NotNil(t, original)
+
+	writeFile(t, dir, "doc.md", markdownWithTitle("Renamed Title"))
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, "Renamed Title", server.Page(original.ID).Title,
+		"the page should have been renamed in place")
+	assert.Equal(t, 0, countPagesTitled(t, server, "Original Title"))
+}
+
+// TestPreserveCommentsLeavesAnUnchangedTitleAlone is the control: the fix has
+// to restore the title that was staged, not stamp the document's title onto
+// every page it touches.
+func TestPreserveCommentsLeavesAnUnchangedTitleAlone(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	config := trackingConfig(server, writeFile(t, dir, "doc.md", markdownWithTitle("Steady")))
+	config.PreserveComments = true
+
+	require.NoError(t, Run(config))
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, 1, countPagesTitled(t, server, "Steady"))
+}


### PR DESCRIPTION
A page whose title changed is renamed by the update that publishes it: the new
title is staged on the page object beforehand, and the comment above that line
says so, because relocating a page refreshes it from Confluence and would
otherwise overwrite the staged name.

--preserve-comments then refetches the page again, further down, to read the
body its inline comments are anchored in -- and replaces the whole object with
what came back, which carries the title Confluence still holds. The rename was
dropped, silently, and only for the flag combination that reads the page twice.

It compounded rather than staying put. The manifest records the title the
document declares, so it now asserted a name the page did not carry, and
ResolveStaleTitle went on to resolve that name to the wrong page for every
document that declared it as a parent. Under --changes-only the fingerprint
matched on the next run too, so the page kept its old name indefinitely.

Restoring the staged title after the refetch is enough: nothing between the two
points changes what the title should be.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
