### PR TITLE
fix(page): order pages that sit under a folder

### DIFF
--- a/mark.go
+++ b/mark.go
@@ -621,6 +621,11 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 
 	var target *confluence.PageInfo
 	var pageCreated bool
+
+	// What this document's headers placed the page under, kept beyond the
+	// resolution block because a folder parent is not visible anywhere else: it
+	// is not a page, so it never appears among the page's ancestors.
+	var resolvedParent *confluence.PageInfo
 	// A page whose title changed has to be written even when its content did
 	// not, or --changes-only would leave it under the old title forever.
 	var titleChanged bool
@@ -638,6 +643,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		if err != nil {
 			return nil, nil, fmt.Errorf("error resolving page %q: %w", meta.Title, err)
 		}
+		resolvedParent = parent
 
 		// The title lookup found nothing, which is how both "this page is new"
 		// and "this page was renamed" look. Ask the manifest which of the two
@@ -994,7 +1000,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 	if meta != nil && meta.Order != nil {
 		placement = &page.Ordered{
 			PageID:   target.ID,
-			ParentID: page.ImmediateParentID(target),
+			ParentID: page.ParentIDFor(target, resolvedParent),
 			Title:    target.Title,
 			Order:    *meta.Order,
 		}

--- a/mark_ordering_test.go
+++ b/mark_ordering_test.go
@@ -1,0 +1,89 @@
+package mark
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// folderOrderedDocument is a document that declares both a folder and a
+// position among its siblings -- the combination that used to get neither.
+func folderOrderedDocument(title string, order string) string {
+	return `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Folder: Manuals -->
+<!-- Title: ` + title + ` -->
+<!-- Order: ` + order + ` -->
+
+# ` + title + `
+
+Some content.
+`
+}
+
+// titlesInOrder names the pages Confluence lists under a parent, in the order
+// the tree shows them.
+func titlesInOrder(server *confluencetest.Server, parentID string) []string {
+	var titles []string
+	for _, id := range server.ChildOrder(parentID) {
+		if page := server.Page(id); page != nil {
+			titles = append(titles, page.Title)
+		}
+	}
+
+	return titles
+}
+
+// TestOrderIsAppliedUnderAFolder pins the class of bug where a placement is
+// dropped for want of a parent id. A folder is not a page, so it never appears
+// among a page's expanded ancestors -- every folder-parented page therefore
+// reported no parent, and OrderChildren discarded its position without a word.
+func TestOrderIsAppliedUnderAFolder(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "a.md", folderOrderedDocument("Second", "2"))
+	writeFile(t, dir, "b.md", folderOrderedDocument("First", "1"))
+
+	require.NoError(t, Run(trackingConfig(server, filepath.Join(dir, "*.md"))))
+
+	folders := server.Folders()
+	require.Len(t, folders, 1, "the declared folder should have been created once")
+
+	assert.Equal(t, []string{"First", "Second"}, titlesInOrder(server, folders[0].ID),
+		"a page under a folder must still be placed where its Order header asks")
+}
+
+// TestOrderIsAppliedUnderAPage guards the ordinary path, which resolves the
+// parent from the page's own ancestors, against the folder fallback added
+// beside it.
+func TestOrderIsAppliedUnderAPage(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	document := func(title, order string) string {
+		return `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: ` + title + ` -->
+<!-- Order: ` + order + ` -->
+
+# ` + title + `
+
+Some content.
+`
+	}
+
+	writeFile(t, dir, "a.md", document("Second", "2"))
+	writeFile(t, dir, "b.md", document("First", "1"))
+
+	require.NoError(t, Run(trackingConfig(server, filepath.Join(dir, "*.md"))))
+
+	parent, err := api.FindPage("DOCS", "Parent", "page")
+	require.NoError(t, err)
+	require.NotNil(t, parent)
+
+	assert.Equal(t, []string{"First", "Second"}, titlesInOrder(server, parent.ID))
+}

--- a/page/order.go
+++ b/page/order.go
@@ -35,7 +35,14 @@ func OrderChildren(api *confluence.API, dryRun bool, pages []Ordered) error {
 	for _, p := range pages {
 		if p.ParentID == "" {
 			// Nothing to be ordered relative to. Confluence's before/after also
-			// misbehave against top-level targets, so this is left alone.
+			// misbehave against top-level targets, so this is left alone -- but
+			// said out loud, because a document that asked for a position and
+			// silently got none looks exactly like one that never asked.
+			log.Warn().Msgf(
+				"page %q asked to be ordered %d but its parent is not known, so it is left where it is",
+				p.Title, p.Order,
+			)
+
 			continue
 		}
 		byParent[p.ParentID] = append(byParent[p.ParentID], p)

--- a/page/parentid_test.go
+++ b/page/parentid_test.go
@@ -1,0 +1,44 @@
+package page
+
+import (
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParentIDForFallsBackToTheResolvedParent pins the class of bug where a
+// folder-parented page reports no parent at all. Folders are not pages and
+// never appear among a page's expanded ancestors, so anything asking the page
+// alone -- page ordering is the one that mattered -- silently got nothing.
+func TestParentIDForFallsBackToTheResolvedParent(t *testing.T) {
+	folderParented := &confluence.PageInfo{ID: "1", Title: "Child"}
+	folder := &confluence.PageInfo{ID: "42", Type: "folder-parent", Title: "Manuals"}
+
+	assert.Empty(t, ImmediateParentID(folderParented),
+		"a folder-parented page has no ancestors to read")
+	assert.Equal(t, "42", ParentIDFor(folderParented, folder))
+}
+
+// TestParentIDForPrefersTheExpandedAncestor guards the ordinary case: what
+// Confluence says about where the page actually sits wins over what this run
+// resolved, which may since have been moved.
+func TestParentIDForPrefersTheExpandedAncestor(t *testing.T) {
+	pg := &confluence.PageInfo{
+		ID: "1",
+		Ancestors: []struct {
+			ID    string `json:"id"`
+			Title string `json:"title"`
+		}{{ID: "9", Title: "Home"}, {ID: "7", Title: "Parent"}},
+	}
+
+	assert.Equal(t, "7", ParentIDFor(pg, &confluence.PageInfo{ID: "42"}))
+}
+
+// TestParentIDForKnowsNothing keeps the "" answer available: a page with no
+// ancestors and no resolved parent is one nothing can be ordered against, and
+// OrderChildren has to be able to tell.
+func TestParentIDForKnowsNothing(t *testing.T) {
+	assert.Empty(t, ParentIDFor(&confluence.PageInfo{ID: "1"}, nil))
+	assert.Empty(t, ParentIDFor(nil, nil))
+}

--- a/page/relocation.go
+++ b/page/relocation.go
@@ -15,6 +15,26 @@ func ImmediateParentID(pg *confluence.PageInfo) string {
 	return pg.Ancestors[len(pg.Ancestors)-1].ID
 }
 
+// ParentIDFor returns the id of a page's direct parent, preferring what
+// Confluence expanded and falling back to the parent this run resolved.
+//
+// A page under a folder has no expanded ancestors -- folders are not pages and
+// never appear in that chain -- so the ancestors alone answer "" for every
+// folder-parented page. Everything that needs a parent id then quietly did
+// nothing: a document declaring both Folder and Order got neither the ordering
+// nor a word about it.
+func ParentIDFor(pg *confluence.PageInfo, resolved *confluence.PageInfo) string {
+	if id := ImmediateParentID(pg); id != "" {
+		return id
+	}
+
+	if resolved != nil {
+		return resolved.ID
+	}
+
+	return ""
+}
+
 // UnderDeclaredParents reports whether a page sits under the parents its
 // headers declare.
 //


### PR DESCRIPTION
A folder is not a page and never appears among a page's expanded
ancestors, so ImmediateParentID answered "" for every folder-parented
page. processFile put that empty string into the Ordered it collected,
and OrderChildren dropped the entry with a bare continue.

A document declaring both Folder and Order therefore got neither the
ordering nor a word about it -- the header may as well not have been
written.

The parent this run resolved is now kept past the resolution block and
used when the ancestors have nothing to say, which is the only place the
folder is known. OrderChildren still leaves a placement alone when it
has no parent to order against, but says so: silently doing nothing is
indistinguishable from never having been asked.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
