### PR TITLE
fix: record a page in the manifest after it is written, not before

### DIFF
--- a/mark.go
+++ b/mark.go
@@ -927,12 +927,6 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		}
 	}
 
-	if tracker != nil && meta != nil {
-		if err := tracker.Record(meta.Space, file, target.ID, meta.Title, sourceHash); err != nil {
-			return nil, nil, fmt.Errorf("unable to record page mapping for %q: %w", file, err)
-		}
-	}
-
 	status := report.StatusPublished
 	if !shouldUpdatePage {
 		status = report.StatusUnchanged
@@ -961,6 +955,19 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to update page: %w", err)
+		}
+	}
+
+	// Recorded after the write, not before it. The mapping asserts what is on
+	// the page -- the title it carries and a fingerprint of the source that
+	// produced its body -- and the manifest is now saved however the run ends,
+	// so recording first meant a body that was refused as malformed, or an
+	// update that failed, still left the mapping claiming both. The fingerprint
+	// is what rename detection matches on, so the next run would then read a
+	// document it had never published as unchanged.
+	if tracker != nil && meta != nil {
+		if err := tracker.Record(meta.Space, file, target.ID, meta.Title, sourceHash); err != nil {
+			return nil, nil, fmt.Errorf("unable to record page mapping for %q: %w", file, err)
 		}
 	}
 

--- a/mark_record_test.go
+++ b/mark_record_test.go
@@ -1,0 +1,63 @@
+package mark
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNothingIsRecordedForAPageThatWasNotWritten: the mapping asserts what is on
+// the page. Recording it before the upload, now that the manifest is saved
+// however the run ends, meant a body refused as malformed still left the
+// manifest claiming the new title and a fingerprint of the source that produced
+// it -- and the fingerprint is what rename detection matches on, so the next run
+// read a document it had never published as unchanged.
+func TestNothingIsRecordedForAPageThatWasNotWritten(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	// An unbalanced tag the author wrote: the well-formedness gate refuses the
+	// body, so nothing is uploaded.
+	file := writeFile(t, dir, "doc.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Refused -->
+
+Text with an <span>unclosed tag.
+`)
+
+	require.Error(t, Run(trackingConfig(server, file)))
+
+	store := manifest.NewStore(confluence.NewAPI(server.URL, "user", "token", false))
+	_, ok, err := store.Lookup("DOCS", filepath.Join(dir, "doc.md"))
+	require.NoError(t, err)
+	assert.False(t, ok,
+		"a page whose body was never uploaded must not be in the manifest")
+}
+
+// TestRecordedTitleIsTheOneThePageCarries covers the same ordering from the
+// other side: a successful publish still has to record, or tracking stops
+// working altogether.
+func TestRecordedTitleIsTheOneThePageCarries(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	file := writeFile(t, dir, "doc.md", markdownWithTitle("Recorded"))
+	require.NoError(t, Run(trackingConfig(server, file)))
+
+	published, err := api.FindPage("DOCS", "Recorded", "page")
+	require.NoError(t, err)
+	require.NotNil(t, published)
+
+	store := manifest.NewStore(confluence.NewAPI(server.URL, "user", "token", false))
+	entry, ok, err := store.Lookup("DOCS", filepath.Join(dir, "doc.md"))
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	assert.Equal(t, published.ID, entry.PageID)
+	assert.Equal(t, "Recorded", entry.Title)
+	assert.NotEmpty(t, entry.Hash, "the fingerprint is what a rename is matched on")
+}


### PR DESCRIPTION
The mapping asserts what is on the page: the title it carries, and a fingerprint
of the source that produced its body. It was written before the upload, which
was survivable while a failed run threw the manifest away -- and stopped being
survivable when the manifest started being saved however the run ends.

So a body refused by the well-formedness check, or an update that failed, now
left the manifest claiming a title the page does not carry and a fingerprint for
content that was never uploaded. The fingerprint is what rename detection
matches on, so the next run reads a document it has never published as one that
has not changed since it did.

Moved below the update, beside RecordVersion, which was already ordered this
way and for the same reason.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
