### PR TITLE
fix(transformer): close void elements and repair comments in raw HTML

### DIFF
--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -143,6 +143,14 @@ func (c *ConfluenceLegacyExtension) Extend(m goldmark.Markdown) {
 		))
 	}
 
+	// Close the void elements and repair the comments an author may have
+	// written by hand, which Markdown allows and storage format does not.
+	// After everything at 110 that owns raw HTML of its own, so that this only
+	// sees what those transformers left behind.
+	m.Parser().AddOptions(parser.WithASTTransformers(
+		util.Prioritized(ctransformer.NewXMLWellFormedTransformer(), 120),
+	))
+
 	m.Parser().AddOptions(parser.WithInlineParsers(
 		// Must be registered with a higher priority than goldmark's linkParser to make sure goldmark doesn't parse
 		// the <ac:*/> tags.
@@ -489,6 +497,17 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 			util.Prioritized(ctransformer.NewAutoLinkTransformer(), 110),
 		))
 	}
+
+	// Close the void elements and repair the comments an author may have
+	// written by hand, which Markdown allows and storage format does not.
+	// After everything at 110 that owns raw HTML of its own -- the <img> and
+	// <details> transformers -- so that this only sees what they left behind,
+	// and never turns an <img> into storage format the <img> transformer would
+	// then fail to recognise.
+	m.Parser().AddOptions(parser.WithASTTransformers(
+		util.Prioritized(ctransformer.NewXMLWellFormedTransformer(), 120),
+	))
+
 	// Add confluence tag parser for <ac:*/> tags
 	m.Parser().AddOptions(parser.WithInlineParsers(
 		util.Prioritized(cparser.NewConfluenceTagParser(), 199),

--- a/markdown/xml_wellformed_test.go
+++ b/markdown/xml_wellformed_test.go
@@ -1,0 +1,92 @@
+package mark
+
+import (
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A void element left open makes the page not well-formed XML, and Confluence
+// rejects the whole page for it. `<br>` in a table cell is the standard way to
+// write a multi-line cell, so an ordinary Markdown table took the page down.
+func TestVoidElementsAreClosedInTableCells(t *testing.T) {
+	out := compileRawHTMLDoc(t, "| a |\n| --- |\n| 1. one<br>2. two |\n")
+
+	assert.Contains(t, out, "<td>1. one<br />2. two</td>")
+	assert.NotContains(t, out, "<br>")
+}
+
+// The same holds for a void element written as its own block.
+func TestVoidElementsAreClosedAtBlockLevel(t *testing.T) {
+	out := compileRawHTMLDoc(t, "before\n\n<hr>\n\nafter\n")
+
+	assert.Contains(t, out, "<hr />")
+	assert.NotContains(t, out, "<hr>")
+}
+
+// A void element nothing else claims is closed too. <img> has its own
+// transformer and becomes an ac:image, but the rest of the void set -- <input>,
+// <hr>, <br>, <col> and the others -- reach the page as raw HTML and would
+// otherwise reach it unclosed.
+func TestVoidElementsWithNoTransformerAreClosed(t *testing.T) {
+	out := compileRawHTMLDoc(t, `<input type="checkbox" checked>`+"\n")
+
+	assert.Contains(t, out, `<input type="checkbox" checked />`)
+	assert.NotContains(t, out, `checked>`)
+}
+
+// XML forbids `--` inside a comment body, so a note an author left to
+// themselves rejected the page. The comment is invisible either way, so the
+// hyphens are collapsed rather than the note being thrown away -- dropping the
+// node outright would also take the `<!-- Info -->` marker that classifies a
+// legacy blockquote, which the blockquote renderer reads at render time.
+func TestCommentWithDoubleHyphenIsRepaired(t *testing.T) {
+	out := compileRawHTMLDoc(t, "<!-- TODO -- revisit this later -->\n\ntext\n")
+
+	assert.Contains(t, out, "<!-- TODO - revisit this later -->")
+	assert.NotContains(t, out, "TODO --")
+}
+
+// The same comment written mid-paragraph arrives as an inline fragment rather
+// than a block, and needs the same repair.
+func TestInlineCommentWithDoubleHyphenIsRepaired(t *testing.T) {
+	out := compileRawHTMLDoc(t, "prose <!-- x -- y --> more prose\n")
+
+	assert.Contains(t, out, "<!-- x - y -->")
+}
+
+// The marker that turns a blockquote into an info macro is an HTML comment the
+// renderer reads out of the AST, so repairing comments must leave it in place.
+func TestLegacyBlockQuoteMarkerSurvives(t *testing.T) {
+	out := compileRawHTMLDoc(t, "> <!-- Info -->\n> Test\n")
+
+	assert.Contains(t, out, `<ac:structured-macro ac:name="info">`)
+	assert.Contains(t, out, "<!-- Info -->")
+}
+
+// Confluence's own markup is well-formed already and must be passed through
+// exactly as written; `<ac:emoticon .../>` is not an unclosed void element.
+func TestConfluenceMarkupIsNotRewritten(t *testing.T) {
+	out := compileRawHTMLDoc(t, `<ac:emoticon ac:name="smile"/>`+"\n")
+
+	assert.Contains(t, out, `<ac:emoticon ac:name="smile"/>`)
+}
+
+// compileRawHTMLDoc compiles a document through the default path with the
+// stdlib templates loaded. Defined here rather than shared so this fix stands
+// on its own.
+func compileRawHTMLDoc(t *testing.T, src string, features ...string) string {
+	t.Helper()
+
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	out, _, err := CompileMarkdown([]byte(src), std, "test.md", types.MarkConfig{Features: features})
+	require.NoError(t, err)
+
+	return out
+}

--- a/transformer/xml_wellformed.go
+++ b/transformer/xml_wellformed.go
@@ -1,0 +1,163 @@
+package transformer
+
+import (
+	"bytes"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+	"golang.org/x/net/html"
+)
+
+// XMLWellFormedTransformer rewrites the raw HTML an author wrote so that it is
+// well-formed XML, which is what Confluence storage format is.
+//
+// Two shapes of hand-written HTML are legal in Markdown and rejected by
+// Confluence, and it rejects the whole page rather than the element:
+//
+//   - a void element left open, `<br>` rather than `<br />`. Writing `<br>` in
+//     a table cell is the standard way to get more than one line into one, so
+//     this took out pages that were otherwise plain Markdown.
+//   - an HTML comment containing `--`, which XML does not allow anywhere in a
+//     comment body.
+//
+// Only the fragments that need it are rewritten; a node whose bytes are already
+// well-formed is left exactly as the author wrote it.
+type XMLWellFormedTransformer struct{}
+
+// NewXMLWellFormedTransformer creates a new instance of XMLWellFormedTransformer.
+func NewXMLWellFormedTransformer() *XMLWellFormedTransformer {
+	return &XMLWellFormedTransformer{}
+}
+
+// Transform implements the parser.ASTTransformer interface.
+func (t *XMLWellFormedTransformer) Transform(doc *ast.Document, reader text.Reader, pc parser.Context) {
+	// Collect first, mutate after: replacing a node clears its NextSibling and
+	// ast.Walk is iterating over that pointer, so mutating mid-walk abandons
+	// every remaining sibling under the same parent.
+	var nodes []ast.Node
+
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		switch node.(type) {
+		case *ast.HTMLBlock, *ast.RawHTML:
+			nodes = append(nodes, node)
+		}
+
+		return ast.WalkContinue, nil
+	})
+
+	source := reader.Source()
+
+	for _, node := range nodes {
+		parent := node.Parent()
+		if parent == nil {
+			continue
+		}
+
+		fixed, changed := wellFormedHTML(ExtractNodeRawContent(node, source))
+		if !changed {
+			continue
+		}
+
+		// SetCode, because the replacement is storage format already: a plain
+		// or "raw" string goes through Writer.RawWrite, which would escape the
+		// very markup being repaired.
+		replacement := ast.NewString(fixed)
+		replacement.SetCode(true)
+
+		parent.InsertBefore(parent, node, replacement)
+		parent.RemoveChild(parent, node)
+	}
+}
+
+// wellFormedHTML returns raw with void elements closed and comment bodies made
+// legal, and reports whether anything had to change. Every other byte, tag and
+// attribute is passed through untouched -- the input is the author's markup,
+// not something to normalise.
+func wellFormedHTML(raw []byte) ([]byte, bool) {
+	if len(raw) == 0 {
+		return raw, false
+	}
+
+	var buf bytes.Buffer
+	changed := false
+
+	tokenizer := html.NewTokenizer(bytes.NewReader(raw))
+
+	for {
+		tokenType := tokenizer.Next()
+		if tokenType == html.ErrorToken {
+			break
+		}
+
+		// Raw is only valid until the next call to Next, and every token's Raw
+		// concatenated is the input, so writing it is a faithful passthrough.
+		token := tokenizer.Raw()
+
+		switch tokenType {
+		case html.StartTagToken:
+			name, _ := tokenizer.TagName()
+			if isVoidElement(string(name)) && bytes.HasSuffix(token, []byte(">")) {
+				buf.Write(token[:len(token)-1])
+				buf.WriteString(" />")
+				changed = true
+				continue
+			}
+
+		case html.CommentToken:
+			// A bogus comment is how the tokenizer reports <![CDATA[...]]>,
+			// which stdlib templates emit on purpose and which is not a
+			// comment at all.
+			if bytes.HasPrefix(token, []byte("<!--")) && bytes.HasSuffix(token, []byte("-->")) && len(token) >= 7 {
+				body, bodyChanged := wellFormedCommentBody(token[4 : len(token)-3])
+				if bodyChanged {
+					buf.WriteString("<!--")
+					buf.Write(body)
+					buf.WriteString("-->")
+					changed = true
+					continue
+				}
+			}
+		}
+
+		buf.Write(token)
+	}
+
+	if !changed {
+		return raw, false
+	}
+
+	return buf.Bytes(), true
+}
+
+// wellFormedCommentBody removes the runs of hyphens that XML forbids inside a
+// comment: `--` anywhere in the body, and a trailing `-` that would run into
+// the closing `-->`. A comment is invisible on the page, so collapsing the
+// hyphens costs the author nothing and keeps the page publishable.
+func wellFormedCommentBody(body []byte) ([]byte, bool) {
+	var buf bytes.Buffer
+
+	hyphens := 0
+	for _, c := range body {
+		if c == '-' {
+			hyphens++
+			if hyphens > 1 {
+				continue
+			}
+		} else {
+			hyphens = 0
+		}
+		buf.WriteByte(c)
+	}
+
+	clean := bytes.TrimRight(buf.Bytes(), "-")
+	if bytes.Equal(clean, body) {
+		return body, false
+	}
+
+	return clean, true
+}

--- a/transformer/xml_wellformed_test.go
+++ b/transformer/xml_wellformed_test.go
@@ -1,0 +1,66 @@
+package transformer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Void elements written the HTML way leave the page as not-well-formed XML,
+// and Confluence rejects the whole page rather than the element. `<br>` inside
+// a table cell is the standard Markdown idiom for a multi-line cell, so this
+// took out documents that were otherwise plain Markdown.
+func TestWellFormedHTMLClosesVoidElements(t *testing.T) {
+	for _, testcase := range []struct {
+		name     string
+		raw      string
+		expected string
+		changed  bool
+	}{
+		{"br", "1. one<br>2. two", "1. one<br />2. two", true},
+		{"hr", "<hr>\n", "<hr />\n", true},
+		{"input", `<input type="checkbox" checked>`, `<input type="checkbox" checked />`, true},
+		{"img with attributes", `<img src="a.png" width="10">`, `<img src="a.png" width="10" />`, true},
+		{"already self-closed", "<br />", "<br />", false},
+		{"self-closed without space", "<br/>", "<br/>", false},
+		{"non-void element untouched", "<b>bold</b>", "<b>bold</b>", false},
+		{"confluence markup untouched", `<ac:emoticon ac:name="smile"/>`, `<ac:emoticon ac:name="smile"/>`, false},
+		{"attribute holding a bracket", `<img alt="a>b" src="x">`, `<img alt="a>b" src="x" />`, true},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			out, changed := wellFormedHTML([]byte(testcase.raw))
+
+			assert.Equal(t, testcase.expected, string(out))
+			assert.Equal(t, testcase.changed, changed)
+		})
+	}
+}
+
+// `--` is illegal anywhere in an XML comment body, so a comment an author wrote
+// as a note to themselves rejected the page it was written in.
+func TestWellFormedHTMLRepairsCommentBodies(t *testing.T) {
+	for _, testcase := range []struct {
+		name     string
+		raw      string
+		expected string
+		changed  bool
+	}{
+		{"double hyphen", "<!-- TODO -- revisit this later -->", "<!-- TODO - revisit this later -->", true},
+		{"long run", "<!-- a ----- b -->", "<!-- a - b -->", true},
+		{"trailing hyphen", "<!-- note- -->", "<!-- note- -->", false},
+		{"body ending in hyphen", "<!-- note --->", "<!-- note -->", true},
+		{"plain comment untouched", "<!-- Info -->", "<!-- Info -->", false},
+		{"single hyphens untouched", "<!-- ac:layout-section type:single -->", "<!-- ac:layout-section type:single -->", false},
+		// The tokenizer reports a CDATA section as a bogus comment; stdlib
+		// templates emit those on purpose and they are not comments at all.
+		{"cdata untouched", "<![CDATA[a -- b]]>", "<![CDATA[a -- b]]>", false},
+		{"unterminated comment untouched", "<!-- a -- b", "<!-- a -- b", false},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			out, changed := wellFormedHTML([]byte(testcase.raw))
+
+			assert.Equal(t, testcase.expected, string(out))
+			assert.Equal(t, testcase.changed, changed)
+		})
+	}
+}


### PR DESCRIPTION
Confluence storage format is XML, and it rejects the whole page -- not the
element -- when the page is not well formed. Two things an author may legally
write in Markdown produce exactly that, and both reached the page byte for byte
because the HTML block renderer and goldmark's inline raw-HTML renderer copy the
author's bytes out verbatim:

  - a void element left open. `| 1. one<br>2. two |` is the standard way to get
    two lines into a table cell, and it emitted <td>1. one<br>2. two</td>.
    <hr> and <input> the same.
  - `--` inside an HTML comment, which XML does not allow anywhere in a comment
    body, so <!-- TODO -- revisit --> took the page down.

A new transformer reparses the raw HTML nodes with a tokenizer and re-emits
them: a void start tag becomes self-closing, a comment body has its hyphen runs
collapsed, and every other byte is passed through as written. Nodes that need
neither are not touched at all.

The comment is repaired rather than dropped. Dropping it would be simpler, but
the marker that turns a legacy blockquote into an info macro is an HTML comment
that ParseBlockQuoteType reads out of the AST at render time, and a comment is
invisible on the page either way.

It runs at 120, after the <img> and <details> transformers at 110, so that an
<img> is still recognisable to the transformer that owns it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
