### PR TITLE
fix(includes): drain every directive at a level under one cycle stack

### DIFF
--- a/includes/sibling_cycle_test.go
+++ b/includes/sibling_cycle_test.go
@@ -1,0 +1,48 @@
+package includes
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A directive that re-includes an ancestor was only caught when it was the
+// *first* directive in the fragment: everything after the first was left for
+// the caller to find on a later pass, and every pass started with an empty
+// stack. Two siblings, one of them circular, therefore expanded each other
+// forever and the document grew until the process was killed.
+func TestSiblingDirectiveReachingAnAncestorIsCircular(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.md"), []byte("b body\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.md"),
+		[]byte("PADDING\n<!-- Include: b.md -->\n<!-- Include: a.md -->\n"), 0644))
+
+	_, _, _, err := ProcessIncludes(dir, "", []byte("<!-- Include: a.md -->\n"), template.New("stdlib"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "circular include detected")
+}
+
+// Every directive at one level is expanded by a single call, so a document with
+// several includes needs no second pass from the caller.
+func TestSiblingDirectivesAreAllExpandedInOneCall(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "one.md"), []byte("first"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "two.md"), []byte("second"), 0644))
+
+	_, out, recurse, err := ProcessIncludes(
+		dir, "",
+		[]byte("<!-- Include: one.md -->\n\n<!-- Include: two.md -->\n"),
+		template.New("stdlib"),
+	)
+
+	require.NoError(t, err)
+	assert.True(t, recurse)
+	assert.Equal(t, "first\n\nsecond\n", string(out))
+}

--- a/includes/templates.go
+++ b/includes/templates.go
@@ -181,6 +181,12 @@ func LoadTemplate(
 	return templates, nil
 }
 
+// maxDirectivesPerLevel bounds how many directives a single level of a document
+// may expand. The stack below names every cycle it can see, but a template that
+// grows the document by some route the stack cannot express would otherwise be
+// expanded until the process ran out of memory; failing loudly is better.
+const maxDirectivesPerLevel = 1000
+
 func ProcessIncludes(
 	base string,
 	includePath string,
@@ -205,72 +211,95 @@ func ProcessIncludesWithStack(
 		return strings.Join(parts, ", ")
 	}
 
-	s := string(contents)
-
-	// A directive inside a code block is a code sample: a page documenting how
-	// to write an Include had the file pulled in where its own example should
-	// have been.
-	code := metadata.CodeRegions(contents)
-	startIdx, endIdx := findIncludeDirective(s, func(offset int) bool {
-		return metadata.InCode(code, offset)
-	})
-	if startIdx == -1 {
-		return templates, contents, false, nil
-	}
-
-	rawDirective := contents[startIdx:endIdx]
-	dir, err := ParseIncludeDirective(rawDirective)
-	if err != nil {
-		return templates, contents, false, err
-	}
-	if dir == nil {
-		return templates, contents, false, nil
-	}
-
-	// Detect circular include loops
-	cleanTmpl := filepath.Clean(dir.Template)
-	for _, item := range stack {
-		if filepath.Clean(item) == cleanTmpl {
-			return templates, contents, false, fmt.Errorf("circular include detected: %s -> %s", strings.Join(append(stack, dir.Template), " -> "), dir.Template)
+	// Every directive at this level is drained here, under one stack, rather
+	// than one per call with the caller looping. A sibling directive that
+	// re-included an ancestor was never compared against the stack -- the
+	// caller's loop started each pass with an empty one -- so
+	// "a.md" holding an include of "b.md" next to an include of itself grew the
+	// document without bound instead of being reported as circular.
+	modified := false
+	for expansions := 0; ; expansions++ {
+		if expansions >= maxDirectivesPerLevel {
+			return templates, contents, false, fmt.Errorf(
+				"more than %d include directives expanded at one level (stack: %s), giving up",
+				maxDirectivesPerLevel,
+				strings.Join(stack, " -> "),
+			)
 		}
+
+		s := string(contents)
+
+		// A directive inside a code block is a code sample: a page documenting how
+		// to write an Include had the file pulled in where its own example should
+		// have been.
+		code := metadata.CodeRegions(contents)
+		startIdx, endIdx := findIncludeDirective(s, func(offset int) bool {
+			return metadata.InCode(code, offset)
+		})
+		if startIdx == -1 {
+			return templates, contents, modified, nil
+		}
+
+		rawDirective := contents[startIdx:endIdx]
+		dir, err := ParseIncludeDirective(rawDirective)
+		if err != nil {
+			return templates, contents, false, err
+		}
+		if dir == nil {
+			return templates, contents, modified, nil
+		}
+
+		// Detect circular include loops
+		cleanTmpl := filepath.Clean(dir.Template)
+		for _, item := range stack {
+			if filepath.Clean(item) == cleanTmpl {
+				return templates, contents, false, fmt.Errorf("circular include detected: %s -> %s", strings.Join(stack, " -> "), dir.Template)
+			}
+		}
+
+		log.Trace().Interface("vardump", dir.Data).Msgf("including template %q", dir.Template)
+
+		// LoadTemplate returns the specific template it loaded, whose name encodes the
+		// delimiters. Execute it directly rather than looking it up by path again,
+		// which would find the wrong parse when the same file is included twice with
+		// different Delims:.
+		loaded, err := LoadTemplate(base, includePath, dir.Template, dir.Left, dir.Right, templates)
+		if err != nil {
+			return templates, contents, false, fmt.Errorf("unable to load template %q: %w", dir.Template, err)
+		}
+		templates = loaded
+
+		var buffer bytes.Buffer
+		err = loaded.Execute(&buffer, dir.Data)
+		if err != nil {
+			return templates, contents, false, fmt.Errorf("unable to execute template %q (vars: %s): %w", dir.Template, formatVardump(dir.Data), err)
+		}
+
+		// A parameter holding an element must hold nothing else, and a template is
+		// written to be read rather than to be careful about that.
+		expanded := TrimElementParameters(buffer.Bytes())
+
+		// Recursively process nested includes with updated stack. The stack is
+		// copied rather than appended in place: every branch off this level
+		// would otherwise share -- and overwrite -- the same backing array.
+		newStack := make([]string, 0, len(stack)+1)
+		newStack = append(newStack, stack...)
+		newStack = append(newStack, dir.Template)
+
+		subTemplates, subBytes, _, subErr := ProcessIncludesWithStack(base, includePath, expanded, templates, newStack)
+		if subErr != nil {
+			return templates, contents, false, subErr
+		}
+		templates = subTemplates
+
+		var res bytes.Buffer
+		res.Write(contents[:startIdx])
+		res.Write(subBytes)
+		res.Write(contents[endIdx:])
+
+		contents = res.Bytes()
+		modified = true
 	}
-
-	log.Trace().Interface("vardump", dir.Data).Msgf("including template %q", dir.Template)
-
-	// LoadTemplate returns the specific template it loaded, whose name encodes the
-	// delimiters. Execute it directly rather than looking it up by path again,
-	// which would find the wrong parse when the same file is included twice with
-	// different Delims:.
-	loaded, err := LoadTemplate(base, includePath, dir.Template, dir.Left, dir.Right, templates)
-	if err != nil {
-		return templates, contents, false, fmt.Errorf("unable to load template %q: %w", dir.Template, err)
-	}
-	templates = loaded
-
-	var buffer bytes.Buffer
-	err = loaded.Execute(&buffer, dir.Data)
-	if err != nil {
-		return templates, contents, false, fmt.Errorf("unable to execute template %q (vars: %s): %w", dir.Template, formatVardump(dir.Data), err)
-	}
-
-	// A parameter holding an element must hold nothing else, and a template is
-	// written to be read rather than to be careful about that.
-	expanded := TrimElementParameters(buffer.Bytes())
-
-	// Recursively process nested includes with updated stack
-	newStack := append(stack, dir.Template)
-	subTemplates, subBytes, _, subErr := ProcessIncludesWithStack(base, includePath, expanded, templates, newStack)
-	if subErr != nil {
-		return templates, contents, false, subErr
-	}
-	templates = subTemplates
-
-	var res bytes.Buffer
-	res.Write(contents[:startIdx])
-	res.Write(subBytes)
-	res.Write(contents[endIdx:])
-
-	return templates, res.Bytes(), true, nil
 }
 
 // DirectiveTargets reports the files a document asks to include, in the order

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -200,6 +200,41 @@ func compileMarkdownWithExtension(markdown []byte, ext goldmark.Extender, logMes
 	return string(html), nil
 }
 
+// maxIncludePasses bounds the number of times the whole document is rescanned
+// for include directives. ProcessIncludes drains every directive it can see in
+// one pass, so a pass that still finds work is expansion feeding itself, and
+// without a bound the document grows until the process is killed.
+const maxIncludePasses = 10
+
+// expandIncludes runs include expansion over the document until it settles,
+// which is what both compile paths need before goldmark ever sees the bytes.
+func expandIncludes(
+	path string,
+	includePath string,
+	markdown []byte,
+	tmpl *template.Template,
+) (*template.Template, []byte, error) {
+	for pass := 0; pass < maxIncludePasses; pass++ {
+		var recurse bool
+		var err error
+
+		tmpl, markdown, recurse, err = includes.ProcessIncludes(
+			filepath.Dir(path),
+			includePath,
+			markdown,
+			tmpl,
+		)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to process includes: %w", err)
+		}
+		if !recurse {
+			return tmpl, markdown, nil
+		}
+	}
+
+	return nil, nil, fmt.Errorf("include expansion did not settle after %d passes over %q", maxIncludePasses, path)
+}
+
 func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib, path string, cfg types.MarkConfig) (string, []attachment.Attachment, error) {
 	var tmpl *template.Template
 	if stdlib != nil {
@@ -208,21 +243,9 @@ func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib, path string, cfg types
 		tmpl = template.New("stdlib")
 	}
 
-	var err error
-	var recurse bool
-	for {
-		tmpl, markdown, recurse, err = includes.ProcessIncludes(
-			filepath.Dir(path),
-			cfg.IncludePath,
-			markdown,
-			tmpl,
-		)
-		if err != nil {
-			return "", nil, fmt.Errorf("unable to process includes: %w", err)
-		}
-		if !recurse {
-			break
-		}
+	tmpl, markdown, err := expandIncludes(path, cfg.IncludePath, markdown, tmpl)
+	if err != nil {
+		return "", nil, err
 	}
 
 	var macros []macro.Macro
@@ -263,21 +286,9 @@ func CompileMarkdownLegacy(markdown []byte, stdlib *stdlib.Lib, path string, cfg
 		tmpl = template.New("stdlib")
 	}
 
-	var err error
-	var recurse bool
-	for {
-		tmpl, markdown, recurse, err = includes.ProcessIncludes(
-			filepath.Dir(path),
-			cfg.IncludePath,
-			markdown,
-			tmpl,
-		)
-		if err != nil {
-			return "", nil, fmt.Errorf("unable to process includes: %w", err)
-		}
-		if !recurse {
-			break
-		}
+	tmpl, markdown, err := expandIncludes(path, cfg.IncludePath, markdown, tmpl)
+	if err != nil {
+		return "", nil, err
 	}
 
 	var macros []macro.Macro


### PR DESCRIPTION
ProcessIncludesWithStack expanded the first directive it found and returned,
leaving any sibling for the caller to find on a later pass -- and CompileMarkdown's
loop started every pass with a fresh, empty stack. A directive that re-included
an ancestor was therefore only ever compared against the stack when it was the
first one in the fragment.

    doc.md: <!-- Include: a.md -->
    a.md:   PADDING
            <!-- Include: b.md -->
            <!-- Include: a.md -->

Each pass grew the document and reported that it had done work, forever, until
the process was killed. A plain self-include was caught, which is why this was
believed covered.

Every directive at one level is now expanded inside a single call, so a sibling
is compared against the same stack its neighbour's expansion was. Two backstops
sit behind that: a cap on directives expanded at one level, and a cap on the
outer passes, which is also now shared by both compile paths rather than written
out twice.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
