### PR TITLE
fix(markdown): list GFM's members instead of registering Table twice

### DIFF
--- a/markdown/compile_test.go
+++ b/markdown/compile_test.go
@@ -1,0 +1,24 @@
+package mark
+
+import (
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/require"
+)
+
+// compileDoc compiles a document through the default path with the stdlib
+// templates loaded, which is what a test asserting on rendered storage format
+// wants.
+func compileDoc(t *testing.T, src string, features ...string) string {
+	t.Helper()
+
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	out, _, err := CompileMarkdown([]byte(src), std, "test.md", types.MarkConfig{Features: features})
+	require.NoError(t, err)
+
+	return out
+}

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -159,11 +159,20 @@ func compileMarkdownWithExtension(markdown []byte, ext goldmark.Extender, logMes
 		goldmark.WithExtensions(
 			extension.Footnote,
 			extension.DefinitionList,
+			// GFM's members are listed one by one rather than through
+			// extension.GFM, which bundles its own default-configured Table.
+			// Registering Table twice put two cell renderers at the same
+			// priority 500, and goldmark sorts renderers with sort.Slice, which
+			// is not stable -- so which alignment method survived was decided by
+			// nothing at all. Alignment came out as ac:align attributes or as
+			// style="text-align:..." depending on the sort.
 			extension.NewTable(
 				extension.WithTableCellAlignMethod(extension.TableCellAlignStyle),
 			),
 			ext,
-			extension.GFM,
+			extension.Linkify,
+			extension.Strikethrough,
+			extension.TaskList,
 		),
 		goldmark.WithParserOptions(
 			parser.WithAutoHeadingID(),

--- a/markdown/table_align_test.go
+++ b/markdown/table_align_test.go
@@ -1,0 +1,27 @@
+package mark
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// extension.GFM bundles a default-configured Table, so registering it next to
+// the configured NewTable put two cell renderers at goldmark's priority 500.
+// PrioritizedSlice.Sort is sort.Slice, which is not stable, so which alignment
+// method reached the page was decided by nothing at all -- it only happened to
+// be the configured one. GFM's members are listed one by one now.
+func TestTableCellAlignmentUsesTheConfiguredMethod(t *testing.T) {
+	out := compileDoc(t, "| a | b |\n| :-: | --: |\n| one | two |\n")
+
+	assert.Contains(t, out, `<th style="text-align:center">a</th>`)
+	assert.Contains(t, out, `<td style="text-align:right">two</td>`)
+	assert.NotContains(t, out, "align=", "the default alignment renderer emits an align attribute instead")
+}
+
+// The rest of GFM has to keep working now that it is registered piecewise.
+func TestGFMMembersStayRegistered(t *testing.T) {
+	assert.Contains(t, compileDoc(t, "~~gone~~\n"), "<del>gone</del>")
+	assert.Contains(t, compileDoc(t, "- [x] done\n"), "<ac:task-status>complete</ac:task-status>")
+	assert.Contains(t, compileDoc(t, "see https://example.com/x for more\n"), `href="https://example.com/x"`)
+}


### PR DESCRIPTION
extension.GFM bundles its own default-configured Table, and it was passed
alongside extension.NewTable(WithTableCellAlignMethod(TableCellAlignStyle)).
Both Extends registered a table-cell renderer at goldmark's priority 500, and
util.PrioritizedSlice.Sort is sort.Slice, which is not stable -- so which
alignment method reached the page was decided by nothing at all. It happened to
be the configured one, which is why cell alignment came out as
style="text-align:..." rather than as an align attribute.

GFM's members -- Linkify, Strikethrough and TaskList -- are now listed one by
one next to the single configured Table.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
