### PR TITLE
fix(markdown): repair the AST macro and include path

### DIFF
--- a/markdown/ast_include_test.go
+++ b/markdown/ast_include_test.go
@@ -1,0 +1,52 @@
+package mark
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeMacroIncludingFragment lays out a document whose include directive is
+// produced by a macro. Includes are expanded over the raw bytes before macros
+// are, so a directive a macro writes is only ever seen by the AST include
+// transformer -- which is the path these tests are about.
+func writeMacroIncludingFragment(t *testing.T, fragment string) (dir string, doc string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "frag.md"), []byte(fragment), 0644))
+
+	return dir, "<!-- Macro: :pull-frag:\n" +
+		"Template: #inline\n" +
+		"inline: \"<!-- Include: frag.md -->\" -->\n\n" +
+		":pull-frag:\n"
+}
+
+// compileInDir compiles a document that lives in dir, with no --include-path
+// configured, which is the ordinary case.
+func compileInDir(t *testing.T, dir string, doc string) string {
+	t.Helper()
+
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	out, _, err := CompileMarkdown([]byte(doc), std, filepath.Join(dir, "doc.md"), types.MarkConfig{})
+	require.NoError(t, err)
+
+	return out
+}
+
+// The AST macro and include transformers were handed the markdown file itself
+// as their base directory, so every relative Template: resolved under
+// "doc.md/" and could only ever be found when --include-path happened to cover
+// it.
+func TestASTIncludeResolvesRelativeToDocumentDirectory(t *testing.T) {
+	dir, doc := writeMacroIncludingFragment(t, "fragment body\n")
+
+	assert.Contains(t, compileInDir(t, dir, doc), "fragment body")
+}

--- a/markdown/ast_include_verbatim_test.go
+++ b/markdown/ast_include_verbatim_test.go
@@ -1,0 +1,22 @@
+package mark
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A macro or include exists to carry storage format that goldmark would
+// otherwise mangle. The sub-document's nodes were turned into raw ast.String
+// nodes, and a raw string in goldmark still goes through Writer.RawWrite, which
+// escapes & < > and " -- so the <ac:structured-macro> the fragment was written
+// to deliver was published as visible literal text.
+func TestASTIncludeKeepsConfluenceMarkupVerbatim(t *testing.T) {
+	dir, doc := writeMacroIncludingFragment(t,
+		`<ac:structured-macro ac:name="info"><ac:rich-text-body>from a fragment</ac:rich-text-body></ac:structured-macro>`)
+
+	out := compileInDir(t, dir, doc)
+
+	assert.Contains(t, out, `<ac:structured-macro ac:name="info">`)
+	assert.NotContains(t, out, "&lt;ac:structured-macro", "storage format must not be escaped into literal text")
+}

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -323,8 +323,13 @@ func NewConfluenceExtension(stdlib *stdlib.Lib, path string, cfg types.MarkConfi
 		tmpl = stdlib.Templates
 	}
 	pipeline := ctransformer.NewPipelineTransformer(
-		ctransformer.NewMacroTransformer(path, path, cfg.IncludePath, tmpl),
-		ctransformer.NewIncludeTransformer(path, path, cfg.IncludePath, tmpl),
+		// The base directory a template path is resolved against is the
+		// document's directory, not the document itself. Passing path for both
+		// made every relative Template: resolve under "doc.md/", which no
+		// filesystem has, so the AST macro and include transformers only ever
+		// worked when --include-path happened to cover the file.
+		ctransformer.NewMacroTransformer(path, filepath.Dir(path), cfg.IncludePath, tmpl),
+		ctransformer.NewIncludeTransformer(path, filepath.Dir(path), cfg.IncludePath, tmpl),
 	)
 	return &ConfluenceExtension{
 		Config:          html.NewConfig(),

--- a/markdown/transformer_pipeline_test.go
+++ b/markdown/transformer_pipeline_test.go
@@ -37,8 +37,11 @@ This is the main body text.`)
 		IncludePath: tempDir,
 	}
 
-	// Compile Markdown using Goldmark AST transformers pipeline
-	htmlOutput, _, err := CompileMarkdown(markdownInput, std, tempDir, cfg)
+	// Compile Markdown using Goldmark AST transformers pipeline. The path is a
+	// file inside the directory, not the directory: passing a directory hid a
+	// base-directory bug in the AST transformers, which resolve relative
+	// template paths against the document's own directory.
+	htmlOutput, _, err := CompileMarkdown(markdownInput, std, filepath.Join(tempDir, "doc.md"), cfg)
 	require.NoError(t, err)
 
 	// Assert that Macro expanded into Include, and Include expanded into Content
@@ -95,7 +98,7 @@ inline: "<!-- Include: inc3.md\ntext: ${1} -->" -->
 		IncludePath: tempDir,
 	}
 
-	htmlOutput, _, err := CompileMarkdown(markdownInput, std, tempDir, cfg)
+	htmlOutput, _, err := CompileMarkdown(markdownInput, std, filepath.Join(tempDir, "doc.md"), cfg)
 	require.NoError(t, err)
 
 	// Assert that multi-level nested includes and macro expansions succeeded
@@ -138,7 +141,7 @@ func TestCircularIncludeLoopError(t *testing.T) {
 		IncludePath: tempDir,
 	}
 
-	_, _, err = CompileMarkdown(markdownInput, std, tempDir, cfg)
+	_, _, err = CompileMarkdown(markdownInput, std, filepath.Join(tempDir, "doc.md"), cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "circular include detected")
 }

--- a/transformer/util.go
+++ b/transformer/util.go
@@ -121,9 +121,9 @@ func ExtractNodeRawContent(node ast.Node, source []byte) []byte {
 
 func convertSegmentsToStrings(doc ast.Node, source []byte) {
 	type replaceItem struct {
-		node  ast.Node
-		val   []byte
-		isRaw bool
+		node     ast.Node
+		val      []byte
+		verbatim bool
 	}
 	var nodesToReplace []replaceItem
 
@@ -137,13 +137,13 @@ func convertSegmentsToStrings(doc ast.Node, source []byte) {
 				val := t.Segment.Value(source)
 				valCopy := make([]byte, len(val))
 				copy(valCopy, val)
-				nodesToReplace = append(nodesToReplace, replaceItem{node: t, val: valCopy, isRaw: false})
+				nodesToReplace = append(nodesToReplace, replaceItem{node: t, val: valCopy, verbatim: false})
 			}
 		case *ast.HTMLBlock:
 			val := extractHTMLBlockBytes(t, source)
 			valCopy := make([]byte, len(val))
 			copy(valCopy, val)
-			nodesToReplace = append(nodesToReplace, replaceItem{node: t, val: valCopy, isRaw: true})
+			nodesToReplace = append(nodesToReplace, replaceItem{node: t, val: valCopy, verbatim: true})
 		case *ast.RawHTML:
 			if t.Segments.Len() == 1 {
 				seg := t.Segments.At(0)
@@ -151,7 +151,7 @@ func convertSegmentsToStrings(doc ast.Node, source []byte) {
 					val := seg.Value(source)
 					valCopy := make([]byte, len(val))
 					copy(valCopy, val)
-					nodesToReplace = append(nodesToReplace, replaceItem{node: t, val: valCopy, isRaw: true})
+					nodesToReplace = append(nodesToReplace, replaceItem{node: t, val: valCopy, verbatim: true})
 				}
 			} else {
 				buf := getBuffer()
@@ -164,7 +164,7 @@ func convertSegmentsToStrings(doc ast.Node, source []byte) {
 				valCopy := make([]byte, buf.Len())
 				copy(valCopy, buf.Bytes())
 				putBuffer(buf)
-				nodesToReplace = append(nodesToReplace, replaceItem{node: t, val: valCopy, isRaw: true})
+				nodesToReplace = append(nodesToReplace, replaceItem{node: t, val: valCopy, verbatim: true})
 			}
 		}
 		return ast.WalkContinue, nil
@@ -174,8 +174,13 @@ func convertSegmentsToStrings(doc ast.Node, source []byte) {
 		parent := item.node.Parent()
 		if parent != nil {
 			strNode := ast.NewString(item.val)
-			if item.isRaw {
-				strNode.SetRaw(true)
+			if item.verbatim {
+				// SetCode, not SetRaw. A "raw" string still goes through
+				// Writer.RawWrite, which escapes & < > and ", so the
+				// <ac:structured-macro> a macro or include exists to carry was
+				// published as visible literal text. SetCode is goldmark's
+				// only verbatim path.
+				strNode.SetCode(true)
 			}
 			parent.InsertBefore(parent, item.node, strNode)
 			parent.RemoveChild(parent, item.node)


### PR DESCRIPTION
Two fixes to the same path, kept together because the second is only reachable and testable once the first works.

**Templates were resolved against the document, not its directory.** `CompileMarkdown` passed `path` as both the path and the base directory to the macro and include AST transformers, while every other call in the same function uses `filepath.Dir(path)`. So resolution tried `mac.md/frag.md` and failed on every real invocation unless `--include-path` happened to cover it. The pipeline test hid this by passing a directory as the path; it now passes a file path inside one.

**Confluence markup brought in by a macro or include was published escaped.** `transformer/util.go` converted raw HTML in a sub-document into an `ast.String` with `SetRaw(true)` — but in goldmark `SetRaw` is not "emit verbatim": raw strings go through `Writer.RawWrite`, which escapes `& < > "`. The verbatim path is `SetCode`. So a macro whose expansion contained `<ac:structured-macro …>` reached the page as literal escaped text, which is exactly what AGENTS.md invariant 3 says the raw-byte pass exists to prevent.

Both confirmed to fail with the fix reverted: the first with `open mac.md/frag.md: not a directory`, the second with `&lt;ac:structured-macro…` on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)