### PR TITLE
fix(parser): keep non-ASCII and link labels in a heading id

### DIFF
--- a/parser/confluenceids.go
+++ b/parser/confluenceids.go
@@ -2,10 +2,22 @@ package parser
 
 import (
 	"fmt"
+	"regexp"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/util"
 )
+
+// reInlineLink matches a link or an image as it is written in the source.
+//
+// goldmark generates a heading id from the raw heading line, before any inline
+// parsing has happened, so "## Heading with [link](https://x.com)" arrived here
+// with the URL still in it and produced "Heading-with-linkhttps//x.com" -- an
+// id no slug an author could write would ever name. The label is the part the
+// reader sees, so it is the part the id is built from.
+var reInlineLink = regexp.MustCompile(`!?\[([^\]]*)\]\([^)]*\)`)
 
 // ConfluenceIDs implements parser.IDs for Confluence-compatible header anchor IDs,
 // preserving '/', '_', '.', and '-' characters in heading IDs.
@@ -23,19 +35,25 @@ func (s *ConfluenceIDs) Generate(value []byte, kind ast.NodeKind) []byte {
 	if s.Values == nil {
 		s.Values = make(map[string]bool)
 	}
+	value = reInlineLink.ReplaceAll(value, []byte("$1"))
 	value = util.TrimLeftSpace(value)
 	value = util.TrimRightSpace(value)
 	result := []byte{}
 	for i := 0; i < len(value); {
-		v := value[i]
-		l := util.UTF8Len(v)
-		i += int(l)
-		if l != 1 {
-			continue
-		}
-		if util.IsAlphaNumeric(v) || v == '/' || v == '_' || v == '.' {
-			result = append(result, v)
-		} else if util.IsSpace(v) || v == '-' {
+		r, size := utf8.DecodeRune(value[i:])
+		i += size
+
+		// Every multi-byte rune used to be dropped, which left a heading
+		// written in a non-Latin script with nothing at all: "## 概要" fell
+		// through to the literal id "heading", and a second such heading in
+		// the same page became "heading-1". Confluence holds non-ASCII ids
+		// perfectly well -- what matters is only that a character is an id
+		// character, which unicode.IsLetter and unicode.IsDigit answer for
+		// every script rather than for one.
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r) || r == '/' || r == '_' || r == '.':
+			result = utf8.AppendRune(result, r)
+		case unicode.IsSpace(r) || r == '-':
 			result = append(result, '-')
 		}
 	}

--- a/parser/confluenceids_unicode_test.go
+++ b/parser/confluenceids_unicode_test.go
@@ -1,0 +1,106 @@
+package parser_test
+
+import (
+	"testing"
+
+	cparser "github.com/kovetskiy/mark/v16/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark/ast"
+)
+
+// TestConfluenceIDsKeepsNonASCII pins the id of a heading written in a script
+// that has no ASCII in it.
+//
+// Every multi-byte rune used to be dropped, so such a heading had nothing left
+// and took the "heading" fallback meant for a title made entirely of
+// punctuation. A page with two of them got "heading" and "heading-1", which no
+// author could link to and which say nothing about what they name.
+func TestConfluenceIDsKeepsNonASCII(t *testing.T) {
+	tests := []struct {
+		value string
+		want  string
+	}{
+		{"概要", "概要"},
+		{"Обзор раздела", "Обзор-раздела"},
+		{"Über uns", "Über-uns"},
+		{"混合 Heading 2", "混合-Heading-2"},
+		// Punctuation alone still has nothing to build an id from.
+		{"!!!", "heading"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			ids := cparser.NewConfluenceIDs()
+			assert.Equal(t, tt.want, string(ids.Generate([]byte(tt.value), ast.KindHeading)))
+		})
+	}
+}
+
+// TestConfluenceIDsSeparatesNonASCIIHeadings covers the consequence of the
+// above for a page rather than a heading: two headings that differ must get
+// two ids, not one id and a numbered duplicate of it.
+func TestConfluenceIDsSeparatesNonASCIIHeadings(t *testing.T) {
+	ids := cparser.NewConfluenceIDs()
+
+	assert.Equal(t, "概要", string(ids.Generate([]byte("概要"), ast.KindHeading)))
+	assert.Equal(t, "詳細", string(ids.Generate([]byte("詳細"), ast.KindHeading)))
+}
+
+// TestConfluenceIDsBuildsTheIDFromALinkLabel pins the id of a heading that
+// contains a link.
+//
+// goldmark generates the id from the raw heading line, before anything has
+// parsed the inlines in it, so the URL used to land in the id:
+// "Heading-with-linkhttps//x.com-and-code". Nothing an author could write in
+// "#..." would name that, so a link to such a heading never resolved.
+func TestConfluenceIDsBuildsTheIDFromALinkLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "inline link",
+			value: "Heading with [link](https://x.com) and code",
+			want:  "Heading-with-link-and-code",
+		},
+		{
+			name:  "link with a title",
+			value: `See [the guide](https://x.com/a "Guide")`,
+			want:  "See-the-guide",
+		},
+		{
+			name:  "image",
+			value: "Heading with ![diagram](img/a.png)",
+			want:  "Heading-with-diagram",
+		},
+		{
+			name:  "two links",
+			value: "[one](https://a.com) and [two](https://b.com)",
+			want:  "one-and-two",
+		},
+		// Brackets that are not a link are ordinary text, and the characters
+		// they hold have always survived into the id.
+		{
+			name:  "brackets that open nothing",
+			value: "Heading [not a link] here",
+			want:  "Heading-not-a-link-here",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ids := cparser.NewConfluenceIDs()
+			assert.Equal(t, tt.want, string(ids.Generate([]byte(tt.value), ast.KindHeading)))
+		})
+	}
+}
+
+// TestConfluenceIDsSurvivesInvalidUTF8 covers the one way a rune-at-a-time
+// loop can fail to terminate. A heading read from a file is arbitrary bytes,
+// and a decoder that returned a zero width on a bad one would spin forever.
+func TestConfluenceIDsSurvivesInvalidUTF8(t *testing.T) {
+	ids := cparser.NewConfluenceIDs()
+
+	assert.Equal(t, "ab", string(ids.Generate([]byte{'a', 0xff, 0xfe, 'b'}, ast.KindHeading)))
+}

--- a/testdata/heading-anchor-links-droph1.html
+++ b/testdata/heading-anchor-links-droph1.html
@@ -13,3 +13,12 @@ key, so <a href="#release-notes">this</a> is left exactly as written rather than
 at.</p>
 <p><a href="https://example.com/#fragment">not an anchor</a> is untouched, and so is
 <a href="#nothing-here">an unknown target</a>.</p>
+<h2 id="概要">概要</h2>
+<p>A heading with no ASCII in it at all still has to become an id made of its own
+characters rather than the literal word &quot;heading&quot;: <a href="#%E6%A6%82%E8%A6%81">the summary</a>.</p>
+<h2 id="詳細">詳細</h2>
+<p>A second such heading is a heading of its own, not the numbered fallback that
+one emptied id forces on the next.</p>
+<h2 id="Heading-with-link-and-code">Heading with <a href="https://example.com">link</a> and code</h2>
+<p>An id is built from what a reader sees, so the link's label counts and its URL
+does not: <a href="#Heading-with-link-and-code">jump</a>.</p>

--- a/testdata/heading-anchor-links-stripnewlines.html
+++ b/testdata/heading-anchor-links-stripnewlines.html
@@ -8,3 +8,9 @@
 <h2 id="Release.Notes">Release.Notes</h2>
 <p>Two headings whose ids differ only in punctuation that matching drops are one key, so <a href="#release-notes">this</a> is left exactly as written rather than guessed at.</p>
 <p><a href="https://example.com/#fragment">not an anchor</a> is untouched, and so is <a href="#nothing-here">an unknown target</a>.</p>
+<h2 id="概要">概要</h2>
+<p>A heading with no ASCII in it at all still has to become an id made of its own characters rather than the literal word &quot;heading&quot;: <a href="#%E6%A6%82%E8%A6%81">the summary</a>.</p>
+<h2 id="詳細">詳細</h2>
+<p>A second such heading is a heading of its own, not the numbered fallback that one emptied id forces on the next.</p>
+<h2 id="Heading-with-link-and-code">Heading with <a href="https://example.com">link</a> and code</h2>
+<p>An id is built from what a reader sees, so the link's label counts and its URL does not: <a href="#Heading-with-link-and-code">jump</a>.</p>

--- a/testdata/heading-anchor-links.html
+++ b/testdata/heading-anchor-links.html
@@ -14,3 +14,12 @@ key, so <a href="#release-notes">this</a> is left exactly as written rather than
 at.</p>
 <p><a href="https://example.com/#fragment">not an anchor</a> is untouched, and so is
 <a href="#nothing-here">an unknown target</a>.</p>
+<h2 id="概要">概要</h2>
+<p>A heading with no ASCII in it at all still has to become an id made of its own
+characters rather than the literal word &quot;heading&quot;: <a href="#%E6%A6%82%E8%A6%81">the summary</a>.</p>
+<h2 id="詳細">詳細</h2>
+<p>A second such heading is a heading of its own, not the numbered fallback that
+one emptied id forces on the next.</p>
+<h2 id="Heading-with-link-and-code">Heading with <a href="https://example.com">link</a> and code</h2>
+<p>An id is built from what a reader sees, so the link's label counts and its URL
+does not: <a href="#Heading-with-link-and-code">jump</a>.</p>

--- a/testdata/heading-anchor-links.md
+++ b/testdata/heading-anchor-links.md
@@ -23,3 +23,18 @@ at.
 
 [not an anchor](https://example.com/#fragment) is untouched, and so is
 [an unknown target](#nothing-here).
+
+## 概要
+
+A heading with no ASCII in it at all still has to become an id made of its own
+characters rather than the literal word "heading": [the summary](#概要).
+
+## 詳細
+
+A second such heading is a heading of its own, not the numbered fallback that
+one emptied id forces on the next.
+
+## Heading with [link](https://example.com) and code
+
+An id is built from what a reader sees, so the link's label counts and its URL
+does not: [jump](#heading-with-link-and-code).

--- a/transformer/anchors.go
+++ b/transformer/anchors.go
@@ -2,6 +2,7 @@ package transformer
 
 import (
 	"strings"
+	"unicode"
 
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
@@ -36,10 +37,15 @@ func NewAnchorTransformer() *AnchorTransformer {
 // survive at all. mark keeps "/" and "." in an id where a slug drops them, so
 // "API/v2 Guide" becomes "API/v2-Guide" one way and "apiv2-guide" the other.
 // Comparing only the alphanumerics is what makes those the same heading.
+//
+// "Letters and digits" has to mean it in every script, not just in ASCII: mark
+// keeps non-ASCII letters in an id, so an a-z test folded every heading written
+// in CJK or Cyrillic down to the empty key -- which is discarded -- and no link
+// to one could ever be matched.
 func anchorKey(s string) string {
 	var b strings.Builder
 	for _, r := range strings.ToLower(s) {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
 			b.WriteRune(r)
 		}
 	}

--- a/transformer/anchors_test.go
+++ b/transformer/anchors_test.go
@@ -12,7 +12,7 @@ func TestAnchorKey(t *testing.T) {
 		{"API/v2-Guide", "apiv2-guide"},    // a slug drops the slash, an id keeps it
 		{"Release.Notes", "release-notes"}, // and the dot
 		{"Heading_With_Underscores", "heading-with-underscores"},
-		{"Ünïcödé", "ünïcödé"}, // neither side keeps non-ASCII
+		{"Ünïcödé", "ünïcödé"}, // case folding has to reach past ASCII
 	}
 	for _, pair := range same {
 		if anchorKey(pair[0]) != anchorKey(pair[1]) {

--- a/transformer/anchors_unicode_test.go
+++ b/transformer/anchors_unicode_test.go
@@ -1,0 +1,36 @@
+package transformer
+
+import "testing"
+
+// TestAnchorKeyKeepsNonASCIILetters pins the other end of the non-ASCII
+// heading id.
+//
+// anchorKey used to test for a-z and 0-9, so an id and a link target written
+// in CJK or Cyrillic both reduced to nothing. The empty key is discarded by
+// Transform, which means every such heading was invisible to anchor matching
+// no matter what the author wrote.
+func TestAnchorKeyKeepsNonASCIILetters(t *testing.T) {
+	kept := []string{"概要", "Обзор", "Über"}
+	for _, value := range kept {
+		if anchorKey(value) == "" {
+			t.Errorf("%q should reduce to a key, got nothing", value)
+		}
+	}
+
+	differ := [][2]string{
+		{"概要", "詳細"},
+		{"Обзор", "Раздел"},
+	}
+	for _, pair := range differ {
+		if anchorKey(pair[0]) == anchorKey(pair[1]) {
+			t.Errorf("%q and %q should not reduce alike, both gave %q",
+				pair[0], pair[1], anchorKey(pair[0]))
+		}
+	}
+
+	// The punctuation an id keeps and a slug drops is still dropped on both
+	// sides, in every script.
+	if anchorKey("概要/詳細") != anchorKey("概要-詳細") {
+		t.Errorf("punctuation should not separate %q from %q", "概要/詳細", "概要-詳細")
+	}
+}


### PR DESCRIPTION
Two ways a heading could end up with an id nothing could link to.

Generate walked the heading a byte at a time and skipped every rune
wider than one byte, so a heading written in a script with no ASCII in
it had nothing left and took the "heading" fallback meant for a title
made of punctuation. A page with two of them published "heading" and
"heading-1". anchorKey then folded the same characters away on the other
end, so even a link written exactly as the heading reduced to the empty
key, which Transform discards.

goldmark also generates the id from the raw heading line, before any
inline parsing, so a link in a heading contributed its URL:
"## Heading with [link](https://x.com)" became
"Heading-with-linkhttps//x.com". No slug an author could write in "#..."
would ever name that. The label is what the reader sees, so it is what
the id is built from.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
