### PR TITLE
fix(renderer): "-" is no language, and a brace in a title is part of it

### DIFF
--- a/renderer/fencedcodeblock.go
+++ b/renderer/fencedcodeblock.go
@@ -48,7 +48,12 @@ var reBlockDetails = regexp.MustCompile(
 // published a Confluence code macro with a theme of "}" and of
 // "{.line-numbers}" respectively, and the first also lost its language and had
 // its line numbering turned on by the digits inside hl_lines.
-var reAttributeBlock = regexp.MustCompile(`\{[^}]*\}`)
+//
+// Anchored to the ends of the info string, which is the only place Pandoc and
+// MkDocs put one. Matching anywhere took a brace out of a title written in the
+// documented space form -- "```js title Some {Thing} Here" published its
+// caption as "Some  Here".
+var reAttributeBlock = regexp.MustCompile(`^\{[^}]*\}|\{[^}]*\}$`)
 
 // reAttributeLang matches the ".language" class inside an attribute block,
 // which is where the language is named when the block is the whole info
@@ -67,6 +72,17 @@ var reAssignedTitle = regexp.MustCompile(`\btitle\s*=\s*(?:"([^"]*)"|'([^']*)'|(
 // is given.
 func parseBlockDetails(info string) (lang string, options []string, title string) {
 	info = strings.TrimSpace(info)
+
+	// "-" is the documented way to write "no language, but there are options
+	// after it" -- README's "```- 1 collapse midnight title ...". Widening the
+	// language class to accept the hyphens in real language names made the bare
+	// marker match as a language of its own, so the macro was published with
+	// ac:name="language" set to "-".
+	noLanguage := false
+	if info == "-" || strings.HasPrefix(info, "- ") {
+		noLanguage = true
+		info = strings.TrimSpace(strings.TrimPrefix(info, "-"))
+	}
 
 	if groups := reAssignedTitle.FindStringSubmatch(info); groups != nil {
 		for _, group := range groups[1:] {
@@ -95,7 +111,7 @@ func parseBlockDetails(info string) (lang string, options []string, title string
 		return lang, nil, title
 	}
 
-	if lang == "" {
+	if lang == "" && !noLanguage {
 		lang = groups[1]
 	}
 	if title == "" {

--- a/renderer/fencedcodeblock_test.go
+++ b/renderer/fencedcodeblock_test.go
@@ -136,20 +136,52 @@ func TestFencedCodeBlockOptions(t *testing.T) {
 	}
 }
 
-// TestFencedCodeBlockDashLanguage records what the "-" prefix currently does,
-// which is not what the README says it does.
+// TestFencedCodeBlockDashLanguage covers the "-" the README offers as the way
+// to write a block with no language but with the other options after it
+// ("- 1 collapse midnight title ...").
 //
-// The README offers "-" as the way to write a block with no language but with
-// the other options ("- 1 collapse midnight title ..."). The regex means to
-// allow that -- its comment reads (<Lang>|-) -- but "-" is also in the language
-// character class, so the first alternative matches it and the language
-// parameter is published as a literal "-" rather than left empty.
+// The regex always meant to allow it -- its comment reads (<Lang>|-) -- but
+// widening the language class to accept the hyphens in real language names
+// (objective-c) made the bare marker match as a language of its own, and the
+// macro went out with ac:name="language" set to a literal "-".
 func TestFencedCodeBlockDashLanguage(t *testing.T) {
 	actual := fencedCode(t, "- 1 collapse title Some long long code")
 	assertWellFormed(t, actual)
 
-	assert.Contains(t, actual, `<ac:parameter ac:name="language">-</ac:parameter>`)
+	assert.Contains(t, actual, `<ac:parameter ac:name="language"></ac:parameter>`,
+		"the marker means no language, not a language called -")
 	assert.Contains(t, actual, `<ac:parameter ac:name="title">Some long long code</ac:parameter>`)
+	assert.Contains(t, actual, `<ac:parameter ac:name="collapse">true</ac:parameter>`,
+		"and the options after it are still read")
+}
+
+// TestFencedCodeBlockDashAlone is the marker with nothing after it.
+func TestFencedCodeBlockDashAlone(t *testing.T) {
+	actual := fencedCode(t, "-")
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `<ac:parameter ac:name="language"></ac:parameter>`)
+}
+
+// TestFencedCodeBlockLanguageWithAHyphenSurvives is the reason the class was
+// widened in the first place, and has to keep working.
+func TestFencedCodeBlockLanguageWithAHyphenSurvives(t *testing.T) {
+	actual := fencedCode(t, "objective-c")
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `<ac:parameter ac:name="language">objective-c</ac:parameter>`)
+}
+
+// TestFencedCodeBlockBraceInATitleIsKept: the attribute-block pattern is for
+// the "{ .js hl_lines=... }" list Pandoc and MkDocs write at one end of the
+// info string. Matching it anywhere took a brace out of a title written in the
+// documented space form.
+func TestFencedCodeBlockBraceInATitleIsKept(t *testing.T) {
+	actual := fencedCode(t, "js title Some {Thing} Here")
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, `<ac:parameter ac:name="title">Some {Thing} Here</ac:parameter>`)
+	assert.Contains(t, actual, `<ac:parameter ac:name="language">js</ac:parameter>`)
 }
 
 // TestFencedCodeBlockEscapesTheCDATATerminator covers a code sample carrying


### PR DESCRIPTION
Two regressions from reading the info strings MkDocs and Pandoc write.

README offers "-" as the way to open a block with no language but with the
options after it: "```- 1 collapse midnight title ...". Widening the language
class to accept the hyphens in real language names -- objective-c, and the rest
of what the class was widened for -- made the bare marker match as a language,
so the macro went out with ac:name="language" set to a literal "-". The
alternation that was there to allow it, (<Lang>|-), became unreachable.

The attribute-block pattern matched "{...}" anywhere in the info string, and
Pandoc and MkDocs only ever write one at an end of it. A title written in the
documented space form lost any brace inside it: "```js title Some {Thing} Here"
published a caption of "Some  Here".

The test that recorded the "-" behaviour said in its own comment that it was
not what README describes; it now pins what README describes. A language that
genuinely contains a hyphen is covered alongside it, since that is what the
class was widened for.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
