### PR TITLE
fix(page): a space that will not name its home page is not a failed publish

### DIFF
--- a/page/ancestry.go
+++ b/page/ancestry.go
@@ -531,12 +531,21 @@ func ValidateAncestry(
 
 	isHomepage := false
 	if len(page.Ancestors) < 1 {
+		// Compared against, not used, so a space that will not give up its home
+		// page must not fail every document in it. Without one to compare
+		// against, a parentless page is treated as the misplacement below --
+		// which is recoverable, where refusing outright was not.
 		homepage, err := api.FindHomePage(space)
 		if err != nil {
-			return nil, fmt.Errorf("can't obtain home page from space %q: %w", space, err)
+			log.Debug().Err(err).Msgf(
+				"no home page for space %q; cannot tell whether %q is it",
+				space, page.Title,
+			)
+
+			homepage = nil
 		}
 
-		if page.ID == homepage.ID {
+		if homepage != nil && page.ID == homepage.ID {
 			log.Debug().Msgf("page is homepage for space %q", space)
 			isHomepage = true
 		} else {

--- a/page/homepage_test.go
+++ b/page/homepage_test.go
@@ -1,0 +1,47 @@
+package page_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/kovetskiy/mark/v16/metadata"
+	"github.com/kovetskiy/mark/v16/page"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolvePageWithoutAHomePage: the home page is only ever compared against
+// -- is the first declared parent the home page, is this parentless page the
+// home page -- and never used as a parent. Refusing the document when the
+// lookup failed therefore aborted every file in the space, including documents
+// whose Parent headers never needed one.
+func TestResolvePageWithoutAHomePage(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	// The space will not say what its home page is, however it is asked.
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if strings.Contains(r.URL.Path, "space") {
+			return http.StatusNotFound, "no such space", true
+		}
+		return 0, "", false
+	})
+
+	parent, _, err := page.ResolvePage(false, api, &metadata.Meta{
+		Space:   "DOCS",
+		Type:    "page",
+		Title:   "Child",
+		Parents: []string{"Parent"},
+	}, nil)
+
+	require.NoError(t, err, "a document with an explicit parent does not need the home page")
+	require.NotNil(t, parent)
+	assert.Equal(t, "Parent", parent.Title)
+}

--- a/page/page.go
+++ b/page/page.go
@@ -46,14 +46,22 @@ func ResolvePage(
 		return nil, page, nil
 	}
 
-	// check to see if home page is in Parents
+	// The home page is only ever compared against here -- never used as a
+	// parent -- so a space that will not give one up is not a reason to refuse
+	// the document. Failing on it aborted every file in the space, including
+	// documents whose Parent headers never needed a home page at all.
 	homepage, err := api.FindHomePage(meta.Space)
 	if err != nil {
-		return nil, nil, fmt.Errorf("can't obtain home page from space %q: %w", meta.Space, err)
+		log.Debug().Err(err).Msgf(
+			"no home page for space %q; publishing without comparing against one",
+			meta.Space,
+		)
+
+		homepage = nil
 	}
 
 	skipHomeAncestry := false
-	if len(meta.Parents) > 0 {
+	if homepage != nil && len(meta.Parents) > 0 {
 		if homepage.Title == meta.Parents[0] {
 			skipHomeAncestry = true
 		}


### PR DESCRIPTION
Both places that ask for the home page only ever compare against it -- is the
first declared parent the home page, is this parentless page the home page --
and neither uses it as a parent. Returning the zero PageInfo when a v1 200 came
back without the expansion was rightly fixed, but the error that replaced it
went to callers that had no use for the answer, so a space that would not give
one up failed every document in it. Including the ones whose Parent headers
never needed a home page at all.

Both now treat "no home page" as "nothing to compare against": the first parent
is not skipped, and a page with no ancestors falls through to the misplacement
the code below already handles -- which is recoverable, where refusing outright
was not.

Paired with only caching outcomes that cannot change: together they mean a
moment's outage costs one document a retry rather than costing every remaining
document in the space its publish.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
