### PR TITLE
fix(mark): stop reading a failed parent lookup as a parent that is fine

### DIFF
--- a/mark.go
+++ b/mark.go
@@ -1145,7 +1145,17 @@ func refreshStaleParents(tracker *manifest.Store, api *confluence.API, meta *met
 		// same question, so this costs nothing on the common path where the
 		// parent is exactly where it says it is.
 		existing, err := api.FindPage(meta.Space, title, "page")
-		if err != nil || existing != nil {
+		if err != nil {
+			// A lookup that failed is not a parent that is missing. Reading it
+			// as one leaves the stale title in place, and a stale title is
+			// exactly the condition this exists to prevent: ancestry creates an
+			// empty page under the old name and moves the real one's children
+			// beneath it. resolveTrackedPage refuses the same conflation.
+			return fmt.Errorf(
+				"unable to look up parent %q in space %q: %w", title, meta.Space, err,
+			)
+		}
+		if existing != nil {
 			continue
 		}
 
@@ -1164,7 +1174,24 @@ func refreshStaleParents(tracker *manifest.Store, api *confluence.API, meta *met
 		}
 
 		renamed, err := api.GetPageByID(pageID)
-		if err != nil || renamed == nil || renamed.Title == title {
+		if err != nil {
+			// Only a recorded page that is genuinely gone may be passed over.
+			// Anything else is a failure to read, and carrying on with the old
+			// title turns a network blip into a duplicate parent.
+			if !errors.Is(err, confluence.ErrNotFound) {
+				return fmt.Errorf(
+					"unable to load page %s recorded for parent %q: %w", pageID, title, err,
+				)
+			}
+
+			log.Warn().Msgf(
+				"parent %q was recorded as page %s, which no longer exists; leaving the title as written",
+				title, pageID,
+			)
+
+			continue
+		}
+		if renamed == nil || renamed.Title == title {
 			continue
 		}
 

--- a/mark_parents_test.go
+++ b/mark_parents_test.go
@@ -1,0 +1,61 @@
+package mark
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// failOnceLookingUp makes the fake refuse the first page lookup for a title and
+// answer every later one normally, which is what a network blip looks like from
+// here.
+func failOnceLookingUp(server *confluencetest.Server, title string) {
+	failed := false
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if failed || r.Method != http.MethodGet {
+			return 0, "", false
+		}
+		if r.URL.Query().Get("title") != title {
+			return 0, "", false
+		}
+
+		failed = true
+
+		return http.StatusForbidden, `{"message":"nope"}`, true
+	})
+}
+
+// TestStaleParentLookupFailureStopsTheRun pins the class of bug where a failed
+// read is treated as an answer. refreshStaleParents asks whether a parent title
+// still resolves, and a lookup that errored used to be indistinguishable from a
+// parent that is exactly where it says it is -- so a blip left the stale title
+// in place, which is the one condition that makes ancestry create an empty
+// duplicate parent and re-home the real one's children.
+func TestStaleParentLookupFailureStopsTheRun(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+	file := writeFile(t, dir, "doc.md", markdownWithTitle("Child"))
+
+	failOnceLookingUp(server, "Parent")
+
+	err := Run(trackingConfig(server, file))
+	require.Error(t, err, "a parent that could not be read is not a parent that is fine")
+	assert.Contains(t, err.Error(), `unable to look up parent "Parent"`)
+}
+
+// TestStaleParentLookupSucceedsNormally guards the other side: the failure path
+// must not have made the ordinary run any more fragile.
+func TestStaleParentLookupSucceedsNormally(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+	file := writeFile(t, dir, "doc.md", markdownWithTitle("Child"))
+
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	published, err := api.FindPage("DOCS", "Child", "page")
+	require.NoError(t, err)
+	require.NotNil(t, published)
+}


### PR DESCRIPTION
refreshStaleParents asks whether each declared parent title still
resolves, and both of its questions answered the same way whether the
API said no or said nothing at all: `if err != nil || existing != nil`
carried on, and so did the GetPageByID beneath it.

Carrying on leaves the stale title in place, which is precisely the
condition the function exists to prevent -- ancestry then creates an
empty page under the old title and moves the real one's children
beneath it. A network blip is enough.

resolveTrackedPage already argues this case in its own comment and lets
only a genuine 404 fall through; this path now does the same. A recorded
parent page that has really been deleted is still passed over, with a
warning, and the title is left as the document wrote it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
