### PR TITLE
fix(confluence): remember only what cannot change

### DIFF
--- a/confluence/api.go
+++ b/confluence/api.go
@@ -404,6 +404,26 @@ func (api *API) FindRootPage(space string) (*PageInfo, error) {
 // costs two requests rather than one on a scoped token, because the v1 refusal
 // is what sends it to v2. A space's home page cannot change mid-run, so asking
 // twice can only ever get the same answer.
+// worthCaching reports whether an outcome is one that cannot change during the
+// run, and so is safe to remember.
+//
+// A space's home page and a space's id are both fixed for the life of a run,
+// which is what makes memoising them correct. The premise does not extend to
+// every way of failing to find them: a 404, or a space that genuinely has no
+// home page, is a conclusion, but a throttling burst or a gateway error is a
+// moment. The retry transport gives up after four attempts, so remembering one
+// of those made a few unlucky seconds fail every remaining file in the space --
+// where before the memoisation the next document would simply have asked again.
+func worthCaching(err error) bool {
+	return err == nil ||
+		errors.Is(err, ErrNotFound) ||
+		errors.Is(err, errNoHomePage)
+}
+
+// errNoHomePage is the answer for a space that exists and has no home page.
+// A conclusion rather than a hiccup, so it is remembered like a success.
+var errNoHomePage = errors.New("space has no home page")
+
 func (api *API) FindHomePage(space string) (*PageInfo, error) {
 	if entry, ok := api.cachedHomePage(space); ok {
 		return clonePageInfo(entry.page), entry.err
@@ -411,12 +431,14 @@ func (api *API) FindHomePage(space string) (*PageInfo, error) {
 
 	page, err := api.fetchHomePage(space)
 
-	api.spaceCacheMutex.Lock()
-	if api.homePageCache == nil {
-		api.homePageCache = make(map[string]homePageCacheEntry)
+	if worthCaching(err) {
+		api.spaceCacheMutex.Lock()
+		if api.homePageCache == nil {
+			api.homePageCache = make(map[string]homePageCacheEntry)
+		}
+		api.homePageCache[space] = homePageCacheEntry{page: clonePageInfo(page), err: err}
+		api.spaceCacheMutex.Unlock()
 	}
-	api.homePageCache[space] = homePageCacheEntry{page: clonePageInfo(page), err: err}
-	api.spaceCacheMutex.Unlock()
 
 	return page, err
 }
@@ -446,7 +468,7 @@ func (api *API) fetchHomePage(space string) (*PageInfo, error) {
 		// thing here rather than falling through to a v2 that does not exist on
 		// Server or Data Center.
 		if homepage.ID == "" {
-			return nil, fmt.Errorf("space %s has no home page", space)
+			return nil, fmt.Errorf("space %s: %w", space, errNoHomePage)
 		}
 
 		return homepage, nil
@@ -485,14 +507,14 @@ func (api *API) fetchHomePage(space string) (*PageInfo, error) {
 	}
 
 	if len(v2Result.Results) == 0 {
-		return nil, fmt.Errorf("space with key %s not found", space)
+		return nil, fmt.Errorf("space with key %s not found: %w", space, ErrNotFound)
 	}
 
 	// A space that exists but has no homepage is a different failure from a
 	// space that does not exist, and reporting it as "not found" sends people
 	// looking for a typo in a space key that is perfectly correct.
 	if v2Result.Results[0].HomepageID == "" {
-		return nil, fmt.Errorf("space %s has no home page", space)
+		return nil, fmt.Errorf("space %s: %w", space, errNoHomePage)
 	}
 
 	return api.GetPageByID(v2Result.Results[0].HomepageID)
@@ -1617,6 +1639,10 @@ func (api *API) GetSpaceID(spaceKey string) (string, error) {
 	}
 
 	id, err := api.fetchSpaceID(spaceKey)
+
+	if !worthCaching(err) {
+		return id, err
+	}
 
 	api.spaceCacheMutex.Lock()
 	if api.spaceIDCache == nil {

--- a/confluence/space_test.go
+++ b/confluence/space_test.go
@@ -2,6 +2,7 @@ package confluence_test
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -101,4 +102,44 @@ func TestFindHomePageV1WithoutAHomepageIsAnError(t *testing.T) {
 
 	assert.Equal(t, 0, server.CountRequests("GET", "/api/v2/spaces"),
 		"v1 answered, so there is nothing for v2 to add")
+}
+
+// TestTransientFailureIsNotCached: memoising the space lookups is correct
+// because a space's home page and id cannot change mid-run. That premise covers
+// a 404 and a space with no home page -- both conclusions -- and not a
+// throttling burst or a gateway error, which are moments.
+//
+// The retry transport gives up after four attempts, so remembering one of those
+// made a few unlucky seconds fail every remaining file in the space. Before the
+// memoisation, the next document simply asked again and succeeded.
+func TestTransientFailureIsNotCached(t *testing.T) {
+	api, server := newAPI(t)
+	space := server.AddSpace("DOCS")
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+
+	var failing bool = true
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		// Both the v1 lookup and the v2 fallback, or the fallback answers and
+		// there is no failure to remember.
+		if failing && strings.Contains(r.URL.Path, "space") {
+			return http.StatusServiceUnavailable, "upstream is busy", true
+		}
+		return 0, "", false
+	})
+
+	_, err := api.FindHomePage("DOCS")
+	require.Error(t, err, "the outage is reported")
+
+	// The outage passes, as outages do.
+	failing = false
+
+	found, err := api.FindHomePage("DOCS")
+	require.NoError(t, err, "the next document must not inherit the failure")
+	require.NotNil(t, found)
+	assert.Equal(t, home.ID, found.ID)
+
+	id, err := api.GetSpaceID("DOCS")
+	require.NoError(t, err)
+	assert.Equal(t, space.ID, id)
 }

--- a/confluence/space_test.go
+++ b/confluence/space_test.go
@@ -118,7 +118,7 @@ func TestTransientFailureIsNotCached(t *testing.T) {
 	home := server.AddPage("DOCS", "Home", "page", "")
 	server.SetHomepage("DOCS", home.ID)
 
-	var failing bool = true
+	failing := true
 	server.SetFail(func(r *http.Request) (int, string, bool) {
 		// Both the v1 lookup and the v2 fallback, or the fallback answers and
 		// there is no failure to remember.


### PR DESCRIPTION
Memoising the two space lookups is correct because a space's home page and its
id are fixed for the life of a run. The comment said as much and then cached
every outcome, including the ones the premise does not cover.

A 404, or a space that exists with no home page, is a conclusion: asking again
gets the same answer, and remembering it is the point. A throttling burst, a
gateway 502 or a connection reset is a moment. retryTransport gives up after
four attempts, so a few unlucky seconds were recorded as the space's permanent
state and every remaining document in it failed without another request being
made. Before the memoisation, file 2 of 500 would simply have asked again.

Only the conclusions are cached now, told apart by sentinel rather than by
message: the two "not found" answers wrap ErrNotFound, and a space with no home
page wraps a new errNoHomePage. Both were already being distinguished in prose,
which nothing could act on.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
