### PR TITLE
feat(parser): read a "$$" fence as a block, so a formula may contain blank lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1283,10 +1283,17 @@ $$
 $$
 ```
 
+The `\[` and `\]` markers work the same way, and a run of more than two
+dollars is matched by its own length, so `$$$` opens and closes a formula too.
+
 Written that way the formula is a block of its own, so it may sit inside a
 blockquote or a list item without the `>` or the indentation reaching LaTeX. A
 formula that opens and closes on one line — `$$E = mc^2$$` — is read as it
 always was, wherever it is written.
+
+`\[` is CommonMark's escape for a literal bracket, so the bracket form is only
+read as a formula when the formula is the whole of the line it is on: `use
+\[brackets\] here` is a sentence about brackets.
 
 A dollar sign in ordinary prose is left alone: a formula may not begin or end
 with a space, so `it costs $5 and $7 today` is a sentence about money rather

--- a/README.md
+++ b/README.md
@@ -1269,10 +1269,31 @@ f(x) = \int_{-\infty}^\infty \hat{f}(\xi)\,e^{2\pi i \xi x}\,d\xi
 \]
 ```
 
+A `$$` alone on a line opens a formula that runs to the next `$$` alone on a
+line, so a formula may contain blank lines — which is how `aligned` and
+`gather` environments are written:
+
+```markdown
+$$
+\begin{aligned}
+  a &= b + c \\
+
+  d &= e + f
+\end{aligned}
+$$
+```
+
+Written that way the formula is a block of its own, so it may sit inside a
+blockquote or a list item without the `>` or the indentation reaching LaTeX. A
+formula that opens and closes on one line — `$$E = mc^2$$` — is read as it
+always was, wherever it is written.
+
 A dollar sign in ordinary prose is left alone: a formula may not begin or end
 with a space, so `it costs $5 and $7 today` is a sentence about money rather
 than mathematics. `\$5` is always literal, and anything inside a code span or a
-code block is quoted rather than rendered.
+code block is quoted rather than rendered — including a `$$` fence, so a
+document explaining this syntax publishes the example rather than a picture of
+it.
 
 A formula MathJax cannot read fails the file, quoting both the formula and the
 complaint — `unable to render formula "\frac{a": Missing close brace` — rather

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -501,6 +501,14 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 
 	// Add math / latex formula support if requested
 	if slices.Contains(c.MarkConfig.Features, "math") {
+		m.Parser().AddOptions(parser.WithBlockParsers(
+			// Between goldmark's fenced code block (700) and its block quote
+			// (800). Below the fence so that a "$$" shown inside one stays a
+			// code sample, and above the paragraph (1000) it would otherwise
+			// become.
+			util.Prioritized(cparser.NewMathBlockParser(), 750),
+		))
+
 		m.Parser().AddOptions(parser.WithInlineParsers(
 			// Ahead of goldmark's own inline parsers, so that a formula holding
 			// markup characters -- and TeX is made of them -- is taken as a

--- a/markdown/math_block_test.go
+++ b/markdown/math_block_test.go
@@ -109,3 +109,51 @@ func TestUnclosedMathFenceDoesNotSwallowTheDocument(t *testing.T) {
 
 	assert.Equal(t, 1, strings.Count(out, "<ac:image"))
 }
+
+// TestBracketFenceIsABlock: "\[" on a line of its own opens a display formula
+// the same way "$$" does. Read as an inline the formula carried the blockquote
+// marker into LaTeX -- and "> " is valid in math mode, so MathJax typeset it
+// happily and published a quietly wrong picture rather than failing.
+func TestBracketFenceIsABlock(t *testing.T) {
+	quoted := compileMath(t, "> \\[\n> E = mc^2\n> \\]\n")
+
+	assert.Contains(t, quoted, `ac:alt="E = mc^2"`)
+	assert.NotContains(t, quoted, "&gt; E = mc")
+	assert.Contains(t, quoted, "<blockquote>")
+
+	// The equation no longer carries the newlines the markers sat on either.
+	plain := compileMath(t, "\\[\nE = mc^2\n\\]\n")
+	assert.Contains(t, plain, `ac:alt="E = mc^2"`)
+}
+
+// TestBracketsInProseStayLiteral: "\[" is CommonMark's escape for a literal
+// bracket, so a sentence using it is prose. Parsing it as a formula published a
+// picture of the word and uploaded an attachment for it.
+func TestBracketsInProseStayLiteral(t *testing.T) {
+	out := compileMath(t, "Use \\[brackets\\] literally here.\n")
+
+	assert.NotContains(t, out, "<ac:image")
+	assert.Contains(t, out, "[brackets]")
+}
+
+// TestBracketFormulaAloneOnALineStillRenders is the line between the two above:
+// display math written on its own line, opening and closing together, is what
+// the README documents and what testdata/math.md carries.
+func TestBracketFormulaAloneOnALineStillRenders(t *testing.T) {
+	out := compileMath(t, "Text.\n\n\\[\\begin{pmatrix} a & b \\end{pmatrix}\\]\n\nMore.\n")
+
+	assert.Contains(t, out, "<ac:image")
+	assert.Contains(t, out, `\begin{pmatrix}`)
+}
+
+// TestLongerDollarFenceIsMatchedByItsOwnLength: a run of three was read as a
+// "$$" fence with a stray "$" after it, which the inline parser then published
+// beside the image.
+func TestLongerDollarFenceIsMatchedByItsOwnLength(t *testing.T) {
+	out := compileMath(t, "$$$\nE = mc^2\n$$$\n")
+
+	assert.Contains(t, out, `ac:alt="E = mc^2"`)
+	assert.Equal(t, 1, strings.Count(out, "<ac:image"))
+	assert.NotContains(t, out, "<p>$</p>")
+	assert.NotContains(t, out, "</ac:image>$")
+}

--- a/markdown/math_block_test.go
+++ b/markdown/math_block_test.go
@@ -1,0 +1,111 @@
+package mark
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// compileMath compiles a document with the math feature on, which is the only
+// way any of this is reachable.
+func compileMath(t *testing.T, src string) string {
+	t.Helper()
+
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	out, _, err := CompileMarkdown([]byte(src), std, "test.md", types.MarkConfig{
+		Features:   []string{"math"},
+		MathFormat: "svg",
+	})
+	require.NoError(t, err)
+
+	return out
+}
+
+// TestMathBlockSpansABlankLine is what the block form exists for. An aligned
+// environment is written with blank lines in it, and an inline parser is handed
+// one block at a time -- so the formula was two blocks to goldmark and could not
+// be seen whole from inside either.
+//
+// Reading past the end of the block instead, which is what the inline parser
+// did before it was bounded, swallowed the paragraphs in between and published
+// them twice.
+func TestMathBlockSpansABlankLine(t *testing.T) {
+	out := compileMath(t, `$$
+\begin{aligned}
+a &= b \\
+
+c &= d
+\end{aligned}
+$$
+
+Prose after.
+`)
+
+	assert.Contains(t, out, `c &amp;= d`, "the whole environment is one formula")
+	assert.Equal(t, 1, strings.Count(out, "<ac:image"), "and it is one image")
+
+	assert.Contains(t, out, "<p>Prose after.</p>",
+		"the paragraph after it is published once, as itself")
+	assert.NotContains(t, out, "<p>\\begin{aligned}",
+		"and the formula's source is not published beside its picture")
+}
+
+// TestMathBlockInABlockquoteDropsThePrefix: the block's lines come from
+// goldmark's own segments, which have already had the "> " taken off. The
+// inline parser reads contiguous source instead, so the prefix went to LaTeX.
+func TestMathBlockInABlockquoteDropsThePrefix(t *testing.T) {
+	out := compileMath(t, "> $$\n> E = mc^2\n> $$\n")
+
+	assert.Contains(t, out, `ac:alt="E = mc^2"`)
+	assert.NotContains(t, out, `ac:alt="&gt;`)
+	assert.Contains(t, out, "<blockquote>", "and it stays inside the quotation")
+}
+
+// TestMathBlockInAListItemDropsTheIndent is the same property for the other
+// construct that prefixes its lines.
+func TestMathBlockInAListItemDropsTheIndent(t *testing.T) {
+	out := compileMath(t, "- item\n\n  $$\n  E = mc^2\n  $$\n")
+
+	assert.Contains(t, out, `ac:alt="E = mc^2"`)
+	assert.NotContains(t, out, `ac:alt="  `)
+}
+
+// TestSingleLineFormulaIsUnchanged: a formula that opens and closes on one line
+// is the inline parser's, whether it stands alone or sits in a sentence. The
+// block parser must not claim it -- it has always worked, and taking it would
+// move the picture out of the paragraph it belongs to.
+func TestSingleLineFormulaIsUnchanged(t *testing.T) {
+	alone := compileMath(t, "$$E = mc^2$$\n")
+	assert.Contains(t, alone, "<p><ac:image", "still a paragraph of its own")
+
+	inSentence := compileMath(t, "The identity $$E = mc^2$$ is famous.\n")
+	assert.Contains(t, inSentence, "<p>The identity <ac:image")
+	assert.Contains(t, inSentence, "is famous.</p>")
+}
+
+// TestMathFenceInsideACodeBlockStaysCode: the block parser sits below
+// goldmark's fenced code block, so a document explaining the syntax publishes
+// the example rather than rendering it.
+func TestMathFenceInsideACodeBlockStaysCode(t *testing.T) {
+	out := compileMath(t, "```markdown\n$$\nE = mc^2\n$$\n```\n")
+
+	assert.Contains(t, out, `ac:name="code"`)
+	assert.Contains(t, out, "$$", "the fence is published as the example it is")
+	assert.NotContains(t, out, "<ac:image")
+}
+
+// TestUnclosedMathFenceDoesNotSwallowTheDocument: an opening fence with no
+// closer takes the rest of the document, which is what a fenced code block does
+// too. What matters is that it is one formula rather than a parse that runs
+// away.
+func TestUnclosedMathFenceDoesNotSwallowTheDocument(t *testing.T) {
+	out := compileMath(t, "$$\nE = mc^2\n\nstill inside\n")
+
+	assert.Equal(t, 1, strings.Count(out, "<ac:image"))
+}

--- a/parser/math.go
+++ b/parser/math.go
@@ -61,13 +61,20 @@ type delimiter struct {
 	// just inside either marker. It is only needed for "$", which is the only
 	// marker that occurs in ordinary writing.
 	strict bool
+	// lineWide requires the formula to be the whole of the line it is written
+	// on. "\[" is CommonMark's escape for a literal bracket, so a sentence
+	// like "use \[brackets\] here" is prose that happens to contain the
+	// marker -- and rendering it produced a picture of the word "brackets" and
+	// uploaded an attachment for it. Display math is written on a line of its
+	// own, so the two are told apart by where the formula sits.
+	lineWide bool
 }
 
 // delimiters are tried in order, so the two-character "$$" has to be tried
 // before the one-character "$" that is its prefix.
 var delimiters = []delimiter{
 	{open: "$$", close: "$$", display: true, multiline: true},
-	{open: `\[`, close: `\]`, display: true, multiline: true},
+	{open: `\[`, close: `\]`, display: true, multiline: true, lineWide: true},
 	{open: `\(`, close: `\)`},
 	{open: "$", close: "$", strict: true},
 }
@@ -120,6 +127,26 @@ func (s *mathParser) Parse(parent ast.Node, block text.Reader, pc parser.Context
 	}
 
 	return nil
+}
+
+// spansWholeLine reports whether nothing but whitespace shares the formula's
+// line with it.
+//
+// The multi-line forms are allowed to run past the end of their first line, so
+// only what precedes the opening marker and what follows the closing one is
+// examined.
+func spansWholeLine(source []byte, start, end int) bool {
+	before := source[:start]
+	if at := bytes.LastIndexByte(before, '\n'); at >= 0 {
+		before = before[at+1:]
+	}
+
+	after := source[end:]
+	if at := bytes.IndexByte(after, '\n'); at >= 0 {
+		after = after[:at]
+	}
+
+	return len(bytes.TrimSpace(before)) == 0 && len(bytes.TrimSpace(after)) == 0
 }
 
 // blockEnd is the offset just past the block goldmark is parsing inlines for.
@@ -181,5 +208,11 @@ func (d delimiter) scan(source []byte, start int) (equation []byte, width int, o
 		return nil, 0, false
 	}
 
-	return equation, len(d.open) + end + len(d.close), true
+	width = len(d.open) + end + len(d.close)
+
+	if d.lineWide && !spansWholeLine(source, start, start+width) {
+		return nil, 0, false
+	}
+
+	return equation, width, true
 }

--- a/parser/mathblock.go
+++ b/parser/mathblock.go
@@ -36,6 +36,10 @@ type MathBlock struct {
 	// Equation is the formula's source, assembled once the closing fence is
 	// found. Empty until then.
 	Equation []byte
+
+	// fence is the pair of markers this block was opened with, so the closer
+	// looked for is the one that matches the opener.
+	fence fence
 }
 
 func (m *MathBlock) Dump(source []byte, level int) {
@@ -64,11 +68,73 @@ func NewMathBlock() *MathBlock {
 	return &MathBlock{}
 }
 
-// mathBlockFence is the marker that opens and closes the block. Only "$$" has
-// the block form: "\[" and "\]" are written around a formula rather than on
-// lines of their own, and a document that puts them on their own lines is read
-// the same way by the inline parser.
-var mathBlockFence = []byte("$$")
+// fence is one pair of markers that can stand on lines of their own around a
+// display formula.
+type fence struct {
+	// dollars says the opener is a run of two or more "$", closed by another
+	// run of two or more. Counting rather than matching a fixed "$$" is what
+	// makes "$$$" a fence rather than a "$$" with a stray dollar after it.
+	dollars bool
+	open    []byte
+	close   []byte
+}
+
+var fences = []fence{
+	{dollars: true},
+	{open: []byte(`\[`), close: []byte(`\]`)},
+}
+
+// openingFence reports which fence, if any, a line opens with, and whether
+// anything follows it.
+//
+// Only a fence with nothing after it opens a block. A formula that opens and
+// closes on one line is left to the inline parser, which has always handled it
+// and whose one-line answer never needed bounding.
+func openingFence(line []byte, pos int) (fence, bool) {
+	rest := line[pos:]
+
+	if run := dollarRun(rest); run >= 2 {
+		if len(bytes.TrimSpace(rest[run:])) > 0 {
+			return fence{}, false
+		}
+
+		return fences[0], true
+	}
+
+	for _, f := range fences[1:] {
+		if !bytes.HasPrefix(rest, f.open) {
+			continue
+		}
+		if len(bytes.TrimSpace(rest[len(f.open):])) > 0 {
+			return fence{}, false
+		}
+
+		return f, true
+	}
+
+	return fence{}, false
+}
+
+// closesBlock reports whether a line is the closing fence.
+func (f fence) closesBlock(line []byte) bool {
+	trimmed := bytes.TrimSpace(line)
+
+	if f.dollars {
+		return len(trimmed) >= 2 && dollarRun(trimmed) == len(trimmed)
+	}
+
+	return bytes.Equal(trimmed, f.close)
+}
+
+// dollarRun counts the "$" a slice opens with.
+func dollarRun(b []byte) int {
+	run := 0
+	for run < len(b) && b[run] == '$' {
+		run++
+	}
+
+	return run
+}
 
 type mathBlockParser struct{}
 
@@ -79,34 +145,35 @@ func NewMathBlockParser() parser.BlockParser {
 }
 
 func (b *mathBlockParser) Trigger() []byte {
-	return []byte{'$'}
+	return []byte{'$', '\\'}
 }
 
 func (b *mathBlockParser) Open(parent ast.Node, reader text.Reader, pc parser.Context) (ast.Node, parser.State) {
 	line, segment := reader.PeekLine()
 
 	pos := pc.BlockOffset()
-	if pos < 0 || !bytes.HasPrefix(line[pos:], mathBlockFence) {
+	if pos < 0 {
 		return nil, parser.NoChildren
 	}
 
-	// Only a fence with nothing after it opens a block. A formula that opens
-	// and closes on one line -- "$$E = mc^2$$", whether alone on the line or in
-	// the middle of a sentence -- is left to the inline parser, which has
-	// always handled it and whose one-line answer never needed bounding.
-	if len(bytes.TrimSpace(line[pos+len(mathBlockFence):])) > 0 {
+	opened, ok := openingFence(line, pos)
+	if !ok {
 		return nil, parser.NoChildren
 	}
 
 	reader.Advance(segment.Len() - 1)
 
-	return NewMathBlock(), parser.NoChildren
+	node := NewMathBlock()
+	node.fence = opened
+
+	return node, parser.NoChildren
 }
 
 func (b *mathBlockParser) Continue(node ast.Node, reader text.Reader, pc parser.Context) parser.State {
 	line, segment := reader.PeekLine()
 
-	if bytes.Equal(bytes.TrimSpace(line), mathBlockFence) {
+	block, ok := node.(*MathBlock)
+	if ok && block.fence.closesBlock(line) {
 		reader.Advance(segment.Len() - 1)
 
 		return parser.Close

--- a/parser/mathblock.go
+++ b/parser/mathblock.go
@@ -1,0 +1,151 @@
+package parser
+
+import (
+	"bytes"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+// MathBlock is a display formula written on lines of its own:
+//
+//	$$
+//	\begin{aligned}
+//	a &= b \\
+//	c &= d
+//	\end{aligned}
+//	$$
+//
+// A block rather than an inline node because that is what it is. An inline
+// parser is handed one block at a time, so a formula containing a blank line --
+// which is how aligned environments are written -- is two blocks to goldmark
+// and cannot be seen whole from inside either of them. Reading the source past
+// the end of the block instead is what the inline parser used to do, and it
+// swallowed the paragraphs in between and published them twice.
+//
+// The block form also settles two things the inline one gets wrong by
+// construction. Its lines come from the block's own segments, so a formula
+// inside a blockquote or a list item carries neither the "> " nor the
+// indentation into the equation. And it cannot fire mid-sentence, so "\[" in
+// running prose stays the escape for a literal bracket that CommonMark says it
+// is.
+type MathBlock struct {
+	ast.BaseBlock
+
+	// Equation is the formula's source, assembled once the closing fence is
+	// found. Empty until then.
+	Equation []byte
+}
+
+func (m *MathBlock) Dump(source []byte, level int) {
+	ast.DumpHelper(m, source, level, map[string]string{
+		"Equation": string(m.Equation),
+	}, nil)
+}
+
+var KindMathBlock = ast.NewNodeKind("MathBlock")
+
+func (m *MathBlock) Kind() ast.NodeKind {
+	return KindMathBlock
+}
+
+// IsRaw keeps goldmark from parsing inlines into the block.
+//
+// Without it the parser walks the block's lines and builds Text children out of
+// them, exactly as it does for a paragraph -- so the formula was published as
+// its picture and then again, immediately after it, as the TeX source. A fenced
+// code block declares itself raw for the same reason.
+func (m *MathBlock) IsRaw() bool {
+	return true
+}
+
+func NewMathBlock() *MathBlock {
+	return &MathBlock{}
+}
+
+// mathBlockFence is the marker that opens and closes the block. Only "$$" has
+// the block form: "\[" and "\]" are written around a formula rather than on
+// lines of their own, and a document that puts them on their own lines is read
+// the same way by the inline parser.
+var mathBlockFence = []byte("$$")
+
+type mathBlockParser struct{}
+
+// NewMathBlockParser returns a parser for display formulas fenced by "$$" on a
+// line of its own.
+func NewMathBlockParser() parser.BlockParser {
+	return &mathBlockParser{}
+}
+
+func (b *mathBlockParser) Trigger() []byte {
+	return []byte{'$'}
+}
+
+func (b *mathBlockParser) Open(parent ast.Node, reader text.Reader, pc parser.Context) (ast.Node, parser.State) {
+	line, segment := reader.PeekLine()
+
+	pos := pc.BlockOffset()
+	if pos < 0 || !bytes.HasPrefix(line[pos:], mathBlockFence) {
+		return nil, parser.NoChildren
+	}
+
+	// Only a fence with nothing after it opens a block. A formula that opens
+	// and closes on one line -- "$$E = mc^2$$", whether alone on the line or in
+	// the middle of a sentence -- is left to the inline parser, which has
+	// always handled it and whose one-line answer never needed bounding.
+	if len(bytes.TrimSpace(line[pos+len(mathBlockFence):])) > 0 {
+		return nil, parser.NoChildren
+	}
+
+	reader.Advance(segment.Len() - 1)
+
+	return NewMathBlock(), parser.NoChildren
+}
+
+func (b *mathBlockParser) Continue(node ast.Node, reader text.Reader, pc parser.Context) parser.State {
+	line, segment := reader.PeekLine()
+
+	if bytes.Equal(bytes.TrimSpace(line), mathBlockFence) {
+		reader.Advance(segment.Len() - 1)
+
+		return parser.Close
+	}
+
+	node.Lines().Append(segment)
+
+	return parser.Continue | parser.NoChildren
+}
+
+func (b *mathBlockParser) Close(node ast.Node, reader text.Reader, pc parser.Context) {
+	block, ok := node.(*MathBlock)
+	if !ok || len(block.Equation) > 0 {
+		return
+	}
+
+	// Assembled from the block's own line segments, which is what leaves a
+	// blockquote's "> " and a list item's indentation out of the equation:
+	// goldmark has already taken the prefix off each line by the time it
+	// records the segment.
+	var buf bytes.Buffer
+
+	lines := block.Lines()
+	source := reader.Source()
+
+	for i := 0; i < lines.Len(); i++ {
+		line := lines.At(i)
+		buf.Write(line.Value(source))
+	}
+
+	block.Equation = bytes.TrimSpace(buf.Bytes())
+}
+
+func (b *mathBlockParser) CanInterruptParagraph() bool {
+	return true
+}
+
+func (b *mathBlockParser) CanAcceptIndentedLine() bool {
+	// Four spaces make an indented code block, and a formula indented that far
+	// is a code sample about one.
+	return false
+}

--- a/renderer/math.go
+++ b/renderer/math.go
@@ -42,6 +42,24 @@ func NewConfluenceMathRenderer(stdlib *stdlib.Lib, attachments attachment.Attach
 // RegisterFuncs implements NodeRenderer.RegisterFuncs .
 func (r *ConfluenceMathRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
 	reg.Register(cparser.KindMath, r.renderMath)
+	reg.Register(cparser.KindMathBlock, r.renderMathBlock)
+}
+
+// renderMathBlock publishes a display formula written on lines of its own. The
+// picture is the same one an inline display formula gets; only where it sits on
+// the page differs, and that is the block structure around it rather than
+// anything here.
+func (r *ConfluenceMathRenderer) renderMathBlock(writer util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+
+	n, ok := node.(*cparser.MathBlock)
+	if !ok {
+		return ast.WalkContinue, nil
+	}
+
+	return r.writeFormula(writer, n.Equation, true)
 }
 
 func (r *ConfluenceMathRenderer) renderMath(writer util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
@@ -51,11 +69,16 @@ func (r *ConfluenceMathRenderer) renderMath(writer util.BufWriter, source []byte
 
 	n := node.(*cparser.Math)
 
+	return r.writeFormula(writer, n.Equation, n.Display)
+}
+
+// writeFormula renders one formula and writes the ac:image that shows it.
+func (r *ConfluenceMathRenderer) writeFormula(writer util.BufWriter, equation []byte, display bool) (ast.WalkStatus, error) {
 	// The error math.Process returns names the formula it could not render,
-	// which locates it better than a line number would: an inline formula has
-	// no position of its own in the AST, and a document usually has few enough
+	// which locates it better than a line number would: a formula has no
+	// position of its own in the AST, and a document usually has few enough
 	// formulas that the source is the clearer identifier.
-	rendered, err := cmath.Process(string(n.Equation), n.Display, r.MarkConfig.MathFormat, r.MarkConfig.MathScale)
+	rendered, err := cmath.Process(string(equation), display, r.MarkConfig.MathFormat, r.MarkConfig.MathScale)
 	if err != nil {
 		return ast.WalkStop, err
 	}
@@ -87,7 +110,7 @@ func (r *ConfluenceMathRenderer) renderMath(writer util.BufWriter, source []byte
 			rendered.Width,
 			rendered.Height,
 			"",
-			string(n.Equation),
+			string(equation),
 			rendered.Filename,
 			"",
 		},


### PR DESCRIPTION
A display formula written between "$$" markers on lines of their own is a block,
and was being parsed as an inline. An inline parser is handed one block at a
time, so an aligned environment -- which is written with blank lines in it --
was two blocks to goldmark and could not be seen whole from inside either of
them:

    $$
    \begin{aligned}
    a &= b \\

    c &= d
    \end{aligned}
    $$

Reading the source past the end of the block instead is what the inline parser
used to do, and it closed against the next "$$" three paragraphs down: the text
between became the equation and was published a second time as prose, and a "#"
or "&" anywhere in it failed the file, LaTeX rejecting both outside a macro.
Bounding the scan to the block stopped the damage and left the formula above
unparseable, landing on the page as raw TeX.

The block form settles two more things by construction. Its lines come from
goldmark's own segments, which have already had the line prefix taken off, so a
formula inside a blockquote or a list item no longer carries "> " or the
indentation into the equation. And it sits below the fenced code block parser,
so a document explaining this syntax publishes the example instead of rendering
it.

A formula that opens and closes on one line stays the inline parser's, alone on
a line or in the middle of a sentence: that case has always worked, its one-line
answer never needed bounding, and moving it would take the picture out of the
paragraph it belongs to. No fixture changes.

MathBlock declares itself raw. Without that goldmark parses inlines into the
block's lines the way it does for a paragraph, and the formula is published as
its picture and then again as its source; a fenced code block says the same
thing for the same reason.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
