### PR TITLE
fix(page): stop identifying a folder collision by its wording

### DIFF
--- a/page/ancestry.go
+++ b/page/ancestry.go
@@ -293,34 +293,40 @@ func EnsureFolderAncestry(
 				folder, err = api.CreateFolder(spaceID, title, &pid, "folder")
 			}
 			if err != nil {
+				createErr := err
+
 				underID := ""
 				if parent != nil {
 					underID = parent.ID
 				} else if anchorPageID != nil {
 					underID = *anchorPageID
 				}
-				// Another file in the same run may have created this folder already.
-				if strings.Contains(err.Error(), "folder exists with the same title") {
-					if id, ok := cachedFolderID(space, underID, title); ok {
-						folder, err = api.GetFolderByID(id)
-					} else {
-						folder, err = resolveFolder(api, space, title, underID, anchorPageID)
-					}
+
+				// Another file in the same run may have created this folder
+				// already. Asked by looking for the folder rather than by
+				// reading the refusal: the "folder exists with the same title"
+				// wording comes from Confluence and is not a contract, so a
+				// reworded or localised instance turned a collision anybody can
+				// hit into a hard failure. A create that failed for a real
+				// reason leaves nothing to find, and the original error is what
+				// gets reported.
+				if id, ok := cachedFolderID(space, underID, title); ok {
+					folder, err = api.GetFolderByID(id)
+				} else {
+					folder, err = resolveFolder(api, space, title, underID, anchorPageID)
 				}
-				if err != nil {
+				if err != nil || folder == nil {
 					return nil, fmt.Errorf(
 						"error creating folder with title %q: %w",
 						title,
-						err,
+						createErr,
 					)
 				}
-				if folder == nil {
-					return nil, fmt.Errorf(
-						"folder %q reported as existing but could not be found in space %q",
-						title,
-						space,
-					)
-				}
+
+				log.Info().Msgf(
+					"folder %q already exists as %s; using it rather than creating another",
+					title, folder.ID,
+				)
 			}
 
 			underID := ""

--- a/page/folderconflict_test.go
+++ b/page/folderconflict_test.go
@@ -1,0 +1,76 @@
+package page_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/page"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFolderCreateConflictDoesNotDependOnWording pins the class of bug where an
+// error is identified by the text Confluence happened to put in it. A folder
+// another file created moments earlier makes the create fail, and recognising
+// that only by the English phrase "folder exists with the same title" turned a
+// recoverable collision into a hard failure the moment the wording changed or
+// the instance answered in another language.
+func TestFolderCreateConflictDoesNotDependOnWording(t *testing.T) {
+	page.ResetFolderCache()
+
+	api, server := newAPI(t)
+	root := server.AddPage("DOCS", "Root", "page", "")
+
+	// The folder another file in this run already created. It is hidden from
+	// the first search so that this run believes it has to create it.
+	server.AddFolder("DOCS", "Manuals", root.ID, "page")
+
+	searched := false
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if !searched && r.URL.Path == "/rest/api/search" {
+			searched = true
+
+			return http.StatusOK, `{"results":[]}`, true
+		}
+
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/api/v2/folders") {
+			// Confluence's own refusal, in a wording no caller may rely on.
+			return http.StatusBadRequest,
+				`{"errors":[{"title":"Es existiert bereits ein Ordner mit diesem Titel"}]}`,
+				true
+		}
+
+		return 0, "", false
+	})
+
+	parent, err := page.EnsureFolderAncestry(false, api, "DOCS", []string{"Manuals"}, &root.ID, nil)
+	require.NoError(t, err, "a folder that already exists is not a failure")
+	require.NotNil(t, parent)
+	assert.Equal(t, "Manuals", parent.Title)
+
+	assert.Len(t, server.Folders(), 1, "no second folder should have been created")
+}
+
+// TestFolderCreateFailureIsStillReported guards the other side: falling back to
+// a lookup must not turn a genuine refusal into silence. Nothing carries the
+// title, so there is nothing to find and the create's own error stands.
+func TestFolderCreateFailureIsStillReported(t *testing.T) {
+	page.ResetFolderCache()
+
+	api, server := newAPI(t)
+	root := server.AddPage("DOCS", "Root", "page", "")
+
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/api/v2/folders") {
+			return http.StatusForbidden, `{"errors":[{"title":"not permitted"}]}`, true
+		}
+
+		return 0, "", false
+	})
+
+	_, err := page.EnsureFolderAncestry(false, api, "DOCS", []string{"Manuals"}, &root.ID, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `error creating folder with title "Manuals"`)
+	assert.Contains(t, err.Error(), "403", "the reason the create was refused has to survive")
+}


### PR DESCRIPTION
Creating a folder that another file in the same run already created
fails, and the recovery was gated on the create error containing the
phrase "folder exists with the same title". That text comes from
Confluence, not from any contract: a reworded response, or an instance
answering in another language, turns an ordinary collision into a hard
failure and leaves the whole hierarchy unbuilt.

The collision is now recognised by looking for the folder rather than by
reading the refusal. A create that failed for a real reason leaves
nothing to find, and its own error is what gets reported -- so the
fallback cannot turn a genuine refusal into silence.

A proper fix belongs in confluence/: CreateFolder returns whatever
newErrorStatusNotOK builds, which flattens status and body into a
string, so a caller cannot ask "was this a conflict?" at all. The
package already has the pattern in ErrNotFound and ErrPropertyConflict;
a sentinel for 400/409 on folder creation would let this ask directly
instead of guessing from what it can find afterwards.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
