### PR TITLE
fix(metadata): three ways the header block lost a document's metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ appended to the values from front matter.
 <page contents>
 ```
 
+Headers are read from the run of comments the document opens with, and only
+from there. Blank lines between them are fine, so headers may be grouped —
+identity, then labels, then properties — but anything else ends the run, and a
+header written below the page's own text is published as text rather than
+applied. Mark warns when it finds one there.
+
+A header Mark does not recognise is an error rather than a warning: the line is
+taken out of the page either way, so a misspelled `Titel` would otherwise
+publish the document without its title and still exit zero.
+
+An `Include` directive may be written among the headers or anywhere below them.
+It is left in the page for the include expander to find, so it is the one
+comment in the header block that survives into the body.
+
 There can be any number of `Parent` headers, if Mark can't find specified
 parent by title, Mark creates it.
 

--- a/metadata/headerblock_test.go
+++ b/metadata/headerblock_test.go
@@ -1,0 +1,84 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// extract runs ExtractMeta the way ProcessFile does, with every optional
+// behaviour off, so that a test says only what the headers said.
+func extract(t *testing.T, document string) (*Meta, string, error) {
+	t.Helper()
+	meta, body, err := ExtractMeta([]byte(document), "", false, false, "", nil, false, "", false)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return meta, string(body), nil
+}
+
+// TestHeadersSurviveBlankLines pins the class of bug where a document that
+// groups its headers loses every one below the first gap. Each comment is its
+// own HTML block and the run used to end at the first byte that was not the
+// previous block's last, so a blank line meant the Label was neither applied
+// nor removed: it did nothing and was published as page text.
+func TestHeadersSurviveBlankLines(t *testing.T) {
+	meta, body, err := extract(t, `<!-- Space: TEST -->
+<!-- Title: Grouped -->
+
+<!-- Label: important -->
+
+Body.
+`)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+
+	assert.Equal(t, "TEST", meta.Space)
+	assert.Equal(t, "Grouped", meta.Title)
+	assert.Equal(t, []string{"important"}, meta.Labels)
+	assert.NotContains(t, body, "<!-- Label:", "the header must not be left in the page")
+	assert.Contains(t, body, "Body.")
+}
+
+// TestHeadersStopAtRealContent pins the boundary the blank-line tolerance must
+// not erase: a comment run separated from the headers by actual text is not
+// metadata, and the text between them has to survive into the page.
+func TestHeadersStopAtRealContent(t *testing.T) {
+	meta, body, err := extract(t, `<!-- Space: TEST -->
+<!-- Title: Split -->
+
+Some prose.
+
+<!-- Label: stranded -->
+`)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+
+	assert.Empty(t, meta.Labels, "a header below the page's own text is not metadata")
+	assert.Contains(t, body, "Some prose.")
+	assert.Contains(t, body, "<!-- Label: stranded -->",
+		"a comment mark did not consume has to stay where the author put it")
+}
+
+// TestMacroAboveHeadersIsKept pins the reason the cut has two boundaries rather
+// than one: whatever a document opens with before its headers -- a Macro
+// definition is the usual case -- is not metadata and must reach the page.
+func TestMacroAboveHeadersIsKept(t *testing.T) {
+	meta, body, err := extract(t, `<macro>
+raw
+</macro>
+
+<!-- Space: TEST -->
+<!-- Title: After Macro -->
+
+Body.
+`)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+
+	assert.Equal(t, "After Macro", meta.Title)
+	assert.Contains(t, body, "<macro>")
+	assert.NotContains(t, body, "<!-- Title:")
+}

--- a/metadata/headerblock_test.go
+++ b/metadata/headerblock_test.go
@@ -105,6 +105,51 @@ Body.
 	assert.Contains(t, body, "<!-- Include: fragment.md -->")
 }
 
+// TestUnknownHeaderIsRefused pins the fix for a misspelled header. The line
+// sits inside the header run, so it is taken out of the body whatever happens
+// next; logging the typo and publishing anyway meant a page silently lost its
+// title and the run still exited zero.
+func TestUnknownHeaderIsRefused(t *testing.T) {
+	_, _, err := extract(t, `<!-- Space: TEST -->
+<!-- Titel: Typo -->
+
+Body.
+`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown header "Titel"`)
+	assert.Contains(t, err.Error(), HeaderTitle, "the message has to name the valid headers")
+	assert.Contains(t, err.Error(), ContentAppearance)
+}
+
+// TestUnknownHeaderBeforeAnyKnownOneIsRefused covers the same typo written as
+// the document's very first line, where nothing has been read as a header yet.
+func TestUnknownHeaderBeforeAnyKnownOneIsRefused(t *testing.T) {
+	_, _, err := extract(t, `<!-- Titel: Typo -->
+<!-- Space: TEST -->
+
+Body.
+`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown header "Titel"`)
+}
+
+// TestCommentBelowHeadersIsNotAHeader guards the other side of the previous
+// test: a comment that is not part of the header run is page content, and
+// refusing those would fail documents that merely mention a colon.
+func TestCommentBelowHeadersIsNotAHeader(t *testing.T) {
+	meta, body, err := extract(t, `<!-- Space: TEST -->
+<!-- Title: Commented -->
+
+Body.
+
+<!-- note: generated file, do not edit -->
+`)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+
+	assert.Contains(t, body, "<!-- note: generated file, do not edit -->")
+}
+
 // TestMacroAboveHeadersIsKept pins the reason the cut has two boundaries rather
 // than one: whatever a document opens with before its headers -- a Macro
 // definition is the usual case -- is not metadata and must reach the page.

--- a/metadata/headerblock_test.go
+++ b/metadata/headerblock_test.go
@@ -62,6 +62,49 @@ Some prose.
 		"a comment mark did not consume has to stay where the author put it")
 }
 
+// TestIncludeAmongHeadersStaysInBody pins the fix for an Include written inside
+// the header block. Includes are expanded later, from the body, but the header
+// run was cut out in one piece -- so the directive was deleted before anything
+// could expand it and the page went up missing a whole section, with a zero
+// exit code.
+func TestIncludeAmongHeadersStaysInBody(t *testing.T) {
+	meta, body, err := extract(t, `<!-- Space: TEST -->
+<!-- Title: With Include -->
+<!-- Include: fragment.md -->
+<!-- Label: keep -->
+
+Body.
+`)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+
+	assert.Equal(t, "With Include", meta.Title)
+	assert.Equal(t, []string{"keep"}, meta.Labels, "headers after the Include still apply")
+	assert.Contains(t, body, "<!-- Include: fragment.md -->",
+		"the Include directive has to reach the expander")
+	assert.NotContains(t, body, "<!-- Title:")
+	assert.NotContains(t, body, "<!-- Label:")
+	assert.Contains(t, body, "Body.")
+}
+
+// TestIncludeAmongHeadersAfterBlankLine covers the two header-run fixes
+// together: the gap must not end the run, and the Include below it must still
+// reach the body.
+func TestIncludeAmongHeadersAfterBlankLine(t *testing.T) {
+	meta, body, err := extract(t, `<!-- Space: TEST -->
+<!-- Title: Grouped Include -->
+
+<!-- Include: fragment.md -->
+
+Body.
+`)
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+
+	assert.Equal(t, "Grouped Include", meta.Title)
+	assert.Contains(t, body, "<!-- Include: fragment.md -->")
+}
+
 // TestMacroAboveHeadersIsKept pins the reason the cut has two boundaries rather
 // than one: whatever a document opens with before its headers -- a Macro
 // definition is the usual case -- is not metadata and must reach the page.

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -424,9 +424,16 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 					meta.Properties[key] = strings.TrimSpace(propValue)
 
 				default:
-					log.Error().
-						Err(nil).
-						Msgf(`encountered unknown header %q line: %#v`, header, line)
+					// Refused rather than reported. The line is inside the
+					// header run, so it is taken out of the body either way,
+					// and a run that logged the typo and published the page
+					// without whatever the header asked for still exited zero
+					// -- a misspelled Title changed what was published and only
+					// said so in a line of output nobody was reading.
+					return nil, nil, fmt.Errorf(
+						"unknown header %q, expected one of: %s",
+						header, strings.Join(knownHeaders, ", "),
+					)
 				}
 
 				lastStop = lineSeg.Stop

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -37,6 +37,27 @@ const (
 	HeaderSynchronized = `Synchronized`
 )
 
+// knownHeaders is every header name a document may write, in the order an
+// unknown one is reported against.
+var knownHeaders = []string{
+	HeaderAttachment,
+	ContentAppearance,
+	HeaderEmoji,
+	HeaderFolder,
+	HeaderImageAlign,
+	HeaderInclude,
+	HeaderLabel,
+	HeaderLayout,
+	HeaderOrder,
+	HeaderParent,
+	HeaderProperty,
+	HeaderSidebar,
+	HeaderSpace,
+	HeaderSynchronized,
+	HeaderTitle,
+	HeaderType,
+}
+
 type Meta struct {
 	Parents           []string
 	Folders           []string
@@ -273,7 +294,7 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 		if htmlBlock, ok := child.(*ast.HTMLBlock); ok {
 			lines := htmlBlock.Lines()
 			if lines.Len() > 0 {
-				if lastStop > 0 && lines.At(0).Start != lastStop {
+				if lastStop > 0 && !onlyWhitespace(data, lastStop, lines.At(0).Start) {
 					break
 				}
 			}
@@ -414,6 +435,10 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 		body = append(append([]byte{}, data[bodyStart:firstStart]...), data[lastStop:]...)
 	}
 
+	if meta != nil {
+		warnStrandedHeaders(body)
+	}
+
 	if titleFromH1 || titleFromFilename || spaceFromCli != "" {
 		if meta == nil {
 			meta = &Meta{}
@@ -463,6 +488,57 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 	meta.Title = strings.Trim(meta.Title, " ")
 	meta.Space = strings.Trim(meta.Space, " ")
 	return meta, body, nil
+}
+
+// onlyWhitespace reports whether nothing but whitespace separates one header
+// comment from the next.
+//
+// Each comment is its own HTML block, and the run of them used to have to be
+// byte-contiguous: a single blank line ended it, so every header below the gap
+// was neither applied nor removed. Grouping headers -- identity, then labels,
+// then properties -- is the natural way to write them and nothing ever said it
+// was forbidden; the symptom was a Label that quietly did nothing and its own
+// comment published as the first line of the page.
+func onlyWhitespace(data []byte, from, to int) bool {
+	if from > to || to > len(data) {
+		return false
+	}
+
+	return strings.TrimSpace(string(data[from:to])) == ""
+}
+
+// warnStrandedHeaders reports header comments that stayed in the page body.
+//
+// Headers are read only from the run of comments the document opens with, so
+// one written after a paragraph -- or after anything else that ends the run --
+// is not metadata at all. It is published as page text and whatever it asked
+// for silently never happens, which is the failure a blank line used to cause
+// and which anything else ending the run still can. Saying so is cheap;
+// guessing what was meant is not.
+func warnStrandedHeaders(body []byte) {
+	for _, line := range strings.Split(string(body), "\n") {
+		key, _, ok := parseHeaderComment(line)
+		if !ok {
+			continue
+		}
+
+		header := cases.Title(language.English).String(key)
+		if header == HeaderInclude {
+			// An Include below the headers is the ordinary way to write one.
+			continue
+		}
+
+		for _, known := range knownHeaders {
+			if header == known {
+				log.Warn().Msgf(
+					"%s header is below the document's opening comments, so it is published as text rather than applied: %s",
+					header, strings.TrimSpace(line),
+				)
+
+				break
+			}
+		}
+	}
 }
 
 func setTitleFromFilename(meta *Meta, filename string) {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -290,6 +290,11 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 	var lastStop int
 	shouldBreak := false
 
+	// The Include directives found among the headers. They are metadata here
+	// only in that this loop has to recognise them; the expansion happens later
+	// and reads the body, so each one is carried across the cut below.
+	var includes []text.Segment
+
 	for child := doc.FirstChild(); child != nil; child = child.NextSibling() {
 		if htmlBlock, ok := child.(*ast.HTMLBlock); ok {
 			lines := htmlBlock.Lines()
@@ -371,7 +376,13 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 					meta.Labels = append(meta.Labels, value)
 
 				case HeaderInclude:
-					// Includes are parsed by a different func
+					// Includes are parsed by a different func, which reads the
+					// body -- so this line has to survive being cut out along
+					// with the headers around it. Without that, an Include
+					// written among the headers was deleted before anything
+					// could expand it and the page went up missing a whole
+					// section, with a zero exit code.
+					includes = append(includes, lineSeg)
 					lastStop = lineSeg.Stop
 					continue
 
@@ -431,8 +442,14 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 
 	if lastStop > 0 {
 		// Only the headers are taken out. Whatever preceded them stays, which
-		// is what keeps a Macro defined above the headers working.
-		body = append(append([]byte{}, data[bodyStart:firstStart]...), data[lastStop:]...)
+		// is what keeps a Macro defined above the headers working, and the
+		// Include directives found among them are put back where they stood.
+		rebuilt := make([]byte, 0, (firstStart-bodyStart)+(len(data)-lastStop))
+		rebuilt = append(rebuilt, data[bodyStart:firstStart]...)
+		for _, include := range includes {
+			rebuilt = append(rebuilt, data[include.Start:include.Stop]...)
+		}
+		body = append(rebuilt, data[lastStop:]...)
 	}
 
 	if meta != nil {


### PR DESCRIPTION
Three fixes to header parsing, sequential edits to the same function, plus the README section that documents the rules they settle.

**A blank line between header comments ended the run, silently.** The loop required byte-contiguity, so grouping headers into blocks — identity, then labels, then properties — dropped every header after the first gap. Both halves of the failure were silent: the label was never applied, *and* `<!-- Label: important -->` was published as visible text on the page. Whitespace-only gaps are now allowed inside the run, and a comment whose key is a known header name warns if it survives into the body.

**An `<!-- Include: -->` written among the headers was deleted and never expanded.** The header loop advanced past it and the body splice cut it out, so a whole section went missing with a zero exit code. Include lines are now collected and spliced back into the body.

**A misspelled header was stripped, logged at ERROR, and the run still succeeded.** `Titel:` silently changed what was published. It is now an error naming every valid header — the line is removed from the body either way, so publishing was already wrong.

Each was confirmed to fail with its fix reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)