### PR TITLE
fix(renderer): decide the <p> by where the element closes, not by its name

### DIFF
--- a/markdown/paragraph_rawhtml_test.go
+++ b/markdown/paragraph_rawhtml_test.go
@@ -59,3 +59,35 @@ func compileParagraphDoc(t *testing.T, src string, features ...string) string {
 
 	return out
 }
+
+// TestParagraphWithTwoElementsOfTheSameName: the wrapper was dropped whenever
+// the paragraph's first and last fragments were tags of the same name, which is
+// true of prose bracketed by two separate elements. The text between them ended
+// up at bare body level.
+func TestParagraphWithTwoElementsOfTheSameName(t *testing.T) {
+	out := compileParagraphDoc(t, "<em>Hello</em> world <em>again</em>\n")
+
+	assert.Contains(t, out, "<p><em>Hello</em> world <em>again</em></p>",
+		"two elements of the same name are not one element around the prose")
+}
+
+// TestParagraphWithACompleteConfluenceElement: an ac: element that opens and
+// closes inside the paragraph is complete, so whatever follows it is prose and
+// belongs in the wrapper. The opening tag was judged on its own, and an
+// <ac:link> is not self-closing, so the paragraph was unwrapped and the trailing
+// prose left at body level.
+func TestParagraphWithACompleteConfluenceElement(t *testing.T) {
+	out := compileParagraphDoc(t, "<ac:link>foo</ac:link> and more prose.\n")
+
+	assert.Contains(t, out, "<p><ac:link>foo</ac:link> and more prose.</p>")
+}
+
+// TestParagraphThatOnlyOpensAConfluenceElement is the case both of the above
+// have to leave alone: a half of an element spread over several blocks, where a
+// <p> would interleave with the element being built.
+func TestParagraphThatOnlyOpensAConfluenceElement(t *testing.T) {
+	out := compileParagraphDoc(t, "<ac:layout-cell>\n\nInside.\n\n</ac:layout-cell>\n")
+
+	assert.NotContains(t, out, "<p><ac:layout-cell>")
+	assert.Contains(t, out, "<p>Inside.</p>")
+}

--- a/renderer/paragraph.go
+++ b/renderer/paragraph.go
@@ -73,13 +73,59 @@ func unwrapParagraph(n ast.Node, source []byte) bool {
 
 	firstTag := rawHTMLTag(first, source)
 
-	if last, ok := n.LastChild().(*ast.RawHTML); ok {
-		if closesTag(firstTag, rawHTMLTag(last, source)) {
-			return true
+	// Where does the element the first fragment opens close?
+	//
+	// Comparing the first and last fragments by name alone said "<em>Hello</em>
+	// world <em>again</em>" was one element with prose inside it, because the
+	// last fragment happens to close an element of the same name. Counting
+	// depth tells the two apart: an element whose closer is the last thing in
+	// the paragraph wraps the whole of it, and one that closes earlier leaves
+	// prose outside it, which is what a <p> is for.
+	if closer := closingFragment(n, firstTag, source); closer != nil {
+		return closer == n.LastChild()
+	}
+
+	// Never closed here: half of an element the author spread over several
+	// blocks, where a <p> would interleave with the element being built.
+	return spansConfluenceElement(firstTag)
+}
+
+// closingFragment returns the fragment that closes the element opened by
+// firstTag, or nil if the paragraph does not close it.
+func closingFragment(n ast.Node, firstTag []byte, source []byte) ast.Node {
+	if !isOpeningTag(firstTag) {
+		return nil
+	}
+
+	name := tagName(firstTag)
+	if len(name) == 0 {
+		return nil
+	}
+
+	depth := 0
+	for child := n.FirstChild(); child != nil; child = child.NextSibling() {
+		raw, ok := child.(*ast.RawHTML)
+		if !ok {
+			continue
+		}
+
+		tag := rawHTMLTag(raw, source)
+		if !bytes.EqualFold(tagName(tag), name) {
+			continue
+		}
+
+		switch {
+		case isOpeningTag(tag):
+			depth++
+		case bytes.HasPrefix(tag, []byte("</")):
+			depth--
+			if depth == 0 {
+				return child
+			}
 		}
 	}
 
-	return spansConfluenceElement(firstTag)
+	return nil
 }
 
 // rawHTMLTag returns the fragment's bytes, which for an inline raw HTML node is
@@ -91,18 +137,6 @@ func rawHTMLTag(n *ast.RawHTML, source []byte) []byte {
 		buf.Write(segment.Value(source))
 	}
 	return bytes.TrimSpace(buf.Bytes())
-}
-
-// closesTag reports whether closing is the closing tag of the element that
-// opening opens.
-func closesTag(opening []byte, closing []byte) bool {
-	if !isOpeningTag(opening) || !bytes.HasPrefix(closing, []byte("</")) {
-		return false
-	}
-
-	name := tagName(opening)
-
-	return len(name) > 0 && bytes.EqualFold(name, tagName(closing))
 }
 
 // spansConfluenceElement reports whether the fragment is the opening or closing


### PR DESCRIPTION
Suppressing the wrapper whenever a paragraph merely began with raw HTML was
already fixed. The narrower rule that replaced it is wrong in two shapes of its
own, and both put prose at bare body level:

    <em>Hello</em> world <em>again</em>

The first and last fragments are tags of the same name, so they were read as one
element wrapping the whole paragraph. They are two elements with prose between
and around them.

    <ac:link>foo</ac:link> and more prose.

The opening tag was judged on its own: an <ac:link> is not self-closing, so it
was taken for half of an element spread over several blocks -- without looking
for the closer sitting in the same paragraph.

Both answers come from counting depth instead. The element the first fragment
opens either closes on the paragraph's last child, in which case it wraps
everything and the <p> is redundant, or it closes earlier and leaves prose
outside it, or it never closes here and really is a half. closesTag compared
names and had no way to tell the first two apart, so it is gone.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
