### PR TITLE
fix(renderer): read the info strings MkDocs and Pandoc write

### DIFF
--- a/renderer/fencedcodeblock.go
+++ b/renderer/fencedcodeblock.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/kovetskiy/mark/v16/attachment"
@@ -37,6 +38,72 @@ var reBlockDetails = regexp.MustCompile(
 	// once the class accepted "#".
 	`^(?:([\w#+./-]*)|-)\s*(\S.*?\S?)??\s*(?:\btitle\s+(\S.*\S?))?$`,
 )
+
+// reAttributeBlock matches the "{...}" attribute list Pandoc and Material for
+// MkDocs write in an info string -- "``` { .js hl_lines="1 2" }" or
+// "```python {.line-numbers}".
+//
+// None of what it holds is mark's option vocabulary, and left in place every
+// word of it fell through to the theme catch-all: the two examples above
+// published a Confluence code macro with a theme of "}" and of
+// "{.line-numbers}" respectively, and the first also lost its language and had
+// its line numbering turned on by the digits inside hl_lines.
+var reAttributeBlock = regexp.MustCompile(`\{[^}]*\}`)
+
+// reAttributeLang matches the ".language" class inside an attribute block,
+// which is where the language is named when the block is the whole info
+// string.
+var reAttributeLang = regexp.MustCompile(`\.([\w#+./-]+)`)
+
+// reAssignedTitle matches a title written with "=" rather than a space.
+//
+// Material for MkDocs' title="config.yml" is the commonest way to caption a
+// code block in a docs-as-code repository, and mark accepted only its own
+// "title config.yml": the caption was dropped and the whole token was
+// published as the macro's theme.
+var reAssignedTitle = regexp.MustCompile(`\btitle\s*=\s*(?:"([^"]*)"|'([^']*)'|(\S+))`)
+
+// parseBlockDetails reads a fence info string into the parts the ac:code macro
+// is given.
+func parseBlockDetails(info string) (lang string, options []string, title string) {
+	info = strings.TrimSpace(info)
+
+	if groups := reAssignedTitle.FindStringSubmatch(info); groups != nil {
+		for _, group := range groups[1:] {
+			if group != "" {
+				title = group
+				break
+			}
+		}
+		info = strings.TrimSpace(reAssignedTitle.ReplaceAllString(info, " "))
+	}
+
+	if block := reAttributeBlock.FindString(info); block != "" {
+		// Only a leading block names the language: Pandoc writes the whole
+		// info string as one attribute list, while MkDocs appends the list
+		// after a language it has already given in the ordinary place.
+		if strings.HasPrefix(info, "{") {
+			if class := reAttributeLang.FindStringSubmatch(block); class != nil {
+				lang = class[1]
+			}
+		}
+		info = strings.TrimSpace(strings.Replace(info, block, " ", 1))
+	}
+
+	groups := reBlockDetails.FindStringSubmatch(info)
+	if len(groups) == 0 {
+		return lang, nil, title
+	}
+
+	if lang == "" {
+		lang = groups[1]
+	}
+	if title == "" {
+		title = groups[3]
+	}
+
+	return lang, strings.Fields(groups[2]), title
+}
 
 // NewConfluenceRenderer creates a new instance of the ConfluenceRenderer
 func NewConfluenceFencedCodeBlockRenderer(stdlib *stdlib.Lib, attachments attachment.Attacher, cfg types.MarkConfig, opts ...html.Option) renderer.NodeRenderer {
@@ -95,39 +162,37 @@ func (r *ConfluenceFencedCodeBlockRenderer) renderFencedCodeBlock(writer util.Bu
 		segment := nodeFencedCodeBlock.Info.Segment
 		info = segment.Value(source)
 	}
-	groups := reBlockDetails.FindStringSubmatch(string(info))
 	linenumbers := false
 	firstline := 0
 	theme := ""
 	collapse := false
-	lang := ""
-	var options []string
-	title := ""
-	if len(groups) > 0 {
-		lang, options, title = groups[1], strings.Fields(groups[2]), groups[3]
-		for _, option := range options {
-			if option == "collapse" {
-				collapse = true
-				continue
-			}
-			if option == "nocollapse" {
-				collapse = false
-				continue
-			}
-			if option == "linenumbers" {
-				linenumbers = true
-				continue
-			}
 
-			var i int
-			if _, err := fmt.Sscanf(option, "%d", &i); err == nil {
-				linenumbers = i > 0
-				firstline = i
-				continue
-			}
-			theme = option
+	lang, options, title := parseBlockDetails(string(info))
+	for _, option := range options {
+		if option == "collapse" {
+			collapse = true
+			continue
+		}
+		if option == "nocollapse" {
+			collapse = false
+			continue
+		}
+		if option == "linenumbers" {
+			linenumbers = true
+			continue
 		}
 
+		// strconv.Atoi rather than fmt.Sscanf("%d"): Sscanf stops at the first
+		// byte it cannot use and reports success for what it read, so an
+		// option that merely begins with a digit -- "1;" or the `2"` left by a
+		// split hl_lines="1 2" -- silently turned line numbering on and moved
+		// the first line. Only an option that is a number all through is one.
+		if i, err := strconv.Atoi(option); err == nil {
+			linenumbers = i > 0
+			firstline = i
+			continue
+		}
+		theme = option
 	}
 
 	var lval []byte

--- a/renderer/fencedcodeblock_infostring_test.go
+++ b/renderer/fencedcodeblock_infostring_test.go
@@ -1,0 +1,110 @@
+package renderer_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFencedCodeBlockMkDocsTitle covers the way a code block is captioned
+// everywhere outside mark.
+//
+// Material for MkDocs writes title="config.yml", and mark accepted only its
+// own "title config.yml": the caption was lost and the entire token fell
+// through to the theme catch-all, so the published macro carried a theme of
+// `title="config.yml"` and no title at all.
+func TestFencedCodeBlockMkDocsTitle(t *testing.T) {
+	tests := []struct {
+		name string
+		info string
+		lang string
+	}{
+		{name: "double quoted", info: `yaml title="config.yml"`, lang: "yaml"},
+		{name: "single quoted", info: `yaml title='config.yml'`, lang: "yaml"},
+		{name: "unquoted", info: `yaml title=config.yml`, lang: "yaml"},
+		{name: "spaces around the equals", info: `yaml title = "config.yml"`, lang: "yaml"},
+		{name: "no language", info: `title="config.yml"`, lang: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := fencedCode(t, tt.info)
+			assertWellFormed(t, actual)
+
+			assert.Contains(t, actual, `<ac:parameter ac:name="language">`+tt.lang+`</ac:parameter>`)
+			assert.Contains(t, actual, `<ac:parameter ac:name="title">config.yml</ac:parameter>`)
+			assert.NotContains(t, actual, `ac:name="theme"`)
+		})
+	}
+}
+
+// TestFencedCodeBlockMkDocsTitleWithSpaces covers a quoted title holding the
+// spaces that the unquoted form could not.
+func TestFencedCodeBlockMkDocsTitleWithSpaces(t *testing.T) {
+	actual := fencedCode(t, `bash collapse title="Deploy the whole thing"`)
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `<ac:parameter ac:name="language">bash</ac:parameter>`)
+	assert.Contains(t, actual, `<ac:parameter ac:name="collapse">true</ac:parameter>`)
+	assert.Contains(t, actual, `<ac:parameter ac:name="title">Deploy the whole thing</ac:parameter>`)
+	assert.NotContains(t, actual, `ac:name="theme"`)
+}
+
+// TestFencedCodeBlockAttributeBlock covers the "{...}" attribute list Pandoc
+// and MkDocs put in an info string.
+//
+// Nothing inside it is mark's vocabulary, so every word of it used to fall
+// through to the theme catch-all -- and in the Pandoc form the language was
+// lost as well and the digits of hl_lines turned line numbering on.
+func TestFencedCodeBlockAttributeBlock(t *testing.T) {
+	tests := []struct {
+		name string
+		info string
+		lang string
+	}{
+		{name: "trailing list keeps the language", info: `python {.line-numbers}`, lang: "python"},
+		{name: "leading list names the language", info: `{ .js hl_lines="1 2" }`, lang: "js"},
+		{name: "leading list with no space", info: `{.python}`, lang: "python"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := fencedCode(t, tt.info)
+			assertWellFormed(t, actual)
+
+			assert.Contains(t, actual, `<ac:parameter ac:name="language">`+tt.lang+`</ac:parameter>`)
+			assert.NotContains(t, actual, `ac:name="theme"`)
+			assert.NotContains(t, actual, `ac:name="linenumbers"`)
+			assert.NotContains(t, actual, `ac:name="firstline"`)
+		})
+	}
+}
+
+// TestFencedCodeBlockAttributeBlockTitle covers the two conventions written
+// together, which is how Material for MkDocs documents its own examples.
+func TestFencedCodeBlockAttributeBlockTitle(t *testing.T) {
+	actual := fencedCode(t, `{ .yaml title="config.yml" }`)
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `<ac:parameter ac:name="language">yaml</ac:parameter>`)
+	assert.Contains(t, actual, `<ac:parameter ac:name="title">config.yml</ac:parameter>`)
+	assert.NotContains(t, actual, `ac:name="theme"`)
+}
+
+// TestFencedCodeBlockNumericOptionMustBeAllDigits covers the option that means
+// two things at once.
+//
+// fmt.Sscanf("%d") stops at the first byte it cannot use and calls what it read
+// a success, so an option that merely began with a digit set the first line and
+// turned numbering on. Only an option that is a number all through is one.
+func TestFencedCodeBlockNumericOptionMustBeAllDigits(t *testing.T) {
+	for _, info := range []string{`go 1;`, `go 2"`, `go 3px`} {
+		t.Run(info, func(t *testing.T) {
+			actual := fencedCode(t, info)
+			assertWellFormed(t, actual)
+
+			assert.NotContains(t, actual, `ac:name="firstline"`)
+			assert.NotContains(t, actual, `ac:name="linenumbers"`)
+		})
+	}
+}


### PR DESCRIPTION
Three ways a fence header was misread, all of them ending in a Confluence
code macro with a garbage theme parameter.

The title pattern required whitespace after the word, so Material for
MkDocs' title="config.yml" -- the commonest way to caption a code block
in a docs-as-code repository -- was not a title at all. It fell through
to the theme catch-all and the caption was lost.

The "{...}" attribute list Pandoc and MkDocs put in an info string was
not recognised either. "```python {.line-numbers}" published a theme of
"{.line-numbers}", and "``` { .js hl_lines="1 2" }" lost its language,
published a theme of "}", and turned line numbering on from the digits
inside hl_lines. A leading block now names the language through its .lang
class, and the block itself is dropped rather than read as options.

The digits got in because fmt.Sscanf("%d") stops at the first byte it
cannot use and reports success for what it read, so any option merely
beginning with a digit set the first line. strconv.Atoi rejects those.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
