### PR TITLE
fix(renderer): keep the <p> around a paragraph that only starts with raw HTML

### DIFF
--- a/markdown/paragraph_rawhtml_test.go
+++ b/markdown/paragraph_rawhtml_test.go
@@ -1,0 +1,61 @@
+package mark
+
+import (
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The <p> wrapper was dropped whenever a paragraph merely *began* with a raw
+// fragment, so the prose after the tag was emitted bare at block level -- while
+// the same tag written mid-sentence kept its wrapper.
+func TestParagraphOpeningWithConfluenceTagKeepsItsWrapper(t *testing.T) {
+	out := compileParagraphDoc(t, `<ac:emoticon ac:name="smile"/> and then trailing prose.`+"\n")
+
+	assert.Equal(t, "<p><ac:emoticon ac:name=\"smile\"/> and then trailing prose.</p>\n", out)
+}
+
+// A paragraph that is nothing but the fragment is the fragment, and a <p>
+// around a Confluence block element is not something Confluence accepts.
+func TestParagraphOfOnlyAConfluenceTagStaysUnwrapped(t *testing.T) {
+	out := compileParagraphDoc(t, `<ac:emoticon ac:name="smile"/>`+"\n")
+
+	assert.Equal(t, "<ac:emoticon ac:name=\"smile\"/>\n", out)
+}
+
+// Hand-written inline HTML that opens and closes within the paragraph is the
+// author's own element, and gets no wrapper -- this is what the old blanket
+// rule was protecting and it has to keep working.
+func TestParagraphOfOneHandWrittenElementStaysUnwrapped(t *testing.T) {
+	out := compileParagraphDoc(t, "<b>bold</b>\n")
+
+	assert.Equal(t, "<b>bold</b>\n", out)
+}
+
+// An author building a Confluence element across several blocks writes its
+// opening tag on a line of its own; a <p> there would interleave with the
+// element.
+func TestParagraphOpeningAConfluenceElementStaysUnwrapped(t *testing.T) {
+	out := compileParagraphDoc(t, "<ac:structured-macro ac:name=\"info\"> leading text\n")
+
+	assert.Equal(t, "<ac:structured-macro ac:name=\"info\"> leading text\n", out)
+}
+
+// compileParagraphDoc compiles a document through the default path with the
+// stdlib templates loaded. Defined here rather than shared so this fix stands
+// on its own.
+func compileParagraphDoc(t *testing.T, src string, features ...string) string {
+	t.Helper()
+
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	out, _, err := CompileMarkdown([]byte(src), std, "test.md", types.MarkConfig{Features: features})
+	require.NoError(t, err)
+
+	return out
+}

--- a/renderer/paragraph.go
+++ b/renderer/paragraph.go
@@ -1,6 +1,8 @@
 package renderer
 
 import (
+	"bytes"
+
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/renderer/html"
@@ -24,9 +26,9 @@ func (r *ConfluenceParagraphRenderer) RegisterFuncs(reg renderer.NodeRendererFun
 }
 
 func (r *ConfluenceParagraphRenderer) renderParagraph(w util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
-	firstChild := n.FirstChild()
+	unwrapped := unwrapParagraph(n, source)
 	if entering {
-		if firstChild == nil || firstChild.Kind() != ast.KindRawHTML {
+		if !unwrapped {
 			if n.Attributes() != nil {
 				_, _ = w.WriteString("<p")
 				html.RenderAttributes(w, n, html.ParagraphAttributeFilter)
@@ -36,10 +38,108 @@ func (r *ConfluenceParagraphRenderer) renderParagraph(w util.BufWriter, source [
 			}
 		}
 	} else {
-		if firstChild == nil || firstChild.Kind() != ast.KindRawHTML {
+		if !unwrapped {
 			_, _ = w.WriteString("</p>")
 		}
 		_, _ = w.WriteString("\n")
 	}
 	return ast.WalkContinue, nil
+}
+
+// unwrapParagraph reports whether the paragraph is markup the author wrote out
+// by hand, and so must be emitted without a <p> wrapper.
+//
+// Merely *starting* with a raw fragment is not enough, which is what this used
+// to test. `<ac:emoticon ac:name="smile"/> and then prose.` is a paragraph with
+// a macro at the front, and dropping the wrapper put the prose after it at bare
+// block level -- while the same tag written mid-sentence kept its <p>.
+//
+// Three shapes are the author's own markup rather than prose:
+//
+//   - one fragment and nothing else, e.g. a macro on its own line;
+//   - a fragment that opens an element and a last fragment that closes it,
+//     which is how <b>bold</b> arrives here;
+//   - one half of a Confluence element the author spread over several blocks,
+//     where a <p> would interleave with the element being built.
+func unwrapParagraph(n ast.Node, source []byte) bool {
+	first, ok := n.FirstChild().(*ast.RawHTML)
+	if !ok {
+		return false
+	}
+
+	if ast.Node(first) == n.LastChild() {
+		return true
+	}
+
+	firstTag := rawHTMLTag(first, source)
+
+	if last, ok := n.LastChild().(*ast.RawHTML); ok {
+		if closesTag(firstTag, rawHTMLTag(last, source)) {
+			return true
+		}
+	}
+
+	return spansConfluenceElement(firstTag)
+}
+
+// rawHTMLTag returns the fragment's bytes, which for an inline raw HTML node is
+// a single tag.
+func rawHTMLTag(n *ast.RawHTML, source []byte) []byte {
+	var buf bytes.Buffer
+	for i := 0; i < n.Segments.Len(); i++ {
+		segment := n.Segments.At(i)
+		buf.Write(segment.Value(source))
+	}
+	return bytes.TrimSpace(buf.Bytes())
+}
+
+// closesTag reports whether closing is the closing tag of the element that
+// opening opens.
+func closesTag(opening []byte, closing []byte) bool {
+	if !isOpeningTag(opening) || !bytes.HasPrefix(closing, []byte("</")) {
+		return false
+	}
+
+	name := tagName(opening)
+
+	return len(name) > 0 && bytes.EqualFold(name, tagName(closing))
+}
+
+// spansConfluenceElement reports whether the fragment is the opening or closing
+// half of a Confluence element rather than a complete one. A self-closing tag
+// is complete, so whatever follows it in the paragraph is ordinary prose.
+func spansConfluenceElement(tag []byte) bool {
+	for _, prefix := range [][]byte{[]byte("<ac:"), []byte("<ri:"), []byte("</ac:"), []byte("</ri:")} {
+		if bytes.HasPrefix(tag, prefix) {
+			return !bytes.HasSuffix(tag, []byte("/>"))
+		}
+	}
+
+	return false
+}
+
+func isOpeningTag(tag []byte) bool {
+	return len(tag) > 1 && tag[0] == '<' && tag[1] != '/' && !bytes.HasSuffix(tag, []byte("/>"))
+}
+
+// tagName returns the element name of an opening or closing tag, empty if the
+// bytes are not a tag at all.
+func tagName(tag []byte) []byte {
+	if len(tag) == 0 || tag[0] != '<' {
+		return nil
+	}
+
+	rest := tag[1:]
+	rest = bytes.TrimPrefix(rest, []byte("/"))
+
+	end := 0
+	for end < len(rest) {
+		switch rest[end] {
+		case ' ', '\t', '\r', '\n', '/', '>':
+			return rest[:end]
+		}
+		end++
+	}
+
+	return rest
 }


### PR DESCRIPTION
The paragraph renderer suppressed both <p> and </p> whenever the paragraph's
first child was ast.KindRawHTML, regardless of what followed it. So

    <ac:emoticon ac:name="smile"/> and then trailing prose.

was emitted bare at block level, prose and all, while the same tag written
mid-sentence kept its wrapper.

The wrapper is now dropped only when the paragraph really is markup the author
wrote out: one fragment and nothing else, a fragment whose element the last
child closes -- which is how <b>bold</b> arrives here -- or one half of a
Confluence element spread over several blocks, where a <p> would interleave with
what the author is building.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
