### PR TITLE
fix(page): check an orphan's scope once, not twice

### DIFF
--- a/mark.go
+++ b/mark.go
@@ -1915,7 +1915,7 @@ func handleOrphans(
 				continue
 			}
 
-			handled, err = page.HandleOrphans(api, action, scopeID, candidates, config.DryRun)
+			handled, err = page.HandleOrphans(api, action, candidates, config.DryRun)
 			if err != nil {
 				return err
 			}

--- a/mark_orphanscope_test.go
+++ b/mark_orphanscope_test.go
@@ -1,0 +1,66 @@
+package mark
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// getsFor counts the GETs the fake received for exactly one content path,
+// which is what a scope check costs: one GetPageByIDExpanded per orphan.
+func getsFor(server *confluencetest.Server, pageID string) int {
+	var n int
+	for _, request := range server.Requests() {
+		if request.Method == http.MethodGet && request.Path == "/rest/api/content/"+pageID {
+			n++
+		}
+	}
+
+	return n
+}
+
+// TestOrphanScopeIsCheckedOnce pins the class of bug where the same remote
+// question is asked twice. handleOrphans filtered its candidates with InScope
+// and HandleOrphans then asked again about every survivor, so the one operation
+// in mark that trashes pages cost twice the API calls it needed -- for an
+// answer that had just been computed.
+func TestOrphanScopeIsCheckedOnce(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Inside", "page", home.ID)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "gone.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Inside -->\n<!-- Title: Gone -->\n\nGone.\n")
+	writeFile(t, dir, "keep.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Inside -->\n<!-- Title: Keep -->\n\nKeep.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		TrackPages: true, OnOrphan: "delete", OrphanUnder: "Inside",
+		Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	gone, err := api.FindPage("DOCS", "Gone", "page")
+	require.NoError(t, err)
+	require.NotNil(t, gone)
+
+	require.NoError(t, os.Remove(filepath.Join(dir, "gone.md")))
+	server.ResetRequests()
+	require.NoError(t, Run(config))
+
+	assert.True(t, server.Page(gone.ID).Trashed, "the orphan is still acted on")
+	assert.Equal(t, 1, getsFor(server, gone.ID),
+		"an orphan's ancestry should be read once, not once per caller that wants the scope")
+}

--- a/page/orphan.go
+++ b/page/orphan.go
@@ -133,32 +133,24 @@ func InScope(api *confluence.API, scopeID string, orphan Orphan) (bool, error) {
 
 // HandleOrphans acts on the pages whose source files are gone.
 //
+// Every orphan given here is acted on: the caller decides what is in scope,
+// because it has to name the same set in what it reports and in what it stops
+// tracking. Asking again here meant a second GetPageByIDExpanded for every
+// candidate -- twice the API cost of the one operation in mark that deletes
+// pages -- for an answer that had just been computed.
+//
 // Returns the paths that were dealt with, which the caller stops tracking. A
 // page that could not be acted on stays in the manifest, so the next run finds
 // it again rather than losing sight of it.
 func HandleOrphans(
 	api *confluence.API,
 	action string,
-	scopeID string,
 	orphans []Orphan,
 	dryRun bool,
 ) ([]string, error) {
 	var handled []string
 
 	for _, orphan := range orphans {
-		inScope, err := InScope(api, scopeID, orphan)
-		if err != nil {
-			return handled, err
-		}
-
-		if !inScope {
-			log.Debug().Msgf(
-				"page %q is outside the orphan scope; leaving it alone", orphan.Title,
-			)
-
-			continue
-		}
-
 		if action == OnOrphanReport {
 			handled = append(handled, orphan.Path)
 


### PR DESCRIPTION
handleOrphans filtered its candidates with page.InScope and then handed
the survivors to page.HandleOrphans, which called InScope on each of
them again. Every call is a GetPageByIDExpanded, so the operation that
archives and trashes pages cost exactly twice the API calls it needed --
and on a large manifest that is the slowest and most dangerous part of a
run.

The check in HandleOrphans is the one that goes. The caller cannot drop
its own: the same set has to be named in what it reports, in what it
acts on and in what it stops tracking, and those disagreeing is the bug
the scope was added to fix.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
