### PR TITLE
fix(confluence): eight defects in the REST client

### DIFF
--- a/confluence/api.go
+++ b/confluence/api.go
@@ -186,6 +186,13 @@ type PageInfo struct {
 	Title string `json:"title"`
 	Type  string `json:"type"`
 
+	// Status is "current", "archived", "trashed" or "draft".
+	//
+	// It matters because v1 filters a lookup to current unless told otherwise,
+	// so a page being absent from a lookup does not mean its title is free: an
+	// archived page is invisible and still owns the name.
+	Status string `json:"status"`
+
 	Version struct {
 		Number  int64  `json:"number"`
 		Message string `json:"message"`
@@ -517,6 +524,10 @@ func (api *API) FindPage(
 		"spaceKey": space,
 		"expand":   "ancestors,version",
 		"type":     pageType,
+		// Stated rather than left to the default, because the default is the
+		// whole subtlety here: this lookup deliberately sees live content only,
+		// and pageHoldingTitle is the one place that asks about the rest.
+		"status": "current",
 	}
 
 	if title != "" {
@@ -573,6 +584,107 @@ func (api *API) FindPage(
 		api.setCacheEntry(canonicalKey, &page)
 	}
 	return clonePageInfo(&page), nil
+}
+
+// statusesHoldingTitle are the states in which a page is invisible to an
+// ordinary lookup and still owns its title.
+//
+// Whether Confluence really refuses to reuse the title of an archived or
+// trashed page is not verifiable from here without an instance. Everything
+// below only ever produces a better error message on a create that has already
+// failed, so being wrong about it costs a misleading sentence rather than a
+// wrong action.
+var statusesHoldingTitle = []string{"archived", "trashed"}
+
+// findPageWithStatus looks a title up in one particular status.
+//
+// Separate from FindPage rather than a parameter on it: the page cache is keyed
+// by space, title and type, with no room for a fourth dimension, and caching an
+// archived page under the key a live one will want would be worse than not
+// caching at all. This is made only after a create has failed, so paying for it
+// each time is fine.
+func (api *API) findPageWithStatus(space, title, pageType, status string) (*PageInfo, error) {
+	result := struct {
+		Results []PageInfo `json:"results"`
+	}{}
+
+	payload := map[string]string{
+		"spaceKey": space,
+		"expand":   "ancestors,version",
+		"type":     pageType,
+		"status":   status,
+	}
+
+	if title != "" {
+		payload["title"] = title
+	}
+
+	request, err := api.v1().Res(
+		"content/", &result,
+	).Get(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	if request.Raw.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
+	if request.Raw.StatusCode != http.StatusOK {
+		return nil, newErrorStatusNotOK(request)
+	}
+
+	if len(result.Results) == 0 {
+		return nil, nil
+	}
+
+	page := result.Results[0]
+	if page.Status == "" {
+		page.Status = status
+	}
+
+	return &page, nil
+}
+
+// pageHoldingTitle finds a page that owns a title without being visible to an
+// ordinary lookup, or nil.
+//
+// This is the gap that made --on-orphan archive a one-way door: mark archives a
+// page, the source file comes back, FindPage returns nil because v1 hides
+// archived content, and the create that follows fails with a bare
+// 400 Bad Request naming nothing.
+func (api *API) pageHoldingTitle(space, title, pageType string) *PageInfo {
+	for _, status := range statusesHoldingTitle {
+		page, err := api.findPageWithStatus(space, title, pageType, status)
+		if err != nil || page == nil {
+			// The create has already failed. A failure to explain it is not
+			// worth replacing the caller's real error with.
+			continue
+		}
+		return page
+	}
+
+	return nil
+}
+
+// explainCreateFailure adds the one cause of a failed create the API never
+// names, and leaves every other failure exactly as it was.
+//
+// It reports rather than acts: restoring or purging somebody's page is a
+// decision for a person, and mark has already shown it cannot see the whole
+// picture here.
+func (api *API) explainCreateFailure(space, title, pageType string, err error) error {
+	blocker := api.pageHoldingTitle(space, title, pageType)
+	if blocker == nil {
+		return err
+	}
+
+	return fmt.Errorf(
+		"%w -- a page titled %q exists in space %s but is %s (id %s), and it still "+
+			"holds the title; restore or purge it in Confluence, or publish under a "+
+			"different title",
+		err, title, space, blocker.Status, blocker.ID,
+	)
 }
 
 func (api *API) CreateAttachment(
@@ -900,7 +1012,7 @@ func (api *API) CreatePage(
 	}
 
 	if request.Raw.StatusCode != http.StatusOK {
-		return nil, newErrorStatusNotOK(request)
+		return nil, api.explainCreateFailure(space, title, pageType, newErrorStatusNotOK(request))
 	}
 
 	page := request.Response.(*PageInfo)
@@ -1596,7 +1708,7 @@ func (api *API) CreatePageWithFolderParent(
 	}
 
 	if request.Raw.StatusCode != http.StatusOK && request.Raw.StatusCode != http.StatusCreated {
-		return nil, newErrorStatusNotOK(request)
+		return nil, api.explainCreateFailure(space, title, pageType, newErrorStatusNotOK(request))
 	}
 
 	result.Links.Full = "/pages/viewpage.action?pageId=" + result.ID

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -1868,9 +1868,47 @@ func (api *API) moveContent(contentID, position, targetID string) error {
 	switch request.Raw.StatusCode {
 	case http.StatusOK, http.StatusNoContent:
 		return nil
+	case http.StatusNotFound, http.StatusMethodNotAllowed:
+		// content/{id}/move is a Cloud endpoint, reached whenever a page's
+		// ancestry stops matching its headers or whenever pages are ordered.
+		// Folder creation is gated on IsCloud() and RestrictPageUpdates names
+		// the old-Server case in so many words; this path did neither, so a
+		// Server or Data Center user reorganising a docs tree got a bare 404
+		// with nothing in it to act on.
+		//
+		// Whether DC lacks the endpoint outright is unverified from here, so
+		// the status stays in the message: a 404 that really is a missing page
+		// arrives looking exactly the same.
+		if !api.IsCloud() {
+			return fmt.Errorf(
+				"unable to move %s (%s %s): this Confluence is not Cloud, and the "+
+					"content move endpoint mark uses to reparent and reorder pages is "+
+					"Cloud-only (status: %d); move the page in Confluence by hand, or "+
+					"leave its ancestry as the instance already has it",
+				api.describeContent(contentID), position, targetID, request.Raw.StatusCode,
+			)
+		}
+		return newErrorStatusNotOK(request)
 	default:
 		return newErrorStatusNotOK(request)
 	}
+}
+
+// describeContent names a page for an error message, falling back to its id.
+//
+// The cache is consulted rather than the API: this is only ever reached after
+// something has already failed, and a second request made to phrase a message
+// more nicely is a second thing that can go wrong.
+func (api *API) describeContent(contentID string) string {
+	api.lazyInit()
+	api.pageCacheMutex.RLock()
+	defer api.pageCacheMutex.RUnlock()
+
+	if page, ok := api.pageCacheByID[contentID]; ok && page != nil && page.Title != "" {
+		return fmt.Sprintf("page %q (%s)", page.Title, contentID)
+	}
+
+	return "content " + contentID
 }
 
 // ErrNotFound reports that Confluence answered 404. It is a sentinel so a

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -538,7 +538,7 @@ func (api *API) FindPage(
 		"content/", &result,
 	).Get(payload)
 	if err != nil {
-		return nil, err
+		return nil, newTransportError(request, fmt.Sprintf("find page %q in space %s", title, space), err)
 	}
 
 	// allow 404 because it's fine if page is not found,
@@ -623,7 +623,9 @@ func (api *API) findPageWithStatus(space, title, pageType, status string) (*Page
 		"content/", &result,
 	).Get(payload)
 	if err != nil {
-		return nil, err
+		return nil, newTransportError(
+			request, fmt.Sprintf("find %s page %q in space %s", status, title, space), err,
+		)
 	}
 
 	if request.Raw.StatusCode == http.StatusNotFound {
@@ -721,7 +723,9 @@ func (api *API) CreateAttachment(
 
 	request, err := resource.Post()
 	if err != nil {
-		return info, err
+		return info, newTransportError(
+			request, fmt.Sprintf("attach %q to page %s", name, pageID), err,
+		)
 	}
 
 	if request.Raw.StatusCode != http.StatusOK {
@@ -789,7 +793,9 @@ func (api *API) UpdateAttachment(
 
 	request, err := resource.Post()
 	if err != nil {
-		return info, err
+		return info, newTransportError(
+			request, fmt.Sprintf("upload a new version of attachment %q of page %s", name, pageID), err,
+		)
 	}
 
 	if request.Raw.StatusCode != http.StatusOK {
@@ -887,7 +893,7 @@ func (api *API) GetAttachments(pageID string) ([]AttachmentInfo, error) {
 			"content/"+pageID+"/child/attachment", &result,
 		).Get(payload)
 		if err != nil {
-			return nil, err
+			return nil, newTransportError(request, "list attachments of page "+pageID, err)
 		}
 
 		if request.Raw.StatusCode != http.StatusOK {
@@ -922,7 +928,7 @@ func (api *API) GetPageByIDExpanded(pageID string, expand string) (*PageInfo, er
 		"content/"+pageID, &PageInfo{},
 	).Get(map[string]string{"expand": expand})
 	if err != nil {
-		return nil, err
+		return nil, newTransportError(request, "read page "+pageID, err)
 	}
 
 	if request.Raw.StatusCode != http.StatusOK {
@@ -947,7 +953,7 @@ func (api *API) GetInlineComments(pageID string) (*InlineComments, error) {
 			"start":  fmt.Sprintf("%d", start),
 		})
 		if err != nil {
-			return nil, err
+			return nil, newTransportError(request, "read inline comments of page "+pageID, err)
 		}
 
 		if request.Raw.StatusCode != http.StatusOK {
@@ -1008,7 +1014,9 @@ func (api *API) CreatePage(
 		"content/", &PageInfo{},
 	).Post(payload)
 	if err != nil {
-		return nil, err
+		return nil, newTransportError(
+			request, fmt.Sprintf("create page %q in space %s", title, space), err,
+		)
 	}
 
 	if request.Raw.StatusCode != http.StatusOK {
@@ -1136,7 +1144,9 @@ func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, ve
 		"content/"+page.ID, &map[string]any{},
 	).Put(payload)
 	if err != nil {
-		return err
+		return newTransportError(
+			request, fmt.Sprintf("update page %q (%s)", page.Title, page.ID), err,
+		)
 	}
 
 	if request.Raw.StatusCode != http.StatusOK {
@@ -1200,7 +1210,7 @@ func (api *API) AddPageLabels(page *PageInfo, newLabels []string) (*LabelInfo, e
 		"content/"+page.ID+"/label", &LabelInfo{},
 	).Post(payload)
 	if err != nil {
-		return nil, err
+		return nil, newTransportError(request, "add labels to page "+page.ID, err)
 	}
 
 	if request.Raw.StatusCode != http.StatusOK {
@@ -1216,7 +1226,9 @@ func (api *API) DeletePageLabel(page *PageInfo, label string) (*LabelInfo, error
 		"content/"+page.ID+"/label", &LabelInfo{},
 	).SetQuery(map[string]string{"name": label}).Delete()
 	if err != nil {
-		return nil, err
+		return nil, newTransportError(
+			request, fmt.Sprintf("remove label %q from page %s", label, page.ID), err,
+		)
 	}
 
 	if request.Raw.StatusCode == http.StatusNoContent {
@@ -1254,7 +1266,7 @@ func (api *API) GetPageLabels(page *PageInfo, prefix string) (*LabelInfo, error)
 			"start":  fmt.Sprintf("%d", start),
 		})
 		if err != nil {
-			return nil, err
+			return nil, newTransportError(request, "read labels of page "+page.ID, err)
 		}
 
 		if request.Raw.StatusCode != http.StatusOK {
@@ -1320,7 +1332,7 @@ func (api *API) fetchUserByName(name string) (*User, error) {
 			"cql": fmt.Sprintf("user.fullname~%q", name),
 		})
 	if err != nil {
-		return nil, err
+		return nil, newTransportError(request, fmt.Sprintf("look up user %q", name), err)
 	}
 
 	// Try old path
@@ -1331,7 +1343,7 @@ func (api *API) fetchUserByName(name string) (*User, error) {
 				"cql": fmt.Sprintf("user.fullname~%q", name),
 			})
 		if err != nil {
-			return nil, err
+			return nil, newTransportError(request, fmt.Sprintf("look up user %q", name), err)
 		}
 		if request.Raw.StatusCode != http.StatusOK {
 			return nil, newErrorStatusNotOK(request)
@@ -1354,7 +1366,7 @@ func (api *API) GetCurrentUser() (*User, error) {
 		Res("current", &user).
 		Get()
 	if err != nil {
-		return nil, err
+		return nil, newTransportError(request, "read the current user", err)
 	}
 
 	if request.Raw.StatusCode != http.StatusOK {
@@ -1463,7 +1475,7 @@ func (api *API) RestrictPageUpdates(
 			},
 		})
 	if err != nil {
-		return err
+		return newTransportError(request, "restrict updates of page "+page.ID, err)
 	}
 
 	if request.Raw.StatusCode != http.StatusOK && request.Raw.StatusCode != http.StatusNoContent {
@@ -1704,7 +1716,9 @@ func (api *API) CreatePageWithFolderParent(
 	result := &PageInfo{}
 	request, err := api.v2().Res("pages", result).Post(payload)
 	if err != nil {
-		return nil, err
+		return nil, newTransportError(
+			request, fmt.Sprintf("create page %q under folder %s", title, folderID), err,
+		)
 	}
 
 	if request.Raw.StatusCode != http.StatusOK && request.Raw.StatusCode != http.StatusCreated {
@@ -1921,26 +1935,66 @@ func newErrorStatusNotOK(request *gopencils.Resource) error {
 		_ = request.Raw.Body.Close()
 	}()
 
+	// The URL is part of every one of these. mark makes several calls per page,
+	// and a status on its own does not say which of them refused.
+	target := requestTarget(request)
+
 	if request.Raw.StatusCode == http.StatusUnauthorized {
-		return errors.New(
-			"the Confluence API returned unexpected status: 401 (Unauthorized)",
+		return fmt.Errorf(
+			"the Confluence API returned unexpected status: 401 (Unauthorized) for %s",
+			target,
 		)
 	}
 
 	if request.Raw.StatusCode == http.StatusNotFound {
 		// Wrapped rather than a bare string so callers that need to act on
 		// "this is gone" specifically can ask with errors.Is instead of
-		// matching on the message. The rendered text is unchanged.
+		// matching on the message.
 		return fmt.Errorf(
-			"the Confluence API returned unexpected status: %w", ErrNotFound,
+			"the Confluence API returned unexpected status: %w for %s", ErrNotFound, target,
 		)
 	}
 
 	output, _ := io.ReadAll(request.Raw.Body)
 
 	return fmt.Errorf(
-		"the Confluence API returned unexpected status: %v, "+
+		"the Confluence API returned unexpected status: %v for %s, "+
 			"output: %q",
-		request.Raw.Status, output,
+		request.Raw.Status, target, output,
+	)
+}
+
+// requestTarget names the URL a request was made to, with any credentials in
+// it redacted.
+func requestTarget(request *gopencils.Resource) string {
+	if request == nil || request.Raw == nil ||
+		request.Raw.Request == nil || request.Raw.Request.URL == nil {
+		return "the Confluence API"
+	}
+
+	return request.Raw.Request.URL.Redacted()
+}
+
+// newTransportError explains an error the HTTP library returned in place of a
+// status.
+//
+// gopencils hands the JSON decode error straight back for any response below
+// 400 whose body it cannot parse, so newErrorStatusNotOK -- the one place that
+// builds a readable message -- is never reached for those. The common trigger
+// is a Confluence behind SSO answering 200 with an HTML login page, and what
+// reached the user was `invalid character '<' looking for beginning of value`:
+// no URL, no status, and no page name.
+func newTransportError(request *gopencils.Resource, operation string, err error) error {
+	// No response at all means the request never completed, and there is
+	// nothing to add beyond what it was trying to do.
+	if request == nil || request.Raw == nil {
+		return fmt.Errorf("unable to %s: %w", operation, err)
+	}
+
+	return fmt.Errorf(
+		"unable to %s: %s answered %s with a body that is not JSON "+
+			"(an SSO login page or a proxy interstitial in front of Confluence is the "+
+			"usual cause): %w",
+		operation, requestTarget(request), request.Raw.Status, err,
 	)
 }

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -889,7 +889,8 @@ func (api *API) CreatePage(
 
 func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, versionMessage string, appearance string, emojiString string) error {
 	nextPageVersion := page.Version.Number + 1
-	oldAncestors := []map[string]any{}
+
+	var oldAncestors []map[string]any
 
 	if page.Type != "blogpost" && len(page.Ancestors) > 0 {
 		// picking only the last one, which is required by confluence
@@ -933,7 +934,6 @@ func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, ve
 			"minorEdit": minorEdit,
 			"message":   versionMessage,
 		},
-		"ancestors": oldAncestors,
 		"body": map[string]any{
 			"storage": map[string]any{
 				"value":          newContent,
@@ -943,6 +943,16 @@ func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, ve
 		"metadata": map[string]any{
 			"properties": properties,
 		},
+	}
+
+	// ancestors on an update is how Confluence documents *moving* a page, so
+	// the key goes in only when there is an ancestor to name. A page created
+	// under a folder comes back from v2 with no ancestors at all -- folders are
+	// not ancestors -- and the update a moment later used to send
+	// "ancestors": [], which is at best ignored and at worst read as a request
+	// to reparent the page to the space root.
+	if len(oldAncestors) > 0 {
+		payload["ancestors"] = oldAncestors
 	}
 
 	request, err := api.v1().Res(

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -30,6 +30,12 @@ type API struct {
 	restV2  *gopencils.Resource
 	BaseURL string
 
+	// bearerToken is the Personal Access Token used when no username was
+	// given. It is kept here instead of being installed on rest/restV2 because
+	// those two would then hand it, and their whole header map, to every
+	// resource derived from them; see resource().
+	bearerToken string
+
 	isCloudFlag bool
 	isCloudOnce sync.Once
 
@@ -279,32 +285,63 @@ func NewAPI(baseURL string, username string, password string, insecureSkipVerify
 	// back with a nil error -- was never retried at all. retryTransport in the
 	// client handles both cases, and is the single place retries happen.
 	rest := gopencils.Api(baseURL+"/rest/api", auth, httpClient, 0)
-	if username == "" {
-		if rest.Headers == nil {
-			rest.Headers = http.Header{}
-		}
-		rest.SetHeader("Authorization", fmt.Sprintf("Bearer %s", password))
-	}
-
 	restV2 := gopencils.Api(baseURL+"/api/v2", auth, httpClient, 0) // v2 API for folders and new features
-	if username == "" {
-		if restV2.Headers == nil {
-			restV2.Headers = http.Header{}
-		}
-		restV2.SetHeader("Authorization", fmt.Sprintf("Bearer %s", password))
-	}
 
 	if zerolog.GlobalLevel() == zerolog.TraceLevel {
 		rest.Logger = &tracer{"rest:"}
 		restV2.Logger = &tracer{"rest-v2:"}
 	}
 
-	return &API{
+	api := &API{
 		rest:          rest,
 		restV2:        restV2,
 		BaseURL:       baseURL,
 		pageCache:     make(map[string]*PageInfo),
 		pageCacheByID: make(map[string]*PageInfo),
+	}
+
+	// A Personal Access Token arrives as the password with no username. It is
+	// recorded rather than installed on rest/restV2 so that resource() can put
+	// it on a header map belonging to one request.
+	if username == "" {
+		api.bearerToken = password
+	}
+
+	return api
+}
+
+// v1 returns a request-scoped resource rooted at /rest/api, and v2 the same for
+// /api/v2. Every call in this package starts from one of them.
+//
+// The indirection is what keeps one request's headers out of the next one's.
+// gopencils hands the same http.Header map to a resource and to everything
+// Res() derives from it, and after each response it copies that response's
+// headers into the map with Add. A header map installed on the two roots
+// therefore lived for the whole run: it grew one value per header per request,
+// and since gopencils sends the *first* value ever recorded for a key, a single
+// odd Content-Type -- an SSO login page, a proxy interstitial, anything
+// answering below 400 -- pinned that Content-Type on every later PUT and POST
+// body for the rest of the run. CreateAttachment used to escape this only by
+// rebinding Headers to a fresh map by hand.
+func (api *API) v1() *gopencils.Resource {
+	return api.resource(api.rest)
+}
+
+func (api *API) v2() *gopencils.Resource {
+	return api.resource(api.restV2)
+}
+
+func (api *API) resource(root *gopencils.Resource) *gopencils.Resource {
+	headers := http.Header{}
+	if api.bearerToken != "" {
+		headers.Set("Authorization", "Bearer "+api.bearerToken)
+	}
+
+	return &gopencils.Resource{
+		Api:     root.Api,
+		Url:     root.Url,
+		Headers: headers,
+		Logger:  root.Logger,
 	}
 }
 
@@ -336,7 +373,7 @@ func (api *API) FindHomePage(space string) (*PageInfo, error) {
 		"expand": "homepage",
 	}
 
-	v1Request, v1Err := api.rest.Res(
+	v1Request, v1Err := api.v1().Res(
 		"space/"+space, &SpaceInfo{},
 	).Get(payload)
 	if v1Err == nil && v1Request.Raw.StatusCode == http.StatusOK {
@@ -356,7 +393,7 @@ func (api *API) FindHomePage(space string) (*PageInfo, error) {
 		} `json:"results"`
 	}{}
 
-	v2Request, v2Err := api.restV2.Res(
+	v2Request, v2Err := api.v2().Res(
 		"spaces", &v2Result,
 	).Get(map[string]string{"keys": space})
 	if v2Err == nil && v2Request.Raw.StatusCode != http.StatusOK {
@@ -421,7 +458,7 @@ func (api *API) FindPage(
 		payload["title"] = title
 	}
 
-	request, err := api.rest.Res(
+	request, err := api.v1().Res(
 		"content/", &result,
 	).Get(payload)
 	if err != nil {
@@ -493,17 +530,15 @@ func (api *API) CreateAttachment(
 		Results []AttachmentInfo `json:"results"`
 	}
 
-	resource := api.rest.Res(
+	resource := api.v1().Res(
 		"content/"+pageID+"/child/attachment", &result,
 	)
 
 	resource.Payload = form.buffer
-	oldHeaders := resource.Headers.Clone()
-	resource.Headers = http.Header{}
-	if resource.Api.BasicAuth == nil {
-		resource.Headers.Set("Authorization", oldHeaders.Get("Authorization"))
-	}
-
+	// The multipart Content-Type has to be the only one on the request. It used
+	// to be set on a hand-made replacement header map because the map reached
+	// here carrying every header of every earlier response; resource() now
+	// gives each request a map of its own, so setting it is enough.
 	resource.SetHeader("Content-Type", form.writer.FormDataContentType())
 	resource.SetHeader("X-Atlassian-Token", "no-check")
 
@@ -563,17 +598,15 @@ func (api *API) UpdateAttachment(
 
 	var result json.RawMessage
 
-	resource := api.rest.Res(
+	resource := api.v1().Res(
 		"content/"+pageID+"/child/attachment/"+attachID+"/data", &result,
 	)
 
 	resource.Payload = form.buffer
-	oldHeaders := resource.Headers.Clone()
-	resource.Headers = http.Header{}
-	if resource.Api.BasicAuth == nil {
-		resource.Headers.Set("Authorization", oldHeaders.Get("Authorization"))
-	}
-
+	// The multipart Content-Type has to be the only one on the request. It used
+	// to be set on a hand-made replacement header map because the map reached
+	// here carrying every header of every earlier response; resource() now
+	// gives each request a map of its own, so setting it is enough.
 	resource.SetHeader("Content-Type", form.writer.FormDataContentType())
 	resource.SetHeader("X-Atlassian-Token", "no-check")
 
@@ -673,7 +706,7 @@ func (api *API) GetAttachments(pageID string) ([]AttachmentInfo, error) {
 			"start":  fmt.Sprintf("%d", start),
 		}
 
-		request, err := api.rest.Res(
+		request, err := api.v1().Res(
 			"content/"+pageID+"/child/attachment", &result,
 		).Get(payload)
 		if err != nil {
@@ -708,7 +741,7 @@ func (api *API) GetPageByID(pageID string) (*PageInfo, error) {
 }
 
 func (api *API) GetPageByIDExpanded(pageID string, expand string) (*PageInfo, error) {
-	request, err := api.rest.Res(
+	request, err := api.v1().Res(
 		"content/"+pageID, &PageInfo{},
 	).Get(map[string]string{"expand": expand})
 	if err != nil {
@@ -729,7 +762,7 @@ func (api *API) GetInlineComments(pageID string) (*InlineComments, error) {
 
 	for {
 		result := &InlineComments{}
-		request, err := api.rest.Res(
+		request, err := api.v1().Res(
 			"content/"+pageID+"/child/comment", result,
 		).Get(map[string]string{
 			"expand": "extensions.inlineProperties",
@@ -794,7 +827,7 @@ func (api *API) CreatePage(
 		}
 	}
 
-	request, err := api.rest.Res(
+	request, err := api.v1().Res(
 		"content/", &PageInfo{},
 	).Post(payload)
 	if err != nil {
@@ -912,7 +945,7 @@ func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, ve
 		},
 	}
 
-	request, err := api.rest.Res(
+	request, err := api.v1().Res(
 		"content/"+page.ID, &map[string]any{},
 	).Put(payload)
 	if err != nil {
@@ -976,7 +1009,7 @@ func (api *API) AddPageLabels(page *PageInfo, newLabels []string) (*LabelInfo, e
 
 	payload := labels
 
-	request, err := api.rest.Res(
+	request, err := api.v1().Res(
 		"content/"+page.ID+"/label", &LabelInfo{},
 	).Post(payload)
 	if err != nil {
@@ -992,7 +1025,7 @@ func (api *API) AddPageLabels(page *PageInfo, newLabels []string) (*LabelInfo, e
 
 func (api *API) DeletePageLabel(page *PageInfo, label string) (*LabelInfo, error) {
 
-	request, err := api.rest.Res(
+	request, err := api.v1().Res(
 		"content/"+page.ID+"/label", &LabelInfo{},
 	).SetQuery(map[string]string{"name": label}).Delete()
 	if err != nil {
@@ -1026,7 +1059,7 @@ func (api *API) GetPageLabels(page *PageInfo, prefix string) (*LabelInfo, error)
 	for {
 		var result labelPage
 
-		request, err := api.rest.Res(
+		request, err := api.v1().Res(
 			"content/"+page.ID+"/label", &result,
 		).Get(map[string]string{
 			"prefix": prefix,
@@ -1093,7 +1126,7 @@ func (api *API) fetchUserByName(name string) (*User, error) {
 	}
 
 	// Try the new path first
-	request, err := api.rest.
+	request, err := api.v1().
 		Res("search").
 		Res("user", &response).
 		Get(map[string]string{
@@ -1105,7 +1138,7 @@ func (api *API) fetchUserByName(name string) (*User, error) {
 
 	// Try old path
 	if request.Raw.StatusCode != http.StatusOK || len(response.Results) == 0 {
-		request, err = api.rest.
+		request, err = api.v1().
 			Res("search", &response).
 			Get(map[string]string{
 				"cql": fmt.Sprintf("user.fullname~%q", name),
@@ -1129,7 +1162,7 @@ func (api *API) fetchUserByName(name string) (*User, error) {
 func (api *API) GetCurrentUser() (*User, error) {
 	var user User
 
-	request, err := api.rest.
+	request, err := api.v1().
 		Res("user").
 		Res("current", &user).
 		Get()
@@ -1189,7 +1222,7 @@ func (api *API) IsCloud() bool {
 
 		// 2. Slow path: probe Cloud-only v2 API endpoint
 		var result any
-		request, err := api.restV2.Res("spaces", &result).Get(map[string]string{
+		request, err := api.v2().Res("spaces", &result).Get(map[string]string{
 			"limit": "1",
 		})
 		api.isCloudFlag = err == nil &&
@@ -1228,7 +1261,7 @@ func (api *API) RestrictPageUpdates(
 	}
 
 	var result any
-	request, err := api.rest.
+	request, err := api.v1().
 		Res("content").
 		Id(page.ID).
 		Res("restriction", &result).
@@ -1291,7 +1324,7 @@ func (api *API) CreateFolder(spaceID, title string, parentID *string, parentType
 		payload["parentType"] = parentType
 	}
 
-	request, err := api.restV2.Res(
+	request, err := api.v2().Res(
 		"folders", &FolderInfo{},
 	).Post(payload)
 	if err != nil {
@@ -1330,7 +1363,7 @@ func (api *API) FindFolder(spaceKey, title, underAncestorID string) (*FolderInfo
 		"expand": "content",
 	}
 
-	request, err := api.rest.Res(
+	request, err := api.v1().Res(
 		"search", &result,
 	).Get(payload)
 	if err != nil {
@@ -1355,7 +1388,7 @@ func (api *API) FindFolder(spaceKey, title, underAncestorID string) (*FolderInfo
 }
 
 func (api *API) GetFolderByID(folderID string) (*FolderInfo, error) {
-	request, err := api.restV2.Res(
+	request, err := api.v2().Res(
 		"folders/"+folderID, &FolderInfo{},
 	).Get()
 	if err != nil {
@@ -1389,7 +1422,7 @@ func (api *API) GetSpaceID(spaceKey string) (string, error) {
 	// about this field, which is what made the mismatch easy to miss.
 	var v1Result SpaceInfo
 
-	request, err := api.rest.Res("space/"+spaceKey, &v1Result).Get()
+	request, err := api.v1().Res("space/"+spaceKey, &v1Result).Get()
 	if err == nil && request.Raw.StatusCode == http.StatusOK && v1Result.ID != 0 {
 		return strconv.Itoa(v1Result.ID), nil
 	}
@@ -1406,7 +1439,7 @@ func (api *API) GetSpaceID(spaceKey string) (string, error) {
 		"keys": spaceKey,
 	}
 
-	request, err = api.restV2.Res(
+	request, err = api.v2().Res(
 		"spaces", &v2Result,
 	).Get(payload)
 	if err != nil {
@@ -1452,7 +1485,7 @@ func (api *API) CreatePageWithFolderParent(
 	}
 
 	result := &PageInfo{}
-	request, err := api.restV2.Res("pages", result).Post(payload)
+	request, err := api.v2().Res("pages", result).Post(payload)
 	if err != nil {
 		return nil, err
 	}
@@ -1502,7 +1535,7 @@ func (api *API) GetChildPages(parentID string) ([]PageInfo, error) {
 			Results []PageInfo `json:"results"`
 		}{}
 
-		request, err := api.rest.Res(
+		request, err := api.v1().Res(
 			"content/"+parentID+"/child/page", &result,
 		).Get(map[string]string{
 			"limit": fmt.Sprintf("%d", pageSize),
@@ -1539,7 +1572,7 @@ func (api *API) GetChildPages(parentID string) ([]PageInfo, error) {
 // make. A tool that removes pages because a file left a repository should leave
 // the last word to a person.
 func (api *API) DeletePage(contentID string) error {
-	request, err := api.rest.Res("content").Id(contentID, &struct{}{}).Delete()
+	request, err := api.v1().Res("content").Id(contentID, &struct{}{}).Delete()
 	if err != nil {
 		return fmt.Errorf("unable to delete content %s: %w", contentID, err)
 	}
@@ -1580,7 +1613,7 @@ func (api *API) ArchivePage(contentID string) error {
 		"pages": []map[string]any{{"id": id}},
 	}
 
-	request, err := api.rest.Res("content").Res("archive", &struct{}{}).Post(payload)
+	request, err := api.v1().Res("content").Res("archive", &struct{}{}).Post(payload)
 	if err != nil {
 		return fmt.Errorf("unable to archive content %s: %w", contentID, err)
 	}
@@ -1610,7 +1643,7 @@ func (api *API) MoveContentAppend(contentID, targetID string) error {
 func (api *API) moveContent(contentID, position, targetID string) error {
 	path := fmt.Sprintf("content/%s/move/%s/%s", contentID, position, targetID)
 	var result map[string]any
-	request, err := api.rest.Res(path, &result).Put(map[string]interface{}{})
+	request, err := api.v1().Res(path, &result).Put(map[string]interface{}{})
 	if err != nil {
 		return fmt.Errorf("failed to move content %s %s %s: %w", contentID, position, targetID, err)
 	}

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -45,6 +45,13 @@ type API struct {
 
 	userCache      map[string]userCacheEntry
 	userCacheMutex sync.RWMutex
+
+	// Both maps are keyed by space key and guarded by the one mutex: they
+	// answer the same question about the same thing and are always populated
+	// from the same place in a run.
+	homePageCache   map[string]homePageCacheEntry
+	spaceIDCache    map[string]spaceIDCacheEntry
+	spaceCacheMutex sync.RWMutex
 }
 
 // userCacheEntry records the outcome of a user lookup, including a failed one:
@@ -53,6 +60,20 @@ type API struct {
 type userCacheEntry struct {
 	user *User
 	err  error
+}
+
+// homePageCacheEntry and spaceIDCacheEntry record what a space lookup answered,
+// failures included. Neither answer can change while a run is in progress, and
+// a space that cannot be resolved cannot become resolvable either -- re-asking
+// only pays the same two round trips again for every file in the space.
+type homePageCacheEntry struct {
+	page *PageInfo
+	err  error
+}
+
+type spaceIDCacheEntry struct {
+	id  string
+	err error
 }
 
 func pageCacheKey(space, title, pageType string) string {
@@ -368,7 +389,39 @@ func (api *API) FindRootPage(space string) (*PageInfo, error) {
 	}, nil
 }
 
+// FindHomePage returns a space's home page.
+//
+// Results are cached for the lifetime of the API value, failures included. The
+// call is made for every non-blogpost document, again for any page that turns
+// out to have no ancestors, and once more when the manifest loads -- and it
+// costs two requests rather than one on a scoped token, because the v1 refusal
+// is what sends it to v2. A space's home page cannot change mid-run, so asking
+// twice can only ever get the same answer.
 func (api *API) FindHomePage(space string) (*PageInfo, error) {
+	if entry, ok := api.cachedHomePage(space); ok {
+		return clonePageInfo(entry.page), entry.err
+	}
+
+	page, err := api.fetchHomePage(space)
+
+	api.spaceCacheMutex.Lock()
+	if api.homePageCache == nil {
+		api.homePageCache = make(map[string]homePageCacheEntry)
+	}
+	api.homePageCache[space] = homePageCacheEntry{page: clonePageInfo(page), err: err}
+	api.spaceCacheMutex.Unlock()
+
+	return page, err
+}
+
+func (api *API) cachedHomePage(space string) (homePageCacheEntry, bool) {
+	api.spaceCacheMutex.RLock()
+	defer api.spaceCacheMutex.RUnlock()
+	entry, ok := api.homePageCache[space]
+	return entry, ok
+}
+
+func (api *API) fetchHomePage(space string) (*PageInfo, error) {
 	payload := map[string]string{
 		"expand": "homepage",
 	}
@@ -377,7 +430,19 @@ func (api *API) FindHomePage(space string) (*PageInfo, error) {
 		"space/"+space, &SpaceInfo{},
 	).Get(payload)
 	if v1Err == nil && v1Request.Raw.StatusCode == http.StatusOK {
-		return &v1Request.Response.(*SpaceInfo).Homepage, nil
+		homepage := &v1Request.Response.(*SpaceInfo).Homepage
+
+		// A 200 does not guarantee a homepage came with it. Returning the zero
+		// PageInfo handed the caller an empty id, which then went out as a
+		// content id -- a page published under nothing at all. v2 already tells
+		// "space has no homepage" apart from "no such space"; v1 says the same
+		// thing here rather than falling through to a v2 that does not exist on
+		// Server or Data Center.
+		if homepage.ID == "" {
+			return nil, fmt.Errorf("space %s has no home page", space)
+		}
+
+		return homepage, nil
 	}
 
 	// Any non-OK v1 answer falls through to v2, mirroring GetSpaceID. The case
@@ -1416,7 +1481,37 @@ func (api *API) GetFolderByID(folderID string) (*FolderInfo, error) {
 	return request.Response.(*FolderInfo), nil
 }
 
+// GetSpaceID resolves a space key to the numeric id v2 endpoints want.
+//
+// Cached for the lifetime of the API value, failures included, for the same
+// reason as FindHomePage: it is called for every file that has a folder in its
+// ancestry and once more per manifest load, and a space key's id does not move
+// while a run is going on.
 func (api *API) GetSpaceID(spaceKey string) (string, error) {
+	if entry, ok := api.cachedSpaceID(spaceKey); ok {
+		return entry.id, entry.err
+	}
+
+	id, err := api.fetchSpaceID(spaceKey)
+
+	api.spaceCacheMutex.Lock()
+	if api.spaceIDCache == nil {
+		api.spaceIDCache = make(map[string]spaceIDCacheEntry)
+	}
+	api.spaceIDCache[spaceKey] = spaceIDCacheEntry{id: id, err: err}
+	api.spaceCacheMutex.Unlock()
+
+	return id, err
+}
+
+func (api *API) cachedSpaceID(spaceKey string) (spaceIDCacheEntry, bool) {
+	api.spaceCacheMutex.RLock()
+	defer api.spaceCacheMutex.RUnlock()
+	entry, ok := api.spaceIDCache[spaceKey]
+	return entry, ok
+}
+
+func (api *API) fetchSpaceID(spaceKey string) (string, error) {
 	// Try v1 first: it looks a space up by key directly, where v2 has to be
 	// asked for a filtered collection.
 	//

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -468,6 +468,35 @@ func paginate[T any](r *http.Request, items []T) (page []T, hasNext bool) {
 	return items[start:end], end < len(items)
 }
 
+// cursorPage slices items the way the v2 API paginates: an opaque cursor
+// rather than a start offset, handed back inside a whole _links.next URL.
+//
+// The fake's cursor is the index of the next item. That is opaque enough that a
+// client cannot do arithmetic on it -- it has to read the link -- and simple
+// enough to be obviously right.
+func cursorPage[T any](r *http.Request, items []T) (page []T, next string) {
+	limit := 100
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	start := 0
+	if v := r.URL.Query().Get("cursor"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			start = n
+		}
+	}
+	if start >= len(items) {
+		return nil, ""
+	}
+	end := min(start+limit, len(items))
+	if end < len(items) {
+		next = strconv.Itoa(end)
+	}
+	return items[start:end], next
+}
+
 func linksWithNext(hasNext bool) map[string]any {
 	links := map[string]any{"base": "/wiki", "context": "/wiki"}
 	if hasNext {
@@ -750,13 +779,23 @@ func (s *Server) contentProperties(w http.ResponseWriter, r *http.Request, conte
 	switch r.Method {
 	case http.MethodGet:
 		if key == "" {
-			results := []map[string]any{}
+			// Paginated, because a real homepage carries the properties of
+			// every app installed on the instance and not just this one's.
+			var owned []*SpaceProperty
 			for _, p := range s.properties {
 				if p.OwnerID == contentID {
-					results = append(results, propertyJSON(p))
+					owned = append(owned, p)
 				}
 			}
-			writeJSON(w, http.StatusOK, map[string]any{"results": results})
+			page, hasNext := paginate(r, owned)
+			results := []map[string]any{}
+			for _, p := range page {
+				results = append(results, propertyJSON(p))
+			}
+			writeJSON(w, http.StatusOK, map[string]any{
+				"results": results,
+				"_links":  linksWithNext(hasNext),
+			})
 			return
 		}
 		p := find(key)
@@ -844,13 +883,27 @@ func (s *Server) spaceProperties(w http.ResponseWriter, r *http.Request, ownerID
 	switch r.Method {
 	case http.MethodGet:
 		key := r.URL.Query().Get("key")
-		results := []map[string]any{}
+		var owned []*SpaceProperty
 		for _, p := range s.properties {
 			if p.OwnerID == ownerID && (key == "" || p.Key == key) {
-				results = append(results, propertyJSON(p))
+				owned = append(owned, p)
 			}
 		}
-		writeJSON(w, http.StatusOK, map[string]any{"results": results})
+		// v2 pages by cursor, and names the next page as a URL rather than as
+		// an offset the client could have worked out for itself.
+		page, next := cursorPage(r, owned)
+		results := []map[string]any{}
+		for _, p := range page {
+			results = append(results, propertyJSON(p))
+		}
+		links := map[string]any{}
+		if next != "" {
+			links["next"] = fmt.Sprintf(
+				"/api/v2/spaces/%s/properties?cursor=%s&limit=%s",
+				ownerID, next, r.URL.Query().Get("limit"),
+			)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"results": results, "_links": links})
 
 	case http.MethodPost:
 		var payload struct {

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -1077,7 +1077,15 @@ func (s *Server) contentByID(w http.ResponseWriter, r *http.Request, id string) 
 		writeJSON(w, http.StatusOK, s.pageJSON(p))
 	case http.MethodPut:
 		var payload struct {
-			Title   string `json:"title"`
+			Title string `json:"title"`
+			// A pointer, so that an absent key and an empty list are different
+			// things. Confluence documents ancestors on an update as the way to
+			// move a page, which makes "ancestors": [] a request rather than a
+			// no-op, and that distinction is the whole question for a page
+			// whose parent is a folder.
+			Ancestors *[]struct {
+				ID string `json:"id"`
+			} `json:"ancestors"`
 			Version struct {
 				Number  int64  `json:"number"`
 				Message string `json:"message"`
@@ -1105,6 +1113,16 @@ func (s *Server) contentByID(w http.ResponseWriter, r *http.Request, id string) 
 		p.Body = payload.Body.Storage.Value
 		if payload.Title != "" {
 			p.Title = payload.Title
+		}
+		// An ancestors key that is present moves the page: to the last id it
+		// names, or -- when the list is empty -- to the root of the space.
+		if payload.Ancestors != nil {
+			parentID := ""
+			if n := len(*payload.Ancestors); n > 0 {
+				parentID = (*payload.Ancestors)[n-1].ID
+			}
+			p.ParentID = parentID
+			s.placeChild(parentID, p.ID, "")
 		}
 		writeJSON(w, http.StatusOK, s.pageJSON(p))
 	default:

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -41,6 +41,20 @@ type Page struct {
 	Archived bool
 }
 
+// Status is what v1 reports for the page and, more to the point, what it
+// filters lookups on. Trashed wins over archived: a page can be archived first
+// and trashed afterwards, and the trash is the state it is in.
+func (p *Page) Status() string {
+	switch {
+	case p.Trashed:
+		return "trashed"
+	case p.Archived:
+		return "archived"
+	default:
+		return "current"
+	}
+}
+
 // Attachment is a file attached to a page.
 type Attachment struct {
 	ID       string
@@ -427,6 +441,7 @@ func (s *Server) pageJSON(p *Page) map[string]any {
 		"id":        p.ID,
 		"title":     p.Title,
 		"type":      p.Type,
+		"status":    p.Status(),
 		"ancestors": ancestors,
 		"version": map[string]any{
 			"number":  p.Version,
@@ -968,6 +983,21 @@ func (s *Server) searchContent(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	spaceKey, title, pageType := q.Get("spaceKey"), q.Get("title"), q.Get("type")
 
+	// An absent status means current, which is the behaviour that hides an
+	// archived page from a lookup while it goes on owning its title. A fake
+	// that returned archived pages here would certify a client that can never
+	// see the problem. Comma-separated, as v1 accepts.
+	wanted := map[string]bool{}
+	for _, status := range strings.Split(q.Get("status"), ",") {
+		status = strings.TrimSpace(status)
+		if status != "" {
+			wanted[status] = true
+		}
+	}
+	if len(wanted) == 0 {
+		wanted["current"] = true
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -982,18 +1012,25 @@ func (s *Server) searchContent(w http.ResponseWriter, r *http.Request) {
 		if title != "" && p.Title != title {
 			continue
 		}
+		if !wanted["any"] && !wanted[p.Status()] {
+			continue
+		}
 		matches = append(matches, p)
 	}
 	// Deterministic ordering: the client takes results[0].
 	sort.Slice(matches, func(i, j int) bool { return matches[i].ID < matches[j].ID })
 
+	page, hasNext := paginate(r, matches)
+
 	results := []map[string]any{}
-	for _, p := range matches {
+	for _, p := range page {
 		results = append(results, s.pageJSON(p))
 	}
+	links := linksWithNext(hasNext)
+	links["base"] = "/wiki"
 	writeJSON(w, http.StatusOK, map[string]any{
 		"results": results,
-		"_links":  map[string]any{"base": "/wiki"},
+		"_links":  links,
 	})
 }
 
@@ -1116,13 +1153,19 @@ func (s *Server) contentByID(w http.ResponseWriter, r *http.Request, id string) 
 		}
 		// An ancestors key that is present moves the page: to the last id it
 		// names, or -- when the list is empty -- to the root of the space.
+		//
+		// Naming the parent a page already has is not a move, and must not
+		// disturb where the page sits among its siblings; only a real change of
+		// parent re-places it.
 		if payload.Ancestors != nil {
 			parentID := ""
 			if n := len(*payload.Ancestors); n > 0 {
 				parentID = (*payload.Ancestors)[n-1].ID
 			}
-			p.ParentID = parentID
-			s.placeChild(parentID, p.ID, "")
+			if parentID != p.ParentID {
+				p.ParentID = parentID
+				s.placeChild(parentID, p.ID, "")
+			}
 		}
 		writeJSON(w, http.StatusOK, s.pageJSON(p))
 	default:

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -1026,11 +1026,9 @@ func (s *Server) searchContent(w http.ResponseWriter, r *http.Request) {
 	for _, p := range page {
 		results = append(results, s.pageJSON(p))
 	}
-	links := linksWithNext(hasNext)
-	links["base"] = "/wiki"
 	writeJSON(w, http.StatusOK, map[string]any{
 		"results": results,
-		"_links":  links,
+		"_links":  linksWithNext(hasNext),
 	})
 }
 

--- a/confluence/errors_test.go
+++ b/confluence/errors_test.go
@@ -1,0 +1,110 @@
+package confluence_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ssoLoginPage stands in for a Confluence behind single sign-on: the proxy
+// answers 200 with an HTML login form instead of passing the API call through.
+// A 200 means the HTTP library decodes the body and hands the decode error
+// straight back, so the one place that builds a readable message is skipped.
+func ssoLoginPage() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<!doctype html><html><body>Sign in to continue</body></html>"))
+	}))
+}
+
+// TestNonJSONSuccessSaysWhatFailed pins the class of bug where a failure
+// surfaces as a bare JSON parse error.
+//
+// What the user used to get was `invalid character '<' looking for beginning of
+// value` -- no URL, no status, no page name, and nothing to suggest an SSO
+// proxy was the cause.
+func TestNonJSONSuccessSaysWhatFailed(t *testing.T) {
+	server := ssoLoginPage()
+	defer server.Close()
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	_, err := api.FindPage("DOCS", "Getting Started", "page")
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "find page", "the operation has to be named")
+	assert.Contains(t, err.Error(), "Getting Started", "and its subject")
+	assert.Contains(t, err.Error(), "DOCS")
+	assert.Contains(t, err.Error(), server.URL, "and the URL that answered")
+	assert.Contains(t, err.Error(), "200 OK", "and the status it answered with")
+	assert.Contains(t, err.Error(), "SSO", "and the cause worth checking first")
+}
+
+// TestNonJSONSuccessIsExplainedOnEveryVerb: the same proxy sits in front of
+// every call, so a create and an update must be as legible as a lookup.
+func TestNonJSONSuccessIsExplainedOnEveryVerb(t *testing.T) {
+	server := ssoLoginPage()
+	defer server.Close()
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	_, err := api.CreatePage("DOCS", "page", nil, "New Page", "<p/>")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create page")
+	assert.Contains(t, err.Error(), "New Page")
+
+	page := &confluence.PageInfo{ID: "1004", Title: "Existing", Type: "page"}
+	err = api.UpdatePage(page, "<p/>", false, "", "full-width", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "update page")
+	assert.Contains(t, err.Error(), "Existing")
+	assert.Contains(t, err.Error(), "1004")
+}
+
+// TestStatusErrorsCarryTheURL covers the other half: a status that is not OK
+// says which of the several calls mark makes per page produced it.
+func TestStatusErrorsCarryTheURL(t *testing.T) {
+	for name, status := range map[string]int{
+		"unauthorized": http.StatusUnauthorized,
+		"not found":    http.StatusNotFound,
+		"server error": http.StatusBadRequest,
+	} {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{"message":"no"}`))
+			}))
+			defer server.Close()
+
+			api := confluence.NewAPI(server.URL, "user", "token", false)
+
+			_, err := api.GetPageByID("1004")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), server.URL)
+			assert.Contains(t, err.Error(), "/rest/api/content/1004")
+		})
+	}
+}
+
+// TestNotFoundStaysASentinel: callers ask "is this gone?" with errors.Is, and
+// adding the URL to the message must not break that.
+func TestNotFoundStaysASentinel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"gone"}`))
+	}))
+	defer server.Close()
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	_, err := api.GetPageByID("1004")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, confluence.ErrNotFound)
+}

--- a/confluence/headers_test.go
+++ b/confluence/headers_test.go
@@ -1,0 +1,96 @@
+package confluence_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResponseHeadersDoNotLeakIntoLaterRequests pins the class of bug where one
+// response's headers are echoed back on every request that follows it.
+//
+// gopencils hands the same http.Header map to a resource and to everything
+// Res() derives from it, and after each response copies that response's headers
+// into the map with Add. With the Authorization header installed on the root
+// resource -- which is what a Personal Access Token used to do -- that map
+// lived for the whole run. Because gopencils sends the *first* value ever
+// recorded for a key, a single odd Content-Type on any sub-400 response pinned
+// that Content-Type on every later PUT and POST body, and Confluence rejects a
+// storage-format update announced as text/html.
+func TestResponseHeadersDoNotLeakIntoLaterRequests(t *testing.T) {
+	var (
+		putContentType string
+		putOddHeader   string
+		putAuth        string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			// A proxy interstitial or SSO shim in front of Confluence,
+			// announcing HTML while still passing the JSON body through.
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Header().Set("X-Odd-Header", "from-a-response")
+			_, _ = w.Write([]byte(
+				`{"results":[{"id":"1001","title":"Leaky","type":"page",` +
+					`"version":{"number":1}}],"_links":{"base":"/wiki"}}`,
+			))
+		case http.MethodPut:
+			putContentType = r.Header.Get("Content-Type")
+			putOddHeader = r.Header.Get("X-Odd-Header")
+			putAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	// A Personal Access Token: no username, which is the setup that used to
+	// install a long-lived header map on the root resource.
+	api := confluence.NewAPI(server.URL, "", "pat-token", false)
+
+	page, err := api.FindPage("DOCS", "Leaky", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+
+	require.NoError(t, api.UpdatePage(page, "<p>body</p>", false, "", "full-width", ""))
+
+	assert.Equal(t, "application/json", putContentType,
+		"the GET response's Content-Type must not survive into the update body")
+	assert.Empty(t, putOddHeader,
+		"no response header may be echoed back on a later request")
+	assert.Equal(t, "Bearer pat-token", putAuth,
+		"the token still has to be sent on every request")
+}
+
+// TestAuthorizationIsSentOnEveryRequest guards the other half of the fix:
+// moving the Personal Access Token off the shared root resource must not stop
+// it from reaching the wire, on either API version.
+func TestAuthorizationIsSentOnEveryRequest(t *testing.T) {
+	var seen []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[],"_links":{"base":"/wiki"}}`))
+	}))
+	defer server.Close()
+
+	api := confluence.NewAPI(server.URL, "", "pat-token", false)
+
+	_, err := api.FindPage("DOCS", "Anything", "page")
+	require.NoError(t, err)
+	_, err = api.GetFolderByID("2001")
+	require.NoError(t, err)
+
+	require.Len(t, seen, 2)
+	for i, got := range seen {
+		assert.Equal(t, "Bearer pat-token", got, "request %d carried no token", i)
+	}
+}

--- a/confluence/move_test.go
+++ b/confluence/move_test.go
@@ -1,0 +1,98 @@
+package confluence_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMoveOnServerSaysTheEndpointIsCloudOnly pins the class of bug where a
+// Cloud-only endpoint is called with no capability check at all.
+//
+// content/{id}/move is reached whenever a page's ancestry stops matching its
+// headers, and whenever pages are ordered. Folder creation is gated on
+// IsCloud() and RestrictPageUpdates detects the old-Server case and says so;
+// this path did neither, so a Server or Data Center user reorganising a docs
+// tree got a bare 404 and nothing to act on.
+func TestMoveOnServerSaysTheEndpointIsCloudOnly(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Confluence Server: no /api/v2 at all, and no content move endpoint.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"no such endpoint"}`))
+	}))
+	defer server.Close()
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	require.False(t, api.IsCloud(), "the fixture has to look like Server for this to mean anything")
+
+	for name, move := range map[string]func() error{
+		"append": func() error { return api.MoveContentAppend("1004", "1003") },
+		"before": func() error { return api.MoveContentBefore("1004", "1005") },
+		"after":  func() error { return api.MoveContentAfter("1004", "1005") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := move()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "not Cloud")
+			assert.Contains(t, err.Error(), "1004", "the page being moved has to be named")
+			assert.Contains(t, err.Error(), "404", "and the status it was refused with")
+		})
+	}
+}
+
+// TestMoveNamesThePageByTitleWhenItCanUses the page cache rather than a second
+// request: the call is only reached once something has already gone wrong.
+func TestMoveNamesThePageByTitleWhenItCan(t *testing.T) {
+	var moveRefused bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/move/") {
+			moveRefused = true
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			_, _ = w.Write([]byte(`{"message":"method not allowed"}`))
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/api/v2") {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"no v2 here"}`))
+			return
+		}
+		_, _ = w.Write([]byte(
+			`{"results":[{"id":"1004","title":"Release Notes","type":"page",` +
+				`"status":"current","version":{"number":1}}],"_links":{"base":"/wiki"}}`,
+		))
+	}))
+	defer server.Close()
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	page, err := api.FindPage("DOCS", "Release Notes", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+
+	err = api.MoveContentAppend(page.ID, "1003")
+	require.Error(t, err)
+	require.True(t, moveRefused)
+	assert.Contains(t, err.Error(), `"Release Notes"`,
+		"a person reading this has to know which page could not be moved")
+}
+
+// TestMoveOnCloudStillReportsAPlain404: the capability message must not swallow
+// a 404 that really is a missing page, which on Cloud is what one means.
+func TestMoveOnCloudStillReportsAPlain404(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddSpace("DOCS")
+	require.True(t, api.IsCloud(), "the fake answers /api/v2/spaces, so it is Cloud")
+
+	err := api.MoveContentAppend("no-such-page", "1003")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+	assert.NotContains(t, err.Error(), "not Cloud")
+}

--- a/confluence/property.go
+++ b/confluence/property.go
@@ -90,7 +90,7 @@ func (api *API) ListSpaceProperties(spaceID string) ([]Property, error) {
 			Res("properties", &result).
 			Get(query)
 		if err != nil {
-			return nil, fmt.Errorf("unable to read properties of space %s: %w", spaceID, err)
+			return nil, newTransportError(request, "read properties of space "+spaceID, err)
 		}
 
 		// A space with no properties at all answers 404 rather than an empty
@@ -166,7 +166,9 @@ func (api *API) SetSpaceProperty(spaceID, key string, value []byte, existing *Pr
 		request, err = space.Res("properties").Res(existing.ID, &result).Put(payload)
 	}
 	if err != nil {
-		return fmt.Errorf("unable to write property %q of space %s: %w", key, spaceID, err)
+		return newTransportError(
+			request, fmt.Sprintf("write property %q of space %s", key, spaceID), err,
+		)
 	}
 
 	return propertyWriteResult(request, key, "space "+spaceID, existing == nil)
@@ -198,7 +200,7 @@ func (api *API) ListContentProperties(contentID string) ([]Property, error) {
 				"start": strconv.Itoa(start),
 			})
 		if err != nil {
-			return nil, fmt.Errorf("unable to read properties of content %s: %w", contentID, err)
+			return nil, newTransportError(request, "read properties of content "+contentID, err)
 		}
 
 		// Only the first page may read 404 as "none set"; one partway through
@@ -253,7 +255,9 @@ func (api *API) SetContentProperty(contentID, key string, value []byte, existing
 		request, err = content.Res("property").Res(key, &result).Put(payload)
 	}
 	if err != nil {
-		return fmt.Errorf("unable to write property %q of content %s: %w", key, contentID, err)
+		return newTransportError(
+			request, fmt.Sprintf("write property %q of content %s", key, contentID), err,
+		)
 	}
 
 	return propertyWriteResult(request, key, "content "+contentID, existing == nil)

--- a/confluence/property.go
+++ b/confluence/property.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strconv"
 
 	"github.com/kovetskiy/gopencils"
 )
@@ -26,16 +28,34 @@ type Property struct {
 	} `json:"version"`
 }
 
-// propertyPageSize is requested when listing properties. Callers here hold a
-// small fixed number of them, so one page is always enough and no pagination
-// loop is needed; asking explicitly keeps that true regardless of what the
-// server's default page size happens to be.
-const propertyPageSize = "100"
+// propertyPageSize is requested when listing properties.
+//
+// One page is never enough on its own, whatever the caller holds. Properties
+// belong to the object, not to the app that wrote them: on Server and Data
+// Center every one of mark's manifest shards is a content property of the space
+// homepage, sitting next to `editor`, `content-appearance-published`, the
+// emoji-title keys and whatever else any installed app has put there. Once the
+// total passes a page and a shard falls off the end, the caller sees no
+// property, treats every mapping it held as absent, and its next write POSTs a
+// key that already exists. Both listings therefore read to the end of the
+// collection.
+const propertyPageSize = 100
 
 // ErrPropertyConflict reports that a property write lost a race with another
 // writer. It is separate from a generic error so a caller can re-read and retry
 // on exactly this case and nothing else.
 var ErrPropertyConflict = errors.New("property version conflict")
+
+// ErrPropertyUnseen reports that a create collided with a property the listing
+// never showed.
+//
+// This is what an incomplete listing looks like from the write side: the key is
+// there, this run did not see it, and everything it held has already been
+// treated as absent. It is deliberately not an ErrPropertyConflict, which
+// callers report as "updated by a concurrent run" and carry on from -- that
+// diagnosis is wrong here, and carrying on loses the same data again on every
+// run afterwards.
+var ErrPropertyUnseen = errors.New("property already exists but was not listed")
 
 // ListSpaceProperties returns every property stored against a space.
 //
@@ -48,30 +68,76 @@ var ErrPropertyConflict = errors.New("property version conflict")
 // key. A space with none is not an error: the first run of anything that stores
 // state this way finds nothing, and that is the normal case.
 func (api *API) ListSpaceProperties(spaceID string) ([]Property, error) {
-	var result struct {
-		Results []Property `json:"results"`
+	var all []Property
+	var cursor string
+
+	for {
+		var result struct {
+			Results []Property `json:"results"`
+			Links   struct {
+				Next string `json:"next"`
+			} `json:"_links"`
+		}
+
+		query := map[string]string{"limit": strconv.Itoa(propertyPageSize)}
+		if cursor != "" {
+			query["cursor"] = cursor
+		}
+
+		request, err := api.v2().
+			Res("spaces").
+			Res(spaceID).
+			Res("properties", &result).
+			Get(query)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read properties of space %s: %w", spaceID, err)
+		}
+
+		// A space with no properties at all answers 404 rather than an empty
+		// collection, so both shapes have to mean "none set". First page only:
+		// a 404 partway through is a real failure, and reading it as "none"
+		// would throw away the pages already in hand.
+		if request.Raw.StatusCode == http.StatusNotFound && cursor == "" {
+			return nil, nil
+		}
+
+		if request.Raw.StatusCode != http.StatusOK {
+			return nil, newErrorStatusNotOK(request)
+		}
+
+		all = append(all, result.Results...)
+
+		next := nextCursor(result.Links.Next)
+		// A server that hands back the cursor it was given would otherwise
+		// keep this loop going for as long as it keeps answering.
+		if next == "" || next == cursor {
+			break
+		}
+		cursor = next
 	}
 
-	request, err := api.v2().
-		Res("spaces").
-		Res(spaceID).
-		Res("properties", &result).
-		Get(map[string]string{"limit": propertyPageSize})
+	return all, nil
+}
+
+// nextCursor pulls the cursor out of a v2 _links.next.
+//
+// v2 paginates by an opaque cursor rather than by offset, and names the next
+// page as a whole URL -- relative on some deployments, absolute on others -- of
+// which the cursor is the only part worth reusing. Rebuilding the request
+// around it rather than following the link keeps this client's base URL and
+// headers, which is what makes the loop work through the scoped-token gateway
+// as well as against a tenant directly.
+func nextCursor(next string) string {
+	if next == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(next)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read properties of space %s: %w", spaceID, err)
+		return ""
 	}
 
-	// A space with no properties at all answers 404 rather than an empty
-	// collection, so both shapes have to mean "none set".
-	if request.Raw.StatusCode == http.StatusNotFound {
-		return nil, nil
-	}
-
-	if request.Raw.StatusCode != http.StatusOK {
-		return nil, newErrorStatusNotOK(request)
-	}
-
-	return result.Results, nil
+	return parsed.Query().Get("cursor")
 }
 
 // SetSpaceProperty writes value to a space property, creating it if absent.
@@ -103,7 +169,7 @@ func (api *API) SetSpaceProperty(spaceID, key string, value []byte, existing *Pr
 		return fmt.Errorf("unable to write property %q of space %s: %w", key, spaceID, err)
 	}
 
-	return propertyWriteResult(request, key, "space "+spaceID)
+	return propertyWriteResult(request, key, "space "+spaceID, existing == nil)
 }
 
 // ListContentProperties returns every property stored against a page.
@@ -112,28 +178,51 @@ func (api *API) SetSpaceProperty(spaceID, key string, value []byte, existing *Pr
 // Center as well as Cloud, which is what makes it usable as the storage of last
 // resort on a non-Cloud instance.
 func (api *API) ListContentProperties(contentID string) ([]Property, error) {
-	var result struct {
-		Results []Property `json:"results"`
+	var all []Property
+	start := 0
+
+	for {
+		var result struct {
+			Results []Property `json:"results"`
+			Links   struct {
+				Next string `json:"next"`
+			} `json:"_links"`
+		}
+
+		request, err := api.v1().
+			Res("content").
+			Res(contentID).
+			Res("property", &result).
+			Get(map[string]string{
+				"limit": strconv.Itoa(propertyPageSize),
+				"start": strconv.Itoa(start),
+			})
+		if err != nil {
+			return nil, fmt.Errorf("unable to read properties of content %s: %w", contentID, err)
+		}
+
+		// Only the first page may read 404 as "none set"; one partway through
+		// is a failure, and swallowing it would discard the pages already read.
+		if request.Raw.StatusCode == http.StatusNotFound && start == 0 {
+			return nil, nil
+		}
+
+		if request.Raw.StatusCode != http.StatusOK {
+			return nil, newErrorStatusNotOK(request)
+		}
+
+		all = append(all, result.Results...)
+
+		// _links.next is the server's own word on whether more exist; the short
+		// page is the second condition because a deployment that omits the link
+		// would otherwise be asked for the same page forever.
+		if result.Links.Next == "" || len(result.Results) < propertyPageSize {
+			break
+		}
+		start += len(result.Results)
 	}
 
-	request, err := api.v1().
-		Res("content").
-		Res(contentID).
-		Res("property", &result).
-		Get(map[string]string{"limit": propertyPageSize})
-	if err != nil {
-		return nil, fmt.Errorf("unable to read properties of content %s: %w", contentID, err)
-	}
-
-	if request.Raw.StatusCode == http.StatusNotFound {
-		return nil, nil
-	}
-
-	if request.Raw.StatusCode != http.StatusOK {
-		return nil, newErrorStatusNotOK(request)
-	}
-
-	return result.Results, nil
+	return all, nil
 }
 
 // SetContentProperty writes value to a page property, creating it if absent.
@@ -167,17 +256,30 @@ func (api *API) SetContentProperty(contentID, key string, value []byte, existing
 		return fmt.Errorf("unable to write property %q of content %s: %w", key, contentID, err)
 	}
 
-	return propertyWriteResult(request, key, "content "+contentID)
+	return propertyWriteResult(request, key, "content "+contentID, existing == nil)
 }
 
 // propertyWriteResult turns a property write response into an error, singling
 // out the version conflict so a caller can react to losing a race and nothing
 // else.
-func propertyWriteResult(request *gopencils.Resource, key, subject string) error {
+//
+// creating says whether the caller believed the key was absent, which is what
+// tells the two ways a 409 arrives apart. Losing a race to another writer is
+// ordinary and survivable. Colliding with a key that was there the whole time
+// is neither: it means the listing this run worked from was incomplete, so
+// whatever that property held has already been treated as missing.
+func propertyWriteResult(request *gopencils.Resource, key, subject string, creating bool) error {
 	switch request.Raw.StatusCode {
 	case http.StatusOK, http.StatusCreated:
 		return nil
 	case http.StatusConflict:
+		if creating {
+			return fmt.Errorf(
+				"property %q of %s already exists but was not in the listing this run read, "+
+					"so anything it held has been treated as absent: %w",
+				key, subject, ErrPropertyUnseen,
+			)
+		}
 		return fmt.Errorf(
 			"property %q of %s was modified concurrently: %w",
 			key, subject, ErrPropertyConflict,

--- a/confluence/property.go
+++ b/confluence/property.go
@@ -52,7 +52,7 @@ func (api *API) ListSpaceProperties(spaceID string) ([]Property, error) {
 		Results []Property `json:"results"`
 	}
 
-	request, err := api.restV2.
+	request, err := api.v2().
 		Res("spaces").
 		Res(spaceID).
 		Res("properties", &result).
@@ -87,7 +87,7 @@ func (api *API) SetSpaceProperty(spaceID, key string, value []byte, existing *Pr
 		err     error
 	)
 
-	space := api.restV2.Res("spaces").Res(spaceID)
+	space := api.v2().Res("spaces").Res(spaceID)
 
 	if existing == nil {
 		// The result pointer goes on the collection resource itself: routing it
@@ -116,7 +116,7 @@ func (api *API) ListContentProperties(contentID string) ([]Property, error) {
 		Results []Property `json:"results"`
 	}
 
-	request, err := api.rest.
+	request, err := api.v1().
 		Res("content").
 		Res(contentID).
 		Res("property", &result).
@@ -149,7 +149,7 @@ func (api *API) SetContentProperty(contentID, key string, value []byte, existing
 		err     error
 	)
 
-	content := api.rest.Res("content").Res(contentID)
+	content := api.v1().Res("content").Res(contentID)
 
 	if existing == nil {
 		request, err = content.Res("property", &result).Post(payload)

--- a/confluence/property_test.go
+++ b/confluence/property_test.go
@@ -1,0 +1,127 @@
+package confluence_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListContentPropertiesReadsEveryPage pins the class of bug where a listing
+// stops at the first page and the caller cannot tell.
+//
+// On Server and Data Center every manifest shard is a content property of the
+// space homepage, sharing that object with `editor`,
+// `content-appearance-published`, the emoji-title keys and every other app on
+// the instance. Past one page a shard silently disappears from the listing, the
+// caller loses every mapping it held, and its next write POSTs a key that
+// already exists.
+func TestListContentPropertiesReadsEveryPage(t *testing.T) {
+	api, server := newAPI(t)
+	page := server.AddPage("DOCS", "Home", "page", "")
+
+	const total = 250
+	for i := range total {
+		server.SetSpaceProperty(page.ID, fmt.Sprintf("key-%03d", i), []byte(`"v"`))
+	}
+
+	properties, err := api.ListContentProperties(page.ID)
+	require.NoError(t, err)
+	assert.Len(t, properties, total, "every page of the collection has to be read")
+
+	seen := map[string]bool{}
+	for _, p := range properties {
+		seen[p.Key] = true
+	}
+	assert.True(t, seen["key-249"], "the last property must survive the walk")
+
+	assert.Equal(t, 3, server.CountRequests("GET", "/content/"+page.ID+"/property"),
+		"250 properties at 100 per page is three requests")
+}
+
+// TestListSpacePropertiesFollowsTheCursor is the v2 half of the same bug. v2
+// pages by an opaque cursor rather than by offset, so the client has to read
+// _links.next instead of counting.
+func TestListSpacePropertiesFollowsTheCursor(t *testing.T) {
+	api, server := newAPI(t)
+	space := server.AddSpace("DOCS")
+
+	const total = 250
+	for i := range total {
+		server.SetSpaceProperty(space.ID, fmt.Sprintf("key-%03d", i), []byte(`"v"`))
+	}
+
+	properties, err := api.ListSpaceProperties(space.ID)
+	require.NoError(t, err)
+	assert.Len(t, properties, total)
+
+	last := properties[len(properties)-1]
+	assert.Equal(t, "key-249", last.Key)
+
+	assert.Equal(t, 3, server.CountRequests("GET", "/spaces/"+space.ID+"/properties"))
+}
+
+// TestListPropertiesOnAnEmptyOwnerIsNotAnError keeps the ordinary first-run
+// case working through the new loop: nothing stored is not a failure.
+func TestListPropertiesOnAnEmptyOwnerIsNotAnError(t *testing.T) {
+	api, server := newAPI(t)
+	space := server.AddSpace("DOCS")
+	page := server.AddPage("DOCS", "Home", "page", "")
+
+	spaceProperties, err := api.ListSpaceProperties(space.ID)
+	require.NoError(t, err)
+	assert.Empty(t, spaceProperties)
+
+	contentProperties, err := api.ListContentProperties(page.ID)
+	require.NoError(t, err)
+	assert.Empty(t, contentProperties)
+}
+
+// TestCreatingAPropertyThatAlreadyExistsIsLoud pins the diagnosis, which is the
+// half of the pagination bug that made it permanent.
+//
+// A create that collides with a key nothing listed is not a lost race. It says
+// the listing was incomplete and its mappings have already been dropped.
+// Reporting it as ErrPropertyConflict made callers log "updated by a concurrent
+// run" and carry on, losing the same data again on every run afterwards.
+func TestCreatingAPropertyThatAlreadyExistsIsLoud(t *testing.T) {
+	api, server := newAPI(t)
+	space := server.AddSpace("DOCS")
+	page := server.AddPage("DOCS", "Home", "page", "")
+
+	server.SetSpaceProperty(space.ID, "mark:manifest:0", []byte(`{"v":1}`))
+	server.SetSpaceProperty(page.ID, "mark:manifest:0", []byte(`{"v":1}`))
+
+	// existing == nil is the caller saying "the listing showed no such key".
+	err := api.SetSpaceProperty(space.ID, "mark:manifest:0", []byte(`{"v":2}`), nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, confluence.ErrPropertyUnseen)
+	assert.NotErrorIs(t, err, confluence.ErrPropertyConflict,
+		"a caller that treats this as a lost race carries on losing the data")
+
+	err = api.SetContentProperty(page.ID, "mark:manifest:0", []byte(`{"v":2}`), nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, confluence.ErrPropertyUnseen)
+}
+
+// TestStalePropertyUpdateStaysAConflict is the counterpart: a write that names
+// a version it no longer supersedes really is a lost race, and callers depend
+// on being able to shrug that one off.
+func TestStalePropertyUpdateStaysAConflict(t *testing.T) {
+	api, server := newAPI(t)
+	space := server.AddSpace("DOCS")
+
+	stored := server.SetSpaceProperty(space.ID, "mark:manifest:0", []byte(`{"v":1}`))
+	// Somebody else has written since; the version in hand is one behind.
+	server.SetSpaceProperty(space.ID, "mark:manifest:0", []byte(`{"v":2}`))
+
+	stale := &confluence.Property{ID: stored.ID, Key: stored.Key}
+	stale.Version.Number = stored.Version
+
+	err := api.SetSpaceProperty(space.ID, "mark:manifest:0", []byte(`{"v":3}`), stale)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, confluence.ErrPropertyConflict)
+	assert.NotErrorIs(t, err, confluence.ErrPropertyUnseen)
+}

--- a/confluence/space_test.go
+++ b/confluence/space_test.go
@@ -1,0 +1,104 @@
+package confluence_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindHomePageIsCached pins the N+1 this call used to be. It is made for
+// every non-blogpost document, again for any page that turns out to have no
+// ancestors, and once more when the manifest loads; on a scoped token each of
+// those costs two round trips, because the v1 refusal is what sends it to v2.
+func TestFindHomePageIsCached(t *testing.T) {
+	api, server := newAPI(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+
+	for range 20 {
+		page, err := api.FindHomePage("DOCS")
+		require.NoError(t, err)
+		require.NotNil(t, page)
+		assert.Equal(t, home.ID, page.ID)
+	}
+
+	assert.Equal(t, 1, server.CountRequests("GET", "/rest/api/space/DOCS"),
+		"twenty files in one space should cost one space lookup")
+}
+
+// TestFindHomePageCachesFailures covers the case the cache can least afford to
+// skip: a space that cannot be resolved cannot become resolvable mid-run, and
+// re-asking pays both round trips again for every file in it.
+func TestFindHomePageCachesFailures(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddSpace("DOCS")
+	server.SetFail(scopedTokenV1Gone(http.StatusNotFound))
+
+	for range 5 {
+		_, err := api.FindHomePage("NOPE")
+		require.Error(t, err)
+	}
+
+	assert.Equal(t, 1, server.CountRequests("GET", "/rest/api/space/NOPE"))
+	assert.Equal(t, 1, server.CountRequests("GET", "/api/v2/spaces"))
+}
+
+// TestGetSpaceIDIsCached is the same property for the other space lookup, which
+// is made once per folder-bearing file.
+func TestGetSpaceIDIsCached(t *testing.T) {
+	api, server := newAPI(t)
+	space := server.AddSpace("DOCS")
+
+	for range 20 {
+		id, err := api.GetSpaceID("DOCS")
+		require.NoError(t, err)
+		assert.Equal(t, space.ID, id)
+	}
+
+	assert.Equal(t, 1, server.CountRequests("GET", "/rest/api/space/DOCS"))
+}
+
+func TestGetSpaceIDCachesPerKey(t *testing.T) {
+	api, server := newAPI(t)
+	docs := server.AddSpace("DOCS")
+	team := server.AddSpace("TEAM")
+
+	for range 3 {
+		id, err := api.GetSpaceID("DOCS")
+		require.NoError(t, err)
+		assert.Equal(t, docs.ID, id)
+
+		id, err = api.GetSpaceID("TEAM")
+		require.NoError(t, err)
+		assert.Equal(t, team.ID, id)
+	}
+
+	assert.Equal(t, 1, server.CountRequests("GET", "/rest/api/space/DOCS"))
+	assert.Equal(t, 1, server.CountRequests("GET", "/rest/api/space/TEAM"))
+}
+
+// TestFindHomePageV1WithoutAHomepageIsAnError pins the class of bug where a 200
+// is taken as an answer without checking that an answer came with it.
+//
+// v1 returns the space whether or not the homepage expansion produced anything,
+// and the zero PageInfo that came back carried an empty id -- which callers
+// then used as a content id, publishing under nothing at all. The v2 path has
+// always distinguished "space has no homepage" from "space not found"; v1 has
+// to say the same thing rather than falling through to a v2 that does not exist
+// on Server or Data Center.
+func TestFindHomePageV1WithoutAHomepageIsAnError(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddSpace("DOCS")
+
+	page, err := api.FindHomePage("DOCS")
+	require.Error(t, err)
+	assert.Nil(t, page)
+	assert.Contains(t, err.Error(), "has no home page")
+	assert.NotContains(t, err.Error(), "not found",
+		"the space key is correct; sending people to hunt for a typo is the wrong answer")
+
+	assert.Equal(t, 0, server.CountRequests("GET", "/api/v2/spaces"),
+		"v1 answered, so there is nothing for v2 to add")
+}

--- a/confluence/status_test.go
+++ b/confluence/status_test.go
@@ -1,0 +1,86 @@
+package confluence_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindPageCarriesStatus pins that live content can be told from the rest at
+// all. PageInfo had no status field, so nothing downstream could distinguish a
+// current page from an archived one even when the response said so.
+func TestFindPageCarriesStatus(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddPage("DOCS", "Live", "page", "")
+
+	page, err := api.FindPage("DOCS", "Live", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+	assert.Equal(t, "current", page.Status)
+}
+
+// TestFindPageDoesNotSeeAnArchivedPage is the fact the whole diagnosis rests
+// on: v1 filters a lookup to current, so the page is gone from mark's view
+// while Confluence still knows about it.
+func TestFindPageDoesNotSeeAnArchivedPage(t *testing.T) {
+	api, server := newAPI(t)
+	page := server.AddPage("DOCS", "Retired", "page", "")
+	require.NoError(t, api.ArchivePage(page.ID))
+
+	found, err := api.FindPage("DOCS", "Retired", "page")
+	require.NoError(t, err)
+	assert.Nil(t, found, "an archived page is not current content")
+}
+
+// TestCreatePageNamesTheArchivedPageHoldingTheTitle pins the class of bug where
+// a failure has exactly one plausible cause and the error names none of them.
+//
+// --on-orphan archive archives a page; the source file comes back; FindPage
+// returns nil because v1 hides archived content; CreatePage fails with a bare
+// 400 Bad Request. There was no way forward from that message short of
+// guessing, and the guess is un-archiving by hand.
+//
+// The diagnosis is a message and nothing else. Whether an archived page truly
+// blocks reuse of its title is not verifiable without a live instance, and
+// restoring somebody's page on a hunch is not mark's decision to make.
+func TestCreatePageNamesTheArchivedPageHoldingTheTitle(t *testing.T) {
+	api, server := newAPI(t)
+	page := server.AddPage("DOCS", "Retired", "page", "")
+	require.NoError(t, api.ArchivePage(page.ID))
+
+	_, err := api.CreatePage("DOCS", "page", nil, "Retired", "<p/>")
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "archived")
+	assert.Contains(t, err.Error(), "Retired", "the title has to be in the message")
+	assert.Contains(t, err.Error(), "DOCS", "and so does the space")
+	assert.Contains(t, err.Error(), page.ID, "and the id of the page to go and look at")
+}
+
+// TestCreatePageNamesATrashedPageHoldingTheTitle covers the other invisible
+// state. --on-orphan trash is the default, so this is the commoner of the two.
+func TestCreatePageNamesATrashedPageHoldingTheTitle(t *testing.T) {
+	api, server := newAPI(t)
+	page := server.AddPage("DOCS", "Deleted", "page", "")
+	require.NoError(t, api.DeletePage(page.ID))
+
+	_, err := api.CreatePage("DOCS", "page", nil, "Deleted", "<p/>")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trashed")
+	assert.Contains(t, err.Error(), page.ID)
+}
+
+// TestCreatePageLeavesUnrelatedFailuresAlone: the diagnosis must not attach
+// itself to a create that failed for some other reason, or every error grows a
+// paragraph that does not apply to it.
+func TestCreatePageLeavesUnrelatedFailuresAlone(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddSpace("DOCS")
+	server.AddPage("DOCS", "Taken", "page", "")
+
+	_, err := api.CreatePage("DOCS", "page", nil, "Taken", "<p/>")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "archived")
+	assert.NotContains(t, err.Error(), "trashed")
+}

--- a/confluence/update_test.go
+++ b/confluence/update_test.go
@@ -1,0 +1,102 @@
+package confluence_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdateOmitsAncestorsWhenThereAreNone pins the request shape: the
+// ancestors key is what Confluence documents for *moving* a page, so sending an
+// empty list is a request, not a formality.
+//
+// A page created under a folder comes back from v2 with no ancestors -- folders
+// are not ancestors -- and the update a moment later used to send
+// "ancestors": [], which reads as "move this to the space root".
+func TestUpdateOmitsAncestorsWhenThereAreNone(t *testing.T) {
+	var body []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			body, _ = io.ReadAll(r.Body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	page := &confluence.PageInfo{ID: "1001", Title: "Orphan", Type: "page"}
+	require.NoError(t, api.UpdatePage(page, "<p/>", false, "", "full-width", ""))
+
+	var payload map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(body, &payload))
+
+	_, present := payload["ancestors"]
+	assert.False(t, present,
+		"an update with nothing to reparent to must not mention ancestors at all")
+}
+
+// TestUpdateKeepsTheAncestorItHas is the other half: when the page does have an
+// ancestry, the last ancestor still has to be named, or the update itself would
+// be the thing that moves it.
+func TestUpdateKeepsTheAncestorItHas(t *testing.T) {
+	var body []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			body, _ = io.ReadAll(r.Body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	page := &confluence.PageInfo{ID: "1001", Title: "Child", Type: "page"}
+	page.Ancestors = append(page.Ancestors, struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	}{ID: "900", Title: "Root"}, struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	}{ID: "950", Title: "Parent"})
+
+	require.NoError(t, api.UpdatePage(page, "<p/>", false, "", "full-width", ""))
+
+	var payload struct {
+		Ancestors []struct {
+			ID string `json:"id"`
+		} `json:"ancestors"`
+	}
+	require.NoError(t, json.Unmarshal(body, &payload))
+	require.Len(t, payload.Ancestors, 1, "Confluence wants only the immediate parent")
+	assert.Equal(t, "950", payload.Ancestors[0].ID)
+}
+
+// TestUpdateDoesNotEvictAFolderParentedPage is the same bug seen from the
+// server's side, through the fake: publish a page into a folder, update it, and
+// it must still be in the folder afterwards.
+func TestUpdateDoesNotEvictAFolderParentedPage(t *testing.T) {
+	api, server := newAPI(t)
+	space := server.AddSpace("DOCS")
+	folder := server.AddFolder("DOCS", "Guides", "", "page")
+
+	page, err := api.CreatePageWithFolderParent("DOCS", "page", folder.ID, "In A Folder", "<p/>")
+	require.NoError(t, err)
+	require.Equal(t, folder.ID, server.Page(page.ID).ParentID)
+
+	require.NoError(t, api.UpdatePage(page, "<p>new</p>", false, "", "full-width", ""))
+
+	assert.Equal(t, folder.ID, server.Page(page.ID).ParentID,
+		"an update must not move the page out of its folder")
+	assert.NotEmpty(t, space.ID)
+}


### PR DESCRIPTION
Eight verified fixes from the code audit, one per commit. Every one has a test, and each was confirmed to fail with its fix reverted.

**These do not split into separate PRs.** Six of the seven commits edit `confluence/api.go`, in sequence and in overlapping regions — four of them will not cherry-pick onto master on their own. The commits are kept separate and each stands alone for review; splitting them into PRs would just mean four merge conflicts.

| commit | fix |
| --- | --- |
| `read every page of a property listing` | The listing stopped at 100 with a comment claiming callers hold "a small fixed number" of properties. On Server/DC all seventeen manifest properties live on the space homepage alongside every other app's. Past 100, a shard falls off the first page: its mappings are lost, and the next write POSTs to a key that already exists — a 409 reported as "updated by a concurrent run". Wrong diagnosis, repeated forever. Now walks `start`/`limit` (v1) and the cursor (v2), and a 409 on a *create* raises a distinct `ErrPropertyUnseen` so the manifest fails loudly instead of shrugging. |
| `say when an invisible page is holding the title` | `FindPage` sent no `status`, and `PageInfo` had no status field, so nothing could tell live content from archived. `--on-orphan archive` followed by a restored source file gave a bare `400 Bad Request` with no way forward. A failed create now re-queries archived and trashed and names the title, space, state and id. |
| `send ancestors on an update only when there is one` | Every update carried an `ancestors` key, and `[]` for folder-parented pages — which Confluence documents as the mechanism for *moving* a page. |
| `memoise the two space lookups` | `FindHomePage` and `GetSpaceID` return values that cannot change mid-run and were called once per file, doubled on the scoped-token path. `FindPage` and `GetUserByName` were already memoised; these two were missed. Also: v1 `FindHomePage` returning 200 with no homepage expansion handed back a zero `PageInfo` whose empty id became a content id downstream. |
| `give every request a header map of its own` | The HTTP resource shared one header map across every derived resource and copied each *response's* headers into it. The map grew for the life of the run, and a single odd `Content-Type` on a sub-400 response (an SSO login page) pinned the wrong one on later writes. |
| `say what failed when the answer is not JSON` | A non-JSON 2xx surfaced as `invalid character '<' looking for beginning of value` with no URL, status or subject — the common trigger being a Confluence behind SSO answering 200 with a login page. |
| `name the Cloud-only move endpoint` | Relocation and ordering call a Cloud-only endpoint with no capability check, so a Server/DC user reorganising their tree got a bare 404. Folders are gated on `IsCloud()` and `RestrictPageUpdates` detects old Server — this path did neither. |

`confluence/confluencetest` grew the endpoints these needed: paginated property listings, status filtering on lookup, and `ancestors` honoured on PUT. Those gaps were why none of this was caught.

## Assumptions

No live Confluence was available, so three points are reasoned rather than observed and are implemented conservatively:
- whether an archived page truly blocks title reuse — the fix only *diagnoses*, it never auto-restores;
- which way Confluence reads `"ancestors": []` — the fix only stops sending it;
- whether DC lacks the move endpoint outright — the status stays in the message rather than asserting the endpoint is absent.

## Testing

`go build ./...`, `go test ./...`, `golangci-lint run ./...` all clean. No public signature changed; `PageInfo` gained a field. No caller outside `confluence/` needed touching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)