### PR TITLE
fix(transformer): leave a CDATA section alone when repairing raw HTML

### DIFF
--- a/transformer/xml_wellformed.go
+++ b/transformer/xml_wellformed.go
@@ -74,11 +74,72 @@ func (t *XMLWellFormedTransformer) Transform(doc *ast.Document, reader text.Read
 	}
 }
 
+var (
+	cdataOpen  = []byte("<![CDATA[")
+	cdataClose = []byte("]]>")
+)
+
 // wellFormedHTML returns raw with void elements closed and comment bodies made
 // legal, and reports whether anything had to change. Every other byte, tag and
 // attribute is passed through untouched -- the input is the author's markup,
 // not something to normalise.
+//
+// CDATA sections are cut out and copied through before any of that happens.
+// html.NewTokenizer has no notion of CDATA: it reports "<![CDATA[" as a bogus
+// comment that ends at the first ">", and then reads everything after it as
+// ordinary markup -- so a "<br>" inside a code sample was rewritten to "<br />"
+// and the sample silently changed, which is the one thing CDATA is there to
+// prevent.
 func wellFormedHTML(raw []byte) ([]byte, bool) {
+	if len(raw) == 0 {
+		return raw, false
+	}
+
+	if !bytes.Contains(raw, cdataOpen) {
+		return wellFormedMarkup(raw)
+	}
+
+	var buf bytes.Buffer
+	changed := false
+	rest := raw
+
+	for len(rest) > 0 {
+		start := bytes.Index(rest, cdataOpen)
+		if start == -1 {
+			out, outChanged := wellFormedMarkup(rest)
+			buf.Write(out)
+			changed = changed || outChanged
+
+			break
+		}
+
+		out, outChanged := wellFormedMarkup(rest[:start])
+		buf.Write(out)
+		changed = changed || outChanged
+
+		end := bytes.Index(rest[start:], cdataClose)
+		if end == -1 {
+			// Unterminated. Everything left is inside the section as far as
+			// anything downstream can tell, so it is copied out as written.
+			buf.Write(rest[start:])
+
+			break
+		}
+
+		stop := start + end + len(cdataClose)
+		buf.Write(rest[start:stop])
+		rest = rest[stop:]
+	}
+
+	if !changed {
+		return raw, false
+	}
+
+	return buf.Bytes(), true
+}
+
+// wellFormedMarkup does the work on a span known to hold no CDATA section.
+func wellFormedMarkup(raw []byte) ([]byte, bool) {
 	if len(raw) == 0 {
 		return raw, false
 	}

--- a/transformer/xml_wellformed_test.go
+++ b/transformer/xml_wellformed_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Void elements written the HTML way leave the page as not-well-formed XML,
@@ -63,4 +64,48 @@ func TestWellFormedHTMLRepairsCommentBodies(t *testing.T) {
 			assert.Equal(t, testcase.changed, changed)
 		})
 	}
+}
+
+// TestCDATAIsCopiedThroughUntouched: html.NewTokenizer has no notion of CDATA.
+// It reports "<![CDATA[" as a bogus comment ending at the first ">" and reads
+// the rest as markup, so a code sample containing "<br>" had it rewritten to
+// "<br />" -- the one thing a CDATA section exists to prevent, done by the pass
+// that was added to make the page well-formed.
+func TestCDATAIsCopiedThroughUntouched(t *testing.T) {
+	samples := []string{
+		`<ac:plain-text-body><![CDATA[if a > b then <br> done]]></ac:plain-text-body>`,
+		`<ac:plain-text-body><![CDATA[<input type="checkbox">]]></ac:plain-text-body>`,
+		`<ac:plain-text-body><![CDATA[a <!-- b -- c --> d]]></ac:plain-text-body>`,
+	}
+
+	for _, sample := range samples {
+		out, changed := wellFormedHTML([]byte(sample))
+
+		assert.False(t, changed, "nothing inside CDATA needs repairing: %s", sample)
+		assert.Equal(t, sample, string(out))
+	}
+}
+
+// TestMarkupAroundCDATAIsStillRepaired is the other half: cutting the sections
+// out must not stop the rest of the block being fixed.
+func TestMarkupAroundCDATAIsStillRepaired(t *testing.T) {
+	out, changed := wellFormedHTML([]byte(
+		`<div><br><ac:plain-text-body><![CDATA[keep <br> me]]></ac:plain-text-body><hr></div>`,
+	))
+
+	require.True(t, changed)
+	assert.Contains(t, string(out), `<div><br />`, "markup before the section is repaired")
+	assert.Contains(t, string(out), `<![CDATA[keep <br> me]]>`, "the section is not")
+	assert.Contains(t, string(out), `<hr /></div>`, "markup after it is repaired")
+}
+
+// TestUnterminatedCDATAIsLeftAlone: an opener with no closer means everything
+// after it is inside the section as far as anything downstream can tell.
+func TestUnterminatedCDATAIsLeftAlone(t *testing.T) {
+	const sample = `<ac:plain-text-body><![CDATA[unterminated <br>`
+
+	out, changed := wellFormedHTML([]byte(sample))
+
+	assert.False(t, changed)
+	assert.Equal(t, sample, string(out))
 }


### PR DESCRIPTION
html.NewTokenizer has no notion of CDATA. It reports "<![CDATA[" as a bogus
comment that ends at the first ">", and then reads everything after that as
ordinary markup -- so the pass added to close void elements walked straight into
code samples and rewrote them:

    <ac:plain-text-body><![CDATA[if a > b then <br> done]]></ac:plain-text-body>
    <ac:plain-text-body><![CDATA[if a > b then <br /> done]]></ac:plain-text-body>

Silently altering a code sample is the one thing a CDATA section exists to
prevent, and mark writes them on purpose -- ac:code and ac:plantuml both do, and
storage format written by hand or produced by a macro reaches this pass as an
HTML block.

The sections are now cut out and copied through before the tokenizer sees
anything, so it only ever runs over the markup between them. The markup around
a section is still repaired, which is what the pass is for. An unterminated
opener takes the rest of the block with it: everything after it is inside the
section as far as anything downstream can tell.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
