### PR TITLE
fix(manifest): one unseen property no longer abandons the whole save

### DIFF
--- a/confluence/property.go
+++ b/confluence/property.go
@@ -51,10 +51,13 @@ var ErrPropertyConflict = errors.New("property version conflict")
 //
 // This is what an incomplete listing looks like from the write side: the key is
 // there, this run did not see it, and everything it held has already been
-// treated as absent. It is deliberately not an ErrPropertyConflict, which
-// callers report as "updated by a concurrent run" and carry on from -- that
-// diagnosis is wrong here, and carrying on loses the same data again on every
-// run afterwards.
+// treated as absent. The diagnosis a plain conflict gets -- "updated by a
+// concurrent run" -- is wrong here and worth saying differently.
+//
+// Deliberately not an ErrPropertyConflict: a caller that shrugs this off the
+// way it shrugs off a lost race loses the same data again on every run
+// afterwards. It is still not a reason to abandon the writes that would have
+// succeeded -- see how the manifest handles it.
 var ErrPropertyUnseen = errors.New("property already exists but was not listed")
 
 // ListSpaceProperties returns every property stored against a space.

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -458,6 +458,12 @@ func (state *spaceState) writeMapping(
 	what string,
 ) (bool, error) {
 	if err := state.writeProperty(api, key, value, existing); err != nil {
+		if errors.Is(err, confluence.ErrPropertyUnseen) {
+			log.Warn().Err(err).Msgf(
+				"%s for space %q was not saved", what, spaceKey,
+			)
+			return false, nil
+		}
 		if errors.Is(err, confluence.ErrPropertyConflict) {
 			log.Warn().Msgf(
 				"%s for space %q was updated by a concurrent run; it was not saved",
@@ -1082,6 +1088,16 @@ func (s *Store) Save() error {
 			}
 
 			if err := state.write(s.api, i, value); err != nil {
+				if errors.Is(err, confluence.ErrPropertyUnseen) {
+					// Said differently from a plain conflict, and still not
+					// fatal: the other shards describe pages this one says
+					// nothing about, and abandoning them helps nobody.
+					log.Warn().Err(err).Msgf(
+						"manifest shard %s of space %q was not saved",
+						PropertyKey(i), spaceKey,
+					)
+					continue
+				}
 				if errors.Is(err, confluence.ErrPropertyConflict) {
 					// Another run wrote between this run's read and its write.
 					// The two are not mergeable from here without re-reading,

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -814,3 +814,31 @@ func TestKeysWrittenBeforeNormalisationAreMigrated(t *testing.T) {
 	assert.Equal(t, map[string]string{"docs/a.md": "1234"}, manifestPages(t, server, id),
 		"the old key should be gone, not sitting beside the new one")
 }
+
+// TestUnseenPropertyDoesNotAbandonTheRestOfTheSave: a 409 on a create raises
+// ErrPropertyUnseen, which was deliberately not an ErrPropertyConflict -- so no
+// caller recognised it, Save returned on the first one, and the run failed.
+//
+// Save writes the folder mapping, then the parents, then seventeen shards, so a
+// collision on the first of those abandoned everything after it. Every one of
+// those describes pages the failed write says nothing about.
+func TestUnseenPropertyDoesNotAbandonTheRestOfTheSave(t *testing.T) {
+	store, server := newStore(t)
+	server.AddSpace("DOCS")
+	id := spaceID(t, server, "DOCS")
+
+	// Recording loads the space, so the listing this run works from happens
+	// here -- and finds nothing.
+	require.NoError(t, store.RecordFolder("DOCS", "anchor\x00Guides", "folder-1"))
+	require.NoError(t, store.Record("DOCS", "a.md", "1", "A", ""))
+
+	// Only then does the folder mapping appear, so the create below collides
+	// with a key this run's listing never showed.
+	server.SetSpaceProperty(id, manifest.FolderPropertyKey, []byte(`{"version":1,"folders":{}}`))
+
+	require.NoError(t, store.Save(),
+		"one unseen property must not fail the whole save")
+
+	assert.Equal(t, map[string]string{"a.md": "1"}, manifestPages(t, server, id),
+		"the page shards are written even though the folder mapping collided")
+}


### PR DESCRIPTION
ErrPropertyUnseen says something worth saying: a create collided with a key the
listing never showed, so the listing was incomplete and whatever that property
held has already been treated as absent. It is deliberately not an
ErrPropertyConflict, because a caller that shrugs it off the way it shrugs off a
lost race loses the same data again on every run afterwards.

But no caller knew about it. Both sites in this package match only
ErrPropertyConflict, so an unseen property fell through to a bare return, out of
Save, out of Run -- and Save writes the folder mapping, then the parents, then
seventeen shards, in that order. A collision on the first of those abandoned the
other eighteen, every one of which describes pages the failed write says nothing
about. Being loud turned into writing nothing at all, which is a worse outcome
than the warn-and-continue the same 409 got before the sentinel existed.

Both sites now recognise it: reported on its own terms rather than as a
concurrent run, and then treated like any other write that could not happen --
the next one is still attempted. The sentinel keeps its meaning; only the blast
radius changes.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
