### PR TITLE
fix: check the compiled body in --compile-only too

### DIFF
--- a/mark.go
+++ b/mark.go
@@ -616,6 +616,19 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		if _, err := fmt.Fprintln(config.output(), html); err != nil {
 			return nil, nil, err
 		}
+
+		// Checked here as well as before an upload. Validating documents in CI
+		// without Confluence credentials is the whole of what --compile-only is
+		// for, and a body that Confluence would reject outright passed that
+		// check silently -- so the failure was found at publish time by the
+		// person who could least act on it.
+		//
+		// The layout wrap and the comment merge are missing from this output,
+		// and neither introduces the errors this catches.
+		if err := markmd.CheckWellFormed(html); err != nil {
+			return nil, nil, err
+		}
+
 		return nil, nil, nil
 	}
 

--- a/mark_wellformed_test.go
+++ b/mark_wellformed_test.go
@@ -128,3 +128,44 @@ An <span>unclosed tag.
 	assert.Empty(t, bodyOfPageTitled(t, server, "Bad"),
 		"the malformed one should have uploaded no body")
 }
+
+// TestCompileOnlyRefusesAMalformedBody: validating documents in CI without
+// Confluence credentials is the whole of what --compile-only is for, and the
+// gate ran only on the path that uploads -- so the mode that exists to catch
+// this exited zero and the failure was found at publish time instead.
+func TestCompileOnlyRefusesAMalformedBody(t *testing.T) {
+	dir := t.TempDir()
+	file := writeFile(t, dir, "doc.md", `<!-- Space: DOCS -->
+<!-- Title: Malformed -->
+
+Text with an <span>unclosed tag.
+`)
+
+	err := Run(Config{
+		Files: file, CompileOnly: true,
+		Features: []string{"mention"}, Output: io.Discard,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not well-formed XML")
+}
+
+// TestCompileOnlyAcceptsAWellFormedBody is the control: the check must not
+// stand in the way of the markup mark itself emits.
+func TestCompileOnlyAcceptsAWellFormedBody(t *testing.T) {
+	dir := t.TempDir()
+	file := writeFile(t, dir, "doc.md", `<!-- Space: DOCS -->
+<!-- Title: Fine -->
+
+A & B, "quoted", 3 < 4, and a table:
+
+| a | b |
+|---|---|
+| 1 | 2 |
+`)
+
+	require.NoError(t, Run(Config{
+		Files: file, CompileOnly: true,
+		Features: []string{"mention"}, Output: io.Discard,
+	}))
+}


### PR DESCRIPTION
The well-formedness check ran only inside the branch that uploads, and
--compile-only returns long before it. So the mode whose entire purpose is
validating documents in CI, without Confluence credentials, printed a body
Confluence would reject in its entirety and exited zero -- leaving the failure
to be found at publish time, by whoever was least able to act on it.

The compile-only output has no layout wrap and no merged comments, and neither
of those introduces the errors this catches, so the same check answers the same
way on both paths.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
