### PR TITLE
fix(renderer): give a GitHub alert a macro title, not a paragraph

### DIFF
--- a/renderer/gh_alerts_blockquote.go
+++ b/renderer/gh_alerts_blockquote.go
@@ -2,6 +2,7 @@ package renderer
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/renderer"
@@ -27,6 +28,27 @@ func NewConfluenceGHAlertsBlockQuoteRenderer(opts ...html.Option) renderer.NodeR
 // RegisterFuncs implements NodeRenderer.RegisterFuncs
 func (r *ConfluenceGHAlertsBlockQuoteRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
 	reg.Register(ast.KindBlockquote, r.renderBlockQuote)
+}
+
+// getConfluenceMacroTitle gives the alert the header Confluence draws for it.
+//
+// The title used to be injected into the body as a paragraph of its own, which
+// published it as the first line of the alert's text rather than as its
+// heading: no icon alignment, no weight, and it moved with the content when a
+// reader edited the page in Confluence. The macro takes a title parameter for
+// exactly this, and it is styled as a header.
+//
+// Only the five types the transformer recognises get one. Nothing else can
+// reach this in practice, but the value is interpolated into an attribute, so
+// answering with a fixed vocabulary rather than with the argument is what keeps
+// the document well-formed no matter what set the attribute.
+func (r *ConfluenceGHAlertsBlockQuoteRenderer) getConfluenceMacroTitle(alertType string) string {
+	switch alertType {
+	case "note", "tip", "important", "warning", "caution":
+		return strings.ToUpper(alertType[:1]) + alertType[1:]
+	default:
+		return ""
+	}
 }
 
 // Define GitHub Alert to Confluence macro mapping
@@ -69,7 +91,11 @@ func (r *ConfluenceGHAlertsBlockQuoteRenderer) renderGHAlert(writer util.BufWrit
 	if quoteLevel == 0 && entering {
 		r.BlockQuoteNode = node
 		macroName := r.getConfluenceMacroName(alertType)
-		prefix := fmt.Sprintf("<ac:structured-macro ac:name=\"%s\"><ac:parameter ac:name=\"icon\">true</ac:parameter><ac:rich-text-body>\n", macroName)
+		prefix := fmt.Sprintf("<ac:structured-macro ac:name=\"%s\"><ac:parameter ac:name=\"icon\">true</ac:parameter>", macroName)
+		if title := r.getConfluenceMacroTitle(alertType); title != "" {
+			prefix += fmt.Sprintf("<ac:parameter ac:name=\"title\">%s</ac:parameter>", title)
+		}
+		prefix += "<ac:rich-text-body>\n"
 		if _, err := writer.Write([]byte(prefix)); err != nil {
 			return ast.WalkStop, err
 		}

--- a/renderer/gh_alerts_title_test.go
+++ b/renderer/gh_alerts_title_test.go
@@ -1,0 +1,55 @@
+package renderer_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGHAlertTitleIsAMacroParameter pins where an alert's name is published.
+//
+// It used to be synthesised into the body as a paragraph of its own, so
+// Confluence drew it as the alert's first line of text rather than as its
+// header -- unstyled, unaligned with the icon, and part of the content a
+// reader editing the page could delete. The macro has a title parameter for
+// exactly this and renders it as a header.
+func TestGHAlertTitleIsAMacroParameter(t *testing.T) {
+	tests := []struct {
+		alert string
+		macro string
+		title string
+	}{
+		{"NOTE", "info", "Note"},
+		{"TIP", "tip", "Tip"},
+		{"IMPORTANT", "info", "Important"},
+		{"WARNING", "note", "Warning"},
+		{"CAUTION", "warning", "Caution"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.alert, func(t *testing.T) {
+			actual := render(t, "> [!"+tt.alert+"]\n> The body.\n", ghAlertRenderers(), ghAlertParserOptions()...)
+			assertWellFormed(t, actual)
+
+			assert.Contains(t, actual,
+				`<ac:structured-macro ac:name="`+tt.macro+`"><ac:parameter ac:name="icon">true</ac:parameter>`+
+					`<ac:parameter ac:name="title">`+tt.title+`</ac:parameter><ac:rich-text-body>`)
+			assert.NotContains(t, actual, "<p>"+tt.title+"</p>",
+				"the title belongs in the macro header, not in its body")
+			assert.Contains(t, actual, "The body.")
+		})
+	}
+}
+
+// TestGHAlertTitleDoesNotReachOtherQuotes covers the two blockquotes that are
+// not alerts. Neither has a name to publish, so neither may grow a title.
+func TestGHAlertTitleDoesNotReachOtherQuotes(t *testing.T) {
+	for _, source := range []string{"> Warn: the old syntax.\n", "> Just a quotation.\n"} {
+		t.Run(source, func(t *testing.T) {
+			actual := render(t, source, ghAlertRenderers(), ghAlertParserOptions()...)
+			assertWellFormed(t, actual)
+
+			assert.NotContains(t, actual, `ac:name="title"`)
+		})
+	}
+}

--- a/testdata/quotes-droph1.html
+++ b/testdata/quotes-droph1.html
@@ -47,39 +47,34 @@ b</p>
 </blockquote>
 <h2 id="GH-Alerts-Heading">GH Alerts Heading</h2>
 <h3 id="Note-Type-Alert-Heading">Note Type Alert Heading</h3>
-<ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
-<p>Note</p>
+<ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:parameter ac:name="title">Note</ac:parameter><ac:rich-text-body>
 <ul>
 <li>Note bullet 1</li>
 <li>Note bullet 2</li>
 </ul>
 </ac:rich-text-body></ac:structured-macro>
 <h3 id="Tip-Type-Alert-Heading">Tip Type Alert Heading</h3>
-<ac:structured-macro ac:name="tip"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
-<p>Tip</p>
+<ac:structured-macro ac:name="tip"><ac:parameter ac:name="icon">true</ac:parameter><ac:parameter ac:name="title">Tip</ac:parameter><ac:rich-text-body>
 <ul>
 <li>Tip bullet 1</li>
 <li>Tip bullet 2</li>
 </ul>
 </ac:rich-text-body></ac:structured-macro>
 <h3 id="Warning-Type-Alert-Heading">Warning Type Alert Heading</h3>
-<ac:structured-macro ac:name="note"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
-<p>Warning</p>
+<ac:structured-macro ac:name="note"><ac:parameter ac:name="icon">true</ac:parameter><ac:parameter ac:name="title">Warning</ac:parameter><ac:rich-text-body>
 <ul>
 <li>Warning bullet 1</li>
 <li>Warning bullet 2</li>
 </ul>
 </ac:rich-text-body></ac:structured-macro>
 <h3 id="Important/Caution-Type-Alert-Heading">Important/Caution Type Alert Heading</h3>
-<ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
-<p>Important</p>
+<ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:parameter ac:name="title">Important</ac:parameter><ac:rich-text-body>
 <ul>
 <li>Important bullet 1</li>
 <li>Important bullet 2</li>
 </ul>
 </ac:rich-text-body></ac:structured-macro>
-<ac:structured-macro ac:name="warning"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
-<p>Caution</p>
+<ac:structured-macro ac:name="warning"><ac:parameter ac:name="icon">true</ac:parameter><ac:parameter ac:name="title">Caution</ac:parameter><ac:rich-text-body>
 <ul>
 <li>Important bullet 1</li>
 <li>Important bullet 2</li>

--- a/testdata/quotes-stripnewlines.html
+++ b/testdata/quotes-stripnewlines.html
@@ -45,39 +45,34 @@
 </blockquote>
 <h2 id="GH-Alerts-Heading">GH Alerts Heading</h2>
 <h3 id="Note-Type-Alert-Heading">Note Type Alert Heading</h3>
-<ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
-<p>Note</p>
+<ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:parameter ac:name="title">Note</ac:parameter><ac:rich-text-body>
 <ul>
 <li>Note bullet 1</li>
 <li>Note bullet 2</li>
 </ul>
 </ac:rich-text-body></ac:structured-macro>
 <h3 id="Tip-Type-Alert-Heading">Tip Type Alert Heading</h3>
-<ac:structured-macro ac:name="tip"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
-<p>Tip</p>
+<ac:structured-macro ac:name="tip"><ac:parameter ac:name="icon">true</ac:parameter><ac:parameter ac:name="title">Tip</ac:parameter><ac:rich-text-body>
 <ul>
 <li>Tip bullet 1</li>
 <li>Tip bullet 2</li>
 </ul>
 </ac:rich-text-body></ac:structured-macro>
 <h3 id="Warning-Type-Alert-Heading">Warning Type Alert Heading</h3>
-<ac:structured-macro ac:name="note"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
-<p>Warning</p>
+<ac:structured-macro ac:name="note"><ac:parameter ac:name="icon">true</ac:parameter><ac:parameter ac:name="title">Warning</ac:parameter><ac:rich-text-body>
 <ul>
 <li>Warning bullet 1</li>
 <li>Warning bullet 2</li>
 </ul>
 </ac:rich-text-body></ac:structured-macro>
 <h3 id="Important/Caution-Type-Alert-Heading">Important/Caution Type Alert Heading</h3>
-<ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
-<p>Important</p>
+<ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:parameter ac:name="title">Important</ac:parameter><ac:rich-text-body>
 <ul>
 <li>Important bullet 1</li>
 <li>Important bullet 2</li>
 </ul>
 </ac:rich-text-body></ac:structured-macro>
-<ac:structured-macro ac:name="warning"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
-<p>Caution</p>
+<ac:structured-macro ac:name="warning"><ac:parameter ac:name="icon">true</ac:parameter><ac:parameter ac:name="title">Caution</ac:parameter><ac:rich-text-body>
 <ul>
 <li>Important bullet 1</li>
 <li>Important bullet 2</li>

--- a/testdata/quotes.html
+++ b/testdata/quotes.html
@@ -48,39 +48,34 @@ b</p>
 </blockquote>
 <h2 id="GH-Alerts-Heading">GH Alerts Heading</h2>
 <h3 id="Note-Type-Alert-Heading">Note Type Alert Heading</h3>
-<ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
-<p>Note</p>
+<ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:parameter ac:name="title">Note</ac:parameter><ac:rich-text-body>
 <ul>
 <li>Note bullet 1</li>
 <li>Note bullet 2</li>
 </ul>
 </ac:rich-text-body></ac:structured-macro>
 <h3 id="Tip-Type-Alert-Heading">Tip Type Alert Heading</h3>
-<ac:structured-macro ac:name="tip"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
-<p>Tip</p>
+<ac:structured-macro ac:name="tip"><ac:parameter ac:name="icon">true</ac:parameter><ac:parameter ac:name="title">Tip</ac:parameter><ac:rich-text-body>
 <ul>
 <li>Tip bullet 1</li>
 <li>Tip bullet 2</li>
 </ul>
 </ac:rich-text-body></ac:structured-macro>
 <h3 id="Warning-Type-Alert-Heading">Warning Type Alert Heading</h3>
-<ac:structured-macro ac:name="note"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
-<p>Warning</p>
+<ac:structured-macro ac:name="note"><ac:parameter ac:name="icon">true</ac:parameter><ac:parameter ac:name="title">Warning</ac:parameter><ac:rich-text-body>
 <ul>
 <li>Warning bullet 1</li>
 <li>Warning bullet 2</li>
 </ul>
 </ac:rich-text-body></ac:structured-macro>
 <h3 id="Important/Caution-Type-Alert-Heading">Important/Caution Type Alert Heading</h3>
-<ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
-<p>Important</p>
+<ac:structured-macro ac:name="info"><ac:parameter ac:name="icon">true</ac:parameter><ac:parameter ac:name="title">Important</ac:parameter><ac:rich-text-body>
 <ul>
 <li>Important bullet 1</li>
 <li>Important bullet 2</li>
 </ul>
 </ac:rich-text-body></ac:structured-macro>
-<ac:structured-macro ac:name="warning"><ac:parameter ac:name="icon">true</ac:parameter><ac:rich-text-body>
-<p>Caution</p>
+<ac:structured-macro ac:name="warning"><ac:parameter ac:name="icon">true</ac:parameter><ac:parameter ac:name="title">Caution</ac:parameter><ac:rich-text-body>
 <ul>
 <li>Important bullet 1</li>
 <li>Important bullet 2</li>

--- a/transformer/gh_alerts.go
+++ b/transformer/gh_alerts.go
@@ -37,7 +37,7 @@ func (t *GHAlertsTransformer) Transform(doc *ast.Document, reader text.Reader, p
 		}
 
 		// Transform the blockquote into a GitHub Alert node
-		t.transformBlockquote(blockquote, alertType, reader)
+		t.transformBlockquote(blockquote, alertType)
 
 		return ast.WalkContinue, nil
 	})
@@ -101,33 +101,27 @@ func (t *GHAlertsTransformer) extractAlertType(blockquote *ast.Blockquote, reade
 
 // transformBlockquote modifies the blockquote to remove the GitHub Alert syntax
 // and adds metadata for rendering
-func (t *GHAlertsTransformer) transformBlockquote(blockquote *ast.Blockquote, alertType string, reader text.Reader) {
+func (t *GHAlertsTransformer) transformBlockquote(blockquote *ast.Blockquote, alertType string) {
 	// Set a custom attribute to identify this as a GitHub Alert
 	blockquote.SetAttribute([]byte("gh-alert-type"), []byte(alertType))
 
-	// Find and remove/replace the GitHub Alert syntax from the first paragraph
+	// Find and remove the GitHub Alert syntax from the first paragraph
 	firstChild := blockquote.FirstChild()
 	if firstChild != nil && firstChild.Kind() == ast.KindParagraph {
 		paragraph := firstChild.(*ast.Paragraph)
-		t.splitAlertParagraph(blockquote, paragraph, alertType, reader)
+		t.stripAlertMarker(blockquote, paragraph)
 	}
 }
 
-// splitAlertParagraph removes the [!TYPE] syntax and creates a separate paragraph for the title
-func (t *GHAlertsTransformer) splitAlertParagraph(blockquote *ast.Blockquote, paragraph *ast.Paragraph, alertType string, reader text.Reader) {
-	// Generate user-friendly title
-	title := strings.ToUpper(alertType[:1]) + alertType[1:]
-
-	// Create a new paragraph for the title
-	titleParagraph := ast.NewParagraph()
-	titleText := ast.NewText()
-	titleText.Segment = text.NewSegment(0, 0) // Dummy segment, we'll use attribute for content
-	titleText.SetAttribute([]byte("replacement-content"), []byte(title))
-	titleParagraph.AppendChild(titleParagraph, titleText)
-
-	// Insert the title paragraph before the current one
-	blockquote.InsertBefore(blockquote, paragraph, titleParagraph)
-
+// stripAlertMarker removes the [!TYPE] syntax, leaving the blockquote holding
+// only what the author wrote underneath it.
+//
+// The alert's title used to be added back here as a paragraph of its own, which
+// made it the first line of the macro's body rather than its header. The
+// renderer passes it as the macro's title parameter instead, which is what
+// Confluence styles as a header -- so nothing has to be synthesised into the
+// body at all.
+func (t *GHAlertsTransformer) stripAlertMarker(blockquote *ast.Blockquote, paragraph *ast.Paragraph) {
 	// Remove the first three nodes ([ !TYPE ]) from the original paragraph
 	currentNode := paragraph.FirstChild()
 	for i := 0; i < 3 && currentNode != nil; i++ {


### PR DESCRIPTION
The transformer synthesised the alert's name into the blockquote as a
paragraph of its own, so the Confluence macro published "Note" as the
first line of its body. It came out unstyled and out of line with the
icon, and it was part of the content -- a reader editing the page in
Confluence could delete it, or type above it.

The info/note/warning/tip macros take ac:parameter ac:name="title" and
render it as a proper header, so the name is passed there and nothing is
put into the body at all. The renderer answers with a fixed vocabulary
rather than with the attribute it was given, since the value lands in an
XML attribute.

The [!WARNING] -> note and [!CAUTION] -> warning colour mapping is
unchanged.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
