### PR TITLE
fix(parser): bound a formula to the block it opens in

### DIFF
--- a/parser/math.go
+++ b/parser/math.go
@@ -90,8 +90,17 @@ func (s *mathParser) Parse(parent ast.Node, block text.Reader, pc parser.Context
 	_, segment := block.Position()
 	start := segment.Start
 
+	// A formula ends inside the block it began in. Handing scan the whole
+	// document let a "$$" written in one paragraph close against the next
+	// "$$" three paragraphs further down: everything between them became the
+	// equation, and since those paragraphs are still blocks of their own they
+	// were published a second time as prose. Swallowed text carrying a "#" or
+	// an "&" was worse -- LaTeX rejects both outside a macro, so the file
+	// failed to compile at all.
+	source = source[:blockEnd(parent, source)]
+
 	for _, d := range delimiters {
-		if !bytes.HasPrefix(source[start:], []byte(d.open)) {
+		if start >= len(source) || !bytes.HasPrefix(source[start:], []byte(d.open)) {
 			continue
 		}
 
@@ -111,6 +120,31 @@ func (s *mathParser) Parse(parent ast.Node, block text.Reader, pc parser.Context
 	}
 
 	return nil
+}
+
+// blockEnd is the offset just past the block goldmark is parsing inlines for.
+//
+// An inline parser is handed the source of the whole document; parent is the
+// block node that owns every inline in this pass, so its own line segments are
+// the only bound available. A block with no lines -- and the inline node an
+// inline parser is never given as a parent, whose Lines panics -- leaves the
+// source as it was.
+func blockEnd(parent ast.Node, source []byte) int {
+	if parent.Type() != ast.TypeBlock {
+		return len(source)
+	}
+
+	lines := parent.Lines()
+	if lines == nil || lines.Len() == 0 {
+		return len(source)
+	}
+
+	last := lines.At(lines.Len() - 1)
+	if last.Stop < 0 || last.Stop > len(source) {
+		return len(source)
+	}
+
+	return last.Stop
 }
 
 // scan finds the end of a formula that starts at the opening marker, and

--- a/parser/math_block_test.go
+++ b/parser/math_block_test.go
@@ -1,0 +1,73 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMathDoesNotReachPastItsBlock pins a formula to the block it opens in.
+//
+// The scan for the closing marker used to run over the rest of the document,
+// so two unrelated "$$" in a page -- a price in one paragraph and a mention in
+// another -- closed against each other and turned everything between them into
+// one equation. The swallowed paragraphs were still blocks of their own, so
+// they were published twice: once as the formula's image and once as prose.
+func TestMathDoesNotReachPastItsBlock(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name:   "dollars in separate paragraphs",
+			source: "A price of $$ in the intro.\n\nSome important paragraph here.\n\nAnother mention of $$ later on.\n",
+		},
+		{
+			name:   "brackets in separate paragraphs",
+			source: "An opening \\[ here.\n\nSome important paragraph here.\n\nA closing \\] there.\n",
+		},
+		{
+			name:   "across a heading",
+			source: "Costs $$ today.\n\n## A Heading\n\nAnd $$ tomorrow.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Empty(t, formulas(t, tt.source))
+		})
+	}
+}
+
+// TestMathStillSpansLinesWithinOneBlock is the other half of the bound: a
+// display formula is written across several lines often enough that stopping
+// at the end of the line would break more than it fixed.
+func TestMathStillSpansLinesWithinOneBlock(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name:   "display formula on its own lines",
+			source: "$$\n\\int_0^1 x\\,dx\n$$\n",
+			want:   []string{"display:\n\\int_0^1 x\\,dx\n"},
+		},
+		{
+			name:   "display formula wrapped mid-paragraph",
+			source: "Text before $$a +\nb$$ and text after.\n",
+			want:   []string{"display:a +\nb"},
+		},
+		{
+			name:   "bracket form across lines",
+			source: "\\[a +\nb\\]\n",
+			want:   []string{"display:a +\nb"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formulas(t, tt.source))
+		})
+	}
+}


### PR DESCRIPTION
The math parser took block.Source() -- the whole document -- and searched
it for the closing delimiter with nothing to stop at. Both display forms
are multiline, so a page that merely mentions "$$" twice closed the first
against the second and made one equation out of everything in between.

The swallowed paragraphs are blocks in their own right, so they were
still rendered afterwards: the page got them twice, once as the alt text
of the formula's image and once as prose. When the text between the two
markers carried a "#" or an "&" the file did not publish at all, failing
with "You can't use macro parameter character # in math mode".

parent is the block node goldmark is parsing inlines for, so its line
segments bound what a formula may reach. A display formula written across
several lines of one paragraph still works, which is why stopping at the
end of the line was not the fix.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
