### PR TITLE
fix(renderer): keep the alt text of an HTML <img>

### DIFF
--- a/markdown/html_img_alt_test.go
+++ b/markdown/html_img_alt_test.go
@@ -1,0 +1,47 @@
+package mark
+
+import (
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The <img> transformer hands the alt text over as a plain ast.String, and the
+// image renderer only ever read a String that was marked as code -- so the alt
+// of an <img> was dropped, while the Markdown spelling of the same image kept
+// its own. <img> is what authors reach for when they want a width.
+func TestHTMLImgAltReachesTheImage(t *testing.T) {
+	out := compileImgDoc(t,
+		`<img src="https://example.com/a.png" alt="a diagram" width="100">`+"\n",
+		"html-img-tag")
+
+	assert.Contains(t, out, `ac:alt="a diagram"`)
+}
+
+// The alt is author text going into an XML attribute, so it is escaped on the
+// way in exactly as the Markdown spelling's alt is.
+func TestHTMLImgAltIsEscaped(t *testing.T) {
+	out := compileImgDoc(t,
+		`<img src="https://example.com/a.png" alt="a &amp; b">`+"\n",
+		"html-img-tag")
+
+	assert.Contains(t, out, `ac:alt="a &amp; b"`)
+	assert.NotContains(t, out, "&amp;amp;")
+}
+
+// compileImgDoc compiles a document through the default path with the stdlib
+// templates loaded. Defined here rather than shared so this fix stands alone.
+func compileImgDoc(t *testing.T, src string, features ...string) string {
+	t.Helper()
+
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	out, _, err := CompileMarkdown([]byte(src), std, "test.md", types.MarkConfig{Features: features})
+	require.NoError(t, err)
+
+	return out
+}

--- a/renderer/image.go
+++ b/renderer/image.go
@@ -239,7 +239,15 @@ func (r *ConfluenceImageRenderer) renderImage(writer util.BufWriter, source []by
 func nodeToHTMLText(n ast.Node, source []byte) []byte {
 	var buf bytes.Buffer
 	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
-		if s, ok := c.(*ast.String); ok && s.IsCode() {
+		if s, ok := c.(*ast.String); ok {
+			// The <img> transformer hands the alt text over as a plain String,
+			// and only the IsCode branch existed, so every alt written as an
+			// HTML attribute was silently dropped while the Markdown spelling
+			// kept its own.
+			//
+			// Written out unescaped, like the Text branch below and for the
+			// same reason: the ac:image template escapes what it interpolates,
+			// and doing it here as well puts a literal &amp;amp; on the page.
 			buf.Write(s.Value)
 		} else if t, ok := c.(*ast.Text); ok {
 			// Not escaped here: every consumer interpolates the result into an


### PR DESCRIPTION
The <img> transformer hands the alt over as a plain ast.String, and
nodeToHTMLText only ever wrote a String that was marked as code -- so
`<img src="x.png" alt="a diagram">` published with no ac:alt at all, while
`![a diagram](x.png)` kept its own. <img> is what authors reach for when they
want a width, so the two spellings of the same picture disagreed on whether the
picture was described.

Written out unescaped, like the Text branch beside it and for the same reason:
the ac:image template escapes what it interpolates, and escaping here as well
puts a literal &amp;amp; on the page.

The test carries its own compile helper rather than sharing one, so the fix
stands on its own.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
