### PR TITLE
feat(renderer): publish same-page links as anchors Confluence can follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1704,6 +1704,16 @@ about which punctuation survives: a heading `API/v2 Guide` becomes
 in punctuation that matching drops, the link is left exactly as written rather
 than guessed at.
 
+Both ends are published in the storage format's own terms rather than as HTML.
+Confluence keeps no `id` on a heading — it generates its own from the element's
+text — so a heading a link points at carries the Anchor macro, and the link
+becomes `<ac:link ac:anchor="…">`. That is what footnotes have always used, and
+it is the difference between a link that works and one that renders, is
+clickable, and does nothing.
+
+Only a heading something links to carries an anchor; the rest are left as they
+were.
+
 ### Linting markdown
 
 We recommend to lint your markdown files with [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) before publishing them to confluence to catch any conversion errors early.

--- a/markdown/anchors_confluence_test.go
+++ b/markdown/anchors_confluence_test.go
@@ -1,0 +1,76 @@
+package mark
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func compileAnchorDoc(t *testing.T, src string) string {
+	t.Helper()
+
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	out, _, err := CompileMarkdown([]byte(src), std, "test.md", types.MarkConfig{})
+	require.NoError(t, err)
+
+	return out
+}
+
+// TestSamePageLinkUsesTheAnchorMacro is the whole point. The HTML idiom --
+// id="X" on the heading, href="#X" on the link -- renders, is clickable, and
+// does nothing, because Confluence keeps no id on a heading and generates its
+// own from the element's text. Both ends now use the storage format's own way
+// of saying it, which is what the footnote renderers have always emitted.
+func TestSamePageLinkUsesTheAnchorMacro(t *testing.T) {
+	out := compileAnchorDoc(t, "## Setup Guide\n\nSee [the setup](#setup-guide) below.\n")
+
+	assert.Contains(t, out,
+		`<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">Setup-Guide</ac:parameter></ac:structured-macro>`,
+		"the heading says where it is")
+	assert.Contains(t, out,
+		`<ac:link ac:anchor="Setup-Guide"><ac:link-body>the setup</ac:link-body></ac:link>`,
+		"and the link goes there")
+
+	assert.NotContains(t, out, `href="#`, "no fragment link survives")
+}
+
+// TestOnlyLinkedHeadingsCarryAnAnchor: a macro on every heading would be markup
+// nobody reads, on every page. Only the ones something points at get one.
+func TestOnlyLinkedHeadingsCarryAnAnchor(t *testing.T) {
+	out := compileAnchorDoc(t, "## Linked\n\n## Unlinked\n\n[go](#linked)\n")
+
+	assert.Equal(t, 1, strings.Count(out, `ac:name="anchor"`))
+	assert.Contains(t, out, `<ac:parameter ac:name="">Linked</ac:parameter>`)
+}
+
+// TestAnchorLinkKeepsItsMarkup: the link body is inline content like any other,
+// so emphasis and code inside it still render.
+func TestAnchorLinkKeepsItsMarkup(t *testing.T) {
+	out := compileAnchorDoc(t, "## Setup\n\n[the **bold** setup](#setup)\n")
+
+	assert.Contains(t, out, `<ac:link-body>the <strong>bold</strong> setup</ac:link-body>`)
+}
+
+// TestAnchorIsEscaped: the id goes into an XML attribute and into a macro
+// parameter, and a heading may contain anything.
+func TestAnchorIsEscaped(t *testing.T) {
+	out := compileAnchorDoc(t, "## A & B\n\n[x](#a--b)\n")
+
+	assert.NotContains(t, out, `ac:anchor="A & B"`)
+	assert.Contains(t, out, "&amp;")
+}
+
+// TestLinksToOtherThingsAreUnchanged is the control: only a "#" destination is
+// an anchor on this page.
+func TestLinksToOtherThingsAreUnchanged(t *testing.T) {
+	out := compileAnchorDoc(t, "[out](https://example.com) and [page](ac:Other Page)\n")
+
+	assert.Contains(t, out, `<a href="https://example.com">out</a>`)
+	assert.NotContains(t, out, "ac:anchor")
+}

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -60,10 +60,10 @@ func (c *ConfluenceLegacyExtension) Extend(m goldmark.Markdown) {
 		util.Prioritized(crenderer.NewConfluenceCodeBlockRenderer(c.Stdlib, c.Path), 100),
 		util.Prioritized(crenderer.NewConfluenceFencedCodeBlockRenderer(c.Stdlib, c, c.MarkConfig), 100),
 		util.Prioritized(crenderer.NewConfluenceHTMLBlockRenderer(c.Stdlib, c, c.Path, c.MarkConfig.ImageAlign), 100),
-		util.Prioritized(crenderer.NewConfluenceHeadingRenderer(c.MarkConfig.DropFirstH1), 100),
+		util.Prioritized(crenderer.NewConfluenceHeadingRenderer(c.Stdlib, c.MarkConfig.DropFirstH1), 100),
 		util.Prioritized(crenderer.NewConfluenceImageRenderer(c.Stdlib, c, c.Path, c.MarkConfig.ImageAlign), 100),
 		util.Prioritized(crenderer.NewConfluenceParagraphRenderer(), 100),
-		util.Prioritized(crenderer.NewConfluenceLinkRenderer(), 100),
+		util.Prioritized(crenderer.NewConfluenceLinkRenderer(c.Stdlib), 100),
 		util.Prioritized(crenderer.NewConfluenceTaskListRenderer(), 100),
 	))
 
@@ -386,10 +386,10 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 		util.Prioritized(crenderer.NewConfluenceCodeBlockRenderer(c.Stdlib, c.Path), 100),
 		util.Prioritized(crenderer.NewConfluenceFencedCodeBlockRenderer(c.Stdlib, c, c.MarkConfig), 100),
 		util.Prioritized(crenderer.NewConfluenceHTMLBlockRenderer(c.Stdlib, c, c.Path, c.MarkConfig.ImageAlign), 100),
-		util.Prioritized(crenderer.NewConfluenceHeadingRenderer(c.MarkConfig.DropFirstH1), 100),
+		util.Prioritized(crenderer.NewConfluenceHeadingRenderer(c.Stdlib, c.MarkConfig.DropFirstH1), 100),
 		util.Prioritized(crenderer.NewConfluenceImageRenderer(c.Stdlib, c, c.Path, c.MarkConfig.ImageAlign), 100),
 		util.Prioritized(crenderer.NewConfluenceParagraphRenderer(), 100),
-		util.Prioritized(crenderer.NewConfluenceLinkRenderer(), 100),
+		util.Prioritized(crenderer.NewConfluenceLinkRenderer(c.Stdlib), 100),
 		util.Prioritized(crenderer.NewConfluenceTaskListRenderer(), 100),
 	))
 

--- a/renderer/heading.go
+++ b/renderer/heading.go
@@ -1,6 +1,8 @@
 package renderer
 
 import (
+	"github.com/kovetskiy/mark/v16/stdlib"
+	ctransformer "github.com/kovetskiy/mark/v16/transformer"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/renderer/html"
@@ -8,13 +10,15 @@ import (
 )
 
 type ConfluenceHeadingRenderer struct {
+	Stdlib *stdlib.Lib
 	html.Config
 	DropFirstH1 bool
 }
 
 // NewConfluenceRenderer creates a new instance of the ConfluenceRenderer
-func NewConfluenceHeadingRenderer(dropFirstH1 bool, opts ...html.Option) renderer.NodeRenderer {
+func NewConfluenceHeadingRenderer(lib *stdlib.Lib, dropFirstH1 bool, opts ...html.Option) renderer.NodeRenderer {
 	return &ConfluenceHeadingRenderer{
+		Stdlib:      lib,
 		Config:      html.NewConfig(),
 		DropFirstH1: dropFirstH1,
 	}
@@ -48,6 +52,25 @@ func (r *ConfluenceHeadingRenderer) goldmarkRenderHeading(w util.BufWriter, sour
 			html.RenderAttributes(w, node, html.HeadingAttributeFilter)
 		}
 		_ = w.WriteByte('>')
+
+		// The heading says where it is, for the links on this page that point
+		// at it. Confluence keeps no id on a heading and generates its own from
+		// the element's text, so the id rendered just above is decoration: the
+		// Anchor macro is what a link can actually reach, and it is what mark
+		// already uses for footnotes.
+		//
+		// Inside the heading rather than before it, which is where the editor
+		// puts one, and the macro renders as nothing either way.
+		if anchor, ok := node.AttributeString(ctransformer.AnchorAttribute); ok && r.Stdlib != nil {
+			err := r.Stdlib.Templates.ExecuteTemplate(w, "ac:anchor", struct {
+				Anchor string
+			}{
+				string(anchor.([]byte)),
+			})
+			if err != nil {
+				return ast.WalkStop, err
+			}
+		}
 	} else {
 		_, _ = w.WriteString("</h")
 		_ = w.WriteByte("0123456"[n.Level])

--- a/renderer/heading_test.go
+++ b/renderer/heading_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/yuin/goldmark/renderer"
 )
 
-func headingRenderers(dropFirstH1 bool) []renderer.NodeRenderer {
+func headingRenderers(t *testing.T, dropFirstH1 bool) []renderer.NodeRenderer {
+	t.Helper()
+
 	return []renderer.NodeRenderer{
-		crenderer.NewConfluenceHeadingRenderer(dropFirstH1),
+		crenderer.NewConfluenceHeadingRenderer(newStdlib(t), dropFirstH1),
 		crenderer.NewConfluenceParagraphRenderer(),
 		crenderer.NewConfluenceTextLegacyRenderer(false),
 	}
@@ -26,7 +28,7 @@ const headingDocument = "# First\n\ntext\n\n## Second\n\n# Third\n"
 // Only the first h1 goes. A later h1 is content, not a repeated title, and an
 // h2 is never a title -- dropping either would silently lose a section heading.
 func TestHeadingDropFirstH1(t *testing.T) {
-	actual := render(t, headingDocument, headingRenderers(true))
+	actual := render(t, headingDocument, headingRenderers(t, true))
 	assertWellFormed(t, actual)
 
 	assert.NotContains(t, actual, "First", "the first h1 goes, text and all")
@@ -36,7 +38,7 @@ func TestHeadingDropFirstH1(t *testing.T) {
 
 // TestHeadingKeepsEverythingByDefault is the same document with the flag off.
 func TestHeadingKeepsEverythingByDefault(t *testing.T) {
-	actual := render(t, headingDocument, headingRenderers(false))
+	actual := render(t, headingDocument, headingRenderers(t, false))
 	assertWellFormed(t, actual)
 
 	assert.Contains(t, actual, "<h1>First</h1>")
@@ -51,7 +53,7 @@ func TestHeadingKeepsEverythingByDefault(t *testing.T) {
 // heading-anchor fixtures in markdown/ pin -- and this only asserts that the
 // renderer passes the attribute through.
 func TestHeadingKeepsItsID(t *testing.T) {
-	actual := render(t, "## A Section\n", headingRenderers(false), parser.WithAutoHeadingID())
+	actual := render(t, "## A Section\n", headingRenderers(t, false), parser.WithAutoHeadingID())
 	assertWellFormed(t, actual)
 
 	assert.Contains(t, actual, `id="a-section"`)
@@ -62,7 +64,7 @@ func TestHeadingKeepsItsID(t *testing.T) {
 // document that opens with a paragraph: the flag drops the first h1 wherever it
 // appears, rather than only when it is the opening block.
 func TestHeadingDropsOnlyTheFirstH1EvenWhenItIsNotFirstInTheDocument(t *testing.T) {
-	actual := render(t, "intro\n\n# Title\n\n# Later\n", headingRenderers(true))
+	actual := render(t, "intro\n\n# Title\n\n# Later\n", headingRenderers(t, true))
 	assertWellFormed(t, actual)
 
 	assert.Contains(t, actual, "intro")

--- a/renderer/link.go
+++ b/renderer/link.go
@@ -1,6 +1,7 @@
 package renderer
 
 import (
+	"github.com/kovetskiy/mark/v16/stdlib"
 	stdhtml "html"
 	"strings"
 
@@ -12,12 +13,14 @@ import (
 
 type ConfluenceLinkRenderer struct {
 	html.Config
+	Stdlib *stdlib.Lib
 }
 
 // NewConfluenceRenderer creates a new instance of the ConfluenceRenderer
-func NewConfluenceLinkRenderer(opts ...html.Option) renderer.NodeRenderer {
+func NewConfluenceLinkRenderer(lib *stdlib.Lib, opts ...html.Option) renderer.NodeRenderer {
 	return &ConfluenceLinkRenderer{
 		Config: html.NewConfig(),
+		Stdlib: lib,
 	}
 }
 
@@ -29,6 +32,32 @@ func (r *ConfluenceLinkRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegi
 // renderLink renders links specifically for confluence
 func (r *ConfluenceLinkRenderer) renderLink(writer util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	n := node.(*ast.Link)
+
+	// A link to an anchor on this page. The HTML idiom -- href="#X" against an
+	// id="X" on the heading -- renders and does nothing when clicked, because
+	// Confluence keeps no id on a heading and generates its own from the
+	// element's text. ac:link with ac:anchor and no ri:page is the storage
+	// format's own way of saying "somewhere on this page", and is what the
+	// footnote renderers have always emitted.
+	if anchor, found := strings.CutPrefix(string(n.Destination), "#"); found && anchor != "" && r.Stdlib != nil {
+		if entering {
+			err := r.Stdlib.Templates.ExecuteTemplate(writer, "ac:link:anchor", struct {
+				Anchor string
+			}{anchor})
+			if err != nil {
+				return ast.WalkStop, err
+			}
+
+			return ast.WalkContinue, nil
+		}
+
+		if _, err := writer.WriteString("</ac:link-body></ac:link>"); err != nil {
+			return ast.WalkStop, err
+		}
+
+		return ast.WalkContinue, nil
+	}
+
 	if len(n.Destination) >= 3 && string(n.Destination[0:3]) == "ac:" {
 		if entering {
 			_, err := writer.Write([]byte("<ac:link><ri:page ri:content-title=\""))

--- a/renderer/link_test.go
+++ b/renderer/link_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/yuin/goldmark/renderer"
 )
 
-func linkRenderers() []renderer.NodeRenderer {
+func linkRenderers(t *testing.T) []renderer.NodeRenderer {
+	t.Helper()
+
 	return []renderer.NodeRenderer{
-		crenderer.NewConfluenceLinkRenderer(),
+		crenderer.NewConfluenceLinkRenderer(newStdlib(t)),
 		crenderer.NewConfluenceParagraphRenderer(),
 		crenderer.NewConfluenceTextLegacyRenderer(false),
 	}
@@ -19,7 +21,7 @@ func linkRenderers() []renderer.NodeRenderer {
 // TestLinkToConfluencePageByTitle covers the ac: destination, which is how a
 // document links to another Confluence page by title rather than by URL.
 func TestLinkToConfluencePageByTitle(t *testing.T) {
-	actual := render(t, "[Text](ac:Page)\n", linkRenderers())
+	actual := render(t, "[Text](ac:Page)\n", linkRenderers(t))
 	assertWellFormed(t, actual)
 
 	assert.Contains(t, actual,
@@ -32,11 +34,11 @@ func TestLinkToConfluencePageByTitle(t *testing.T) {
 // rejects the whole page, not the one link -- and a quote closes the attribute
 // early, letting document text inject attributes of its own.
 func TestLinkTitleIsEscapedIntoTheAttribute(t *testing.T) {
-	amp := render(t, "[A & B](<ac:Q & A>)\n", linkRenderers())
+	amp := render(t, "[A & B](<ac:Q & A>)\n", linkRenderers(t))
 	assertWellFormed(t, amp)
 	assert.Contains(t, amp, `ri:content-title="Q &amp; A"`)
 
-	quoted := render(t, "[t](<ac:Say \"hi\">)\n", linkRenderers())
+	quoted := render(t, "[t](<ac:Say \"hi\">)\n", linkRenderers(t))
 	assertWellFormed(t, quoted)
 	assert.NotContains(t, quoted, `ri:content-title="Say "hi""`,
 		"a raw quote would close the attribute and let the rest inject more")
@@ -50,7 +52,7 @@ func TestLinkBodyEscapesTheCDATATerminator(t *testing.T) {
 	// A code span is how the sequence gets into link text at all: a bare "]" in
 	// a label ends the label, and a backslash-escaped one stays backslashed
 	// (see TestLinkBodyKeepsBackslashEscapes).
-	actual := render(t, "[a `]]>` b](ac:Page)\n", linkRenderers())
+	actual := render(t, "[a `]]>` b](ac:Page)\n", linkRenderers(t))
 	assertWellFormed(t, actual)
 
 	assert.Contains(t, actual, `<![CDATA[a ]]><![CDATA[]]]]><![CDATA[> b]]>`)
@@ -63,11 +65,11 @@ func TestLinkBodyEscapesTheCDATATerminator(t *testing.T) {
 // fares better -- emphasis is dropped to plain text, which is all
 // ac:plain-text-link-body can hold.
 func TestLinkBodyKeepsBackslashEscapes(t *testing.T) {
-	escaped := render(t, `[foo \_bar\_](ac:Page)`+"\n", linkRenderers())
+	escaped := render(t, `[foo \_bar\_](ac:Page)`+"\n", linkRenderers(t))
 	assertWellFormed(t, escaped)
 	assert.Contains(t, escaped, `<![CDATA[foo \_bar\_]]>`)
 
-	emphasised := render(t, "[**bold** text](ac:Page)\n", linkRenderers())
+	emphasised := render(t, "[**bold** text](ac:Page)\n", linkRenderers(t))
 	assertWellFormed(t, emphasised)
 	assert.Contains(t, emphasised, `<![CDATA[bold text]]>`)
 }
@@ -75,7 +77,7 @@ func TestLinkBodyKeepsBackslashEscapes(t *testing.T) {
 // TestLinkWithEmptyPageTitleFallsBackToTheText covers a bare "ac:" destination:
 // with no title after the prefix, the link text is the title.
 func TestLinkWithEmptyPageTitleFallsBackToTheText(t *testing.T) {
-	actual := render(t, "[bare](ac:)\n", linkRenderers())
+	actual := render(t, "[bare](ac:)\n", linkRenderers(t))
 	assertWellFormed(t, actual)
 
 	assert.Contains(t, actual, `ri:content-title="bare"`)
@@ -85,7 +87,7 @@ func TestLinkWithEmptyPageTitleFallsBackToTheText(t *testing.T) {
 // change: an ordinary URL is still an <a>, with the destination and title
 // escaped for HTML.
 func TestOrdinaryLinkKeepsGoldmarkBehaviour(t *testing.T) {
-	actual := render(t, "[ext](https://example.com/a?b=1&c=2 \"T & T\")\n", linkRenderers())
+	actual := render(t, "[ext](https://example.com/a?b=1&c=2 \"T & T\")\n", linkRenderers(t))
 	assertWellFormed(t, actual)
 
 	assert.Contains(t, actual, `<a href="https://example.com/a?b=1&amp;c=2" title="T &amp; T">ext</a>`)

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -355,6 +355,16 @@ func templates(api *confluence.API) (*template.Template, error) {
 			`</ac:structured-macro>`,
 		),
 
+		// A link to an anchor on the same page. Confluence keeps no id on a
+		// heading and generates its own from the element's text, so the HTML
+		// idiom -- id="X" on the heading, href="#X" on the link -- renders,
+		// looks right, and does nothing when clicked. ac:link with ac:anchor
+		// and no ri:page is the storage format's own way of saying it.
+		`ac:link:anchor`: text(
+			`<ac:link ac:anchor="{{ .Anchor | xmlesc }}">`,
+			`<ac:link-body>`,
+		),
+
 		// The marker is superscript inside the link body rather than around
 		// the whole link: ac:link-body is documented to take sup, while a
 		// storage-format sup wrapping a macro is not, and the editor is free

--- a/testdata/heading-anchor-custom-ids-droph1.html
+++ b/testdata/heading-anchor-custom-ids-droph1.html
@@ -1,14 +1,14 @@
 <p>An author can name a heading's anchor with the <code>{#custom-id}</code> syntax every other
 Markdown tool understands, rather than accepting the one Mark derives from the
 heading text.</p>
-<h2 id="custom-id">My Heading</h2>
+<h2 id="custom-id"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">custom-id</ac:parameter></ac:structured-macro>My Heading</h2>
 <p>The braces are consumed rather than rendered, so the heading reads as written
-and the anchor is exactly what was asked for: <a href="#custom-id">exact</a>.</p>
-<h2 id="Another-Heading">Another Heading</h2>
+and the anchor is exactly what was asked for: <ac:link ac:anchor="custom-id"><ac:link-body>exact</ac:link-body></ac:link>.</p>
+<h2 id="Another-Heading"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">Another-Heading</ac:parameter></ac:structured-macro>Another Heading</h2>
 <p>A heading with no custom id keeps its derived anchor, and a link written in the
-usual slug style still finds it: <a href="#Another-Heading">slug</a>.</p>
-<h2 id="rel">Release Notes</h2>
+usual slug style still finds it: <ac:link ac:anchor="Another-Heading"><ac:link-body>slug</ac:link-body></ac:link>.</p>
+<h2 id="rel"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">rel</ac:parameter></ac:structured-macro>Release Notes</h2>
 <p>Naming an anchor replaces the derived one rather than adding to it, so the slug
-of the heading text no longer resolves: <a href="#release-notes">by slug</a> is left as
-written, while <a href="#rel">by name</a> resolves. This is what other Markdown tools do
+of the heading text no longer resolves: <ac:link ac:anchor="release-notes"><ac:link-body>by slug</ac:link-body></ac:link> is left as
+written, while <ac:link ac:anchor="rel"><ac:link-body>by name</ac:link-body></ac:link> resolves. This is what other Markdown tools do
 too -- a custom id is the id, not an alias.</p>

--- a/testdata/heading-anchor-custom-ids-stripnewlines.html
+++ b/testdata/heading-anchor-custom-ids-stripnewlines.html
@@ -1,8 +1,8 @@
 <h1 id="Custom-Anchor-IDs">Custom Anchor IDs</h1>
 <p>An author can name a heading's anchor with the <code>{#custom-id}</code> syntax every other Markdown tool understands, rather than accepting the one Mark derives from the heading text.</p>
-<h2 id="custom-id">My Heading</h2>
-<p>The braces are consumed rather than rendered, so the heading reads as written and the anchor is exactly what was asked for: <a href="#custom-id">exact</a>.</p>
-<h2 id="Another-Heading">Another Heading</h2>
-<p>A heading with no custom id keeps its derived anchor, and a link written in the usual slug style still finds it: <a href="#Another-Heading">slug</a>.</p>
-<h2 id="rel">Release Notes</h2>
-<p>Naming an anchor replaces the derived one rather than adding to it, so the slug of the heading text no longer resolves: <a href="#release-notes">by slug</a> is left as written, while <a href="#rel">by name</a> resolves. This is what other Markdown tools do too -- a custom id is the id, not an alias.</p>
+<h2 id="custom-id"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">custom-id</ac:parameter></ac:structured-macro>My Heading</h2>
+<p>The braces are consumed rather than rendered, so the heading reads as written and the anchor is exactly what was asked for: <ac:link ac:anchor="custom-id"><ac:link-body>exact</ac:link-body></ac:link>.</p>
+<h2 id="Another-Heading"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">Another-Heading</ac:parameter></ac:structured-macro>Another Heading</h2>
+<p>A heading with no custom id keeps its derived anchor, and a link written in the usual slug style still finds it: <ac:link ac:anchor="Another-Heading"><ac:link-body>slug</ac:link-body></ac:link>.</p>
+<h2 id="rel"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">rel</ac:parameter></ac:structured-macro>Release Notes</h2>
+<p>Naming an anchor replaces the derived one rather than adding to it, so the slug of the heading text no longer resolves: <ac:link ac:anchor="release-notes"><ac:link-body>by slug</ac:link-body></ac:link> is left as written, while <ac:link ac:anchor="rel"><ac:link-body>by name</ac:link-body></ac:link> resolves. This is what other Markdown tools do too -- a custom id is the id, not an alias.</p>

--- a/testdata/heading-anchor-custom-ids.html
+++ b/testdata/heading-anchor-custom-ids.html
@@ -2,14 +2,14 @@
 <p>An author can name a heading's anchor with the <code>{#custom-id}</code> syntax every other
 Markdown tool understands, rather than accepting the one Mark derives from the
 heading text.</p>
-<h2 id="custom-id">My Heading</h2>
+<h2 id="custom-id"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">custom-id</ac:parameter></ac:structured-macro>My Heading</h2>
 <p>The braces are consumed rather than rendered, so the heading reads as written
-and the anchor is exactly what was asked for: <a href="#custom-id">exact</a>.</p>
-<h2 id="Another-Heading">Another Heading</h2>
+and the anchor is exactly what was asked for: <ac:link ac:anchor="custom-id"><ac:link-body>exact</ac:link-body></ac:link>.</p>
+<h2 id="Another-Heading"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">Another-Heading</ac:parameter></ac:structured-macro>Another Heading</h2>
 <p>A heading with no custom id keeps its derived anchor, and a link written in the
-usual slug style still finds it: <a href="#Another-Heading">slug</a>.</p>
-<h2 id="rel">Release Notes</h2>
+usual slug style still finds it: <ac:link ac:anchor="Another-Heading"><ac:link-body>slug</ac:link-body></ac:link>.</p>
+<h2 id="rel"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">rel</ac:parameter></ac:structured-macro>Release Notes</h2>
 <p>Naming an anchor replaces the derived one rather than adding to it, so the slug
-of the heading text no longer resolves: <a href="#release-notes">by slug</a> is left as
-written, while <a href="#rel">by name</a> resolves. This is what other Markdown tools do
+of the heading text no longer resolves: <ac:link ac:anchor="release-notes"><ac:link-body>by slug</ac:link-body></ac:link> is left as
+written, while <ac:link ac:anchor="rel"><ac:link-body>by name</ac:link-body></ac:link> resolves. This is what other Markdown tools do
 too -- a custom id is the id, not an alias.</p>

--- a/testdata/heading-anchor-links-droph1.html
+++ b/testdata/heading-anchor-links-droph1.html
@@ -1,24 +1,24 @@
 <p>Headings become ids that keep their capitals and punctuation, while the links
 authors write use the lowercase-and-hyphens slug every other Markdown tool
 produces. Both ends have to end up naming the same thing.</p>
-<h2 id="My-Heading">My Heading</h2>
-<p><a href="#My-Heading">slug style</a> and <a href="#My-Heading">exact style</a>.</p>
-<h2 id="API/v2-Guide">API/v2 Guide</h2>
+<h2 id="My-Heading"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">My-Heading</ac:parameter></ac:structured-macro>My Heading</h2>
+<p><ac:link ac:anchor="My-Heading"><ac:link-body>slug style</ac:link-body></ac:link> and <ac:link ac:anchor="My-Heading"><ac:link-body>exact style</ac:link-body></ac:link>.</p>
+<h2 id="API/v2-Guide"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">API/v2-Guide</ac:parameter></ac:structured-macro>API/v2 Guide</h2>
 <p>The conventions disagree about which characters survive at all, so matching is
-on the letters and digits: <a href="#API/v2-Guide">dropped punctuation</a>.</p>
+on the letters and digits: <ac:link ac:anchor="API/v2-Guide"><ac:link-body>dropped punctuation</ac:link-body></ac:link>.</p>
 <h2 id="Release-Notes">Release Notes</h2>
 <h2 id="Release.Notes">Release.Notes</h2>
 <p>Two headings whose ids differ only in punctuation that matching drops are one
-key, so <a href="#release-notes">this</a> is left exactly as written rather than guessed
+key, so <ac:link ac:anchor="release-notes"><ac:link-body>this</ac:link-body></ac:link> is left exactly as written rather than guessed
 at.</p>
 <p><a href="https://example.com/#fragment">not an anchor</a> is untouched, and so is
-<a href="#nothing-here">an unknown target</a>.</p>
-<h2 id="概要">概要</h2>
+<ac:link ac:anchor="nothing-here"><ac:link-body>an unknown target</ac:link-body></ac:link>.</p>
+<h2 id="概要"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">概要</ac:parameter></ac:structured-macro>概要</h2>
 <p>A heading with no ASCII in it at all still has to become an id made of its own
-characters rather than the literal word &quot;heading&quot;: <a href="#%E6%A6%82%E8%A6%81">the summary</a>.</p>
+characters rather than the literal word &quot;heading&quot;: <ac:link ac:anchor="概要"><ac:link-body>the summary</ac:link-body></ac:link>.</p>
 <h2 id="詳細">詳細</h2>
 <p>A second such heading is a heading of its own, not the numbered fallback that
 one emptied id forces on the next.</p>
-<h2 id="Heading-with-link-and-code">Heading with <a href="https://example.com">link</a> and code</h2>
+<h2 id="Heading-with-link-and-code"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">Heading-with-link-and-code</ac:parameter></ac:structured-macro>Heading with <a href="https://example.com">link</a> and code</h2>
 <p>An id is built from what a reader sees, so the link's label counts and its URL
-does not: <a href="#Heading-with-link-and-code">jump</a>.</p>
+does not: <ac:link ac:anchor="Heading-with-link-and-code"><ac:link-body>jump</ac:link-body></ac:link>.</p>

--- a/testdata/heading-anchor-links-stripnewlines.html
+++ b/testdata/heading-anchor-links-stripnewlines.html
@@ -1,16 +1,16 @@
 <h1 id="Anchor-Links">Anchor Links</h1>
 <p>Headings become ids that keep their capitals and punctuation, while the links authors write use the lowercase-and-hyphens slug every other Markdown tool produces. Both ends have to end up naming the same thing.</p>
-<h2 id="My-Heading">My Heading</h2>
-<p><a href="#My-Heading">slug style</a> and <a href="#My-Heading">exact style</a>.</p>
-<h2 id="API/v2-Guide">API/v2 Guide</h2>
-<p>The conventions disagree about which characters survive at all, so matching is on the letters and digits: <a href="#API/v2-Guide">dropped punctuation</a>.</p>
+<h2 id="My-Heading"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">My-Heading</ac:parameter></ac:structured-macro>My Heading</h2>
+<p><ac:link ac:anchor="My-Heading"><ac:link-body>slug style</ac:link-body></ac:link> and <ac:link ac:anchor="My-Heading"><ac:link-body>exact style</ac:link-body></ac:link>.</p>
+<h2 id="API/v2-Guide"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">API/v2-Guide</ac:parameter></ac:structured-macro>API/v2 Guide</h2>
+<p>The conventions disagree about which characters survive at all, so matching is on the letters and digits: <ac:link ac:anchor="API/v2-Guide"><ac:link-body>dropped punctuation</ac:link-body></ac:link>.</p>
 <h2 id="Release-Notes">Release Notes</h2>
 <h2 id="Release.Notes">Release.Notes</h2>
-<p>Two headings whose ids differ only in punctuation that matching drops are one key, so <a href="#release-notes">this</a> is left exactly as written rather than guessed at.</p>
-<p><a href="https://example.com/#fragment">not an anchor</a> is untouched, and so is <a href="#nothing-here">an unknown target</a>.</p>
-<h2 id="概要">概要</h2>
-<p>A heading with no ASCII in it at all still has to become an id made of its own characters rather than the literal word &quot;heading&quot;: <a href="#%E6%A6%82%E8%A6%81">the summary</a>.</p>
+<p>Two headings whose ids differ only in punctuation that matching drops are one key, so <ac:link ac:anchor="release-notes"><ac:link-body>this</ac:link-body></ac:link> is left exactly as written rather than guessed at.</p>
+<p><a href="https://example.com/#fragment">not an anchor</a> is untouched, and so is <ac:link ac:anchor="nothing-here"><ac:link-body>an unknown target</ac:link-body></ac:link>.</p>
+<h2 id="概要"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">概要</ac:parameter></ac:structured-macro>概要</h2>
+<p>A heading with no ASCII in it at all still has to become an id made of its own characters rather than the literal word &quot;heading&quot;: <ac:link ac:anchor="概要"><ac:link-body>the summary</ac:link-body></ac:link>.</p>
 <h2 id="詳細">詳細</h2>
 <p>A second such heading is a heading of its own, not the numbered fallback that one emptied id forces on the next.</p>
-<h2 id="Heading-with-link-and-code">Heading with <a href="https://example.com">link</a> and code</h2>
-<p>An id is built from what a reader sees, so the link's label counts and its URL does not: <a href="#Heading-with-link-and-code">jump</a>.</p>
+<h2 id="Heading-with-link-and-code"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">Heading-with-link-and-code</ac:parameter></ac:structured-macro>Heading with <a href="https://example.com">link</a> and code</h2>
+<p>An id is built from what a reader sees, so the link's label counts and its URL does not: <ac:link ac:anchor="Heading-with-link-and-code"><ac:link-body>jump</ac:link-body></ac:link>.</p>

--- a/testdata/heading-anchor-links.html
+++ b/testdata/heading-anchor-links.html
@@ -2,24 +2,24 @@
 <p>Headings become ids that keep their capitals and punctuation, while the links
 authors write use the lowercase-and-hyphens slug every other Markdown tool
 produces. Both ends have to end up naming the same thing.</p>
-<h2 id="My-Heading">My Heading</h2>
-<p><a href="#My-Heading">slug style</a> and <a href="#My-Heading">exact style</a>.</p>
-<h2 id="API/v2-Guide">API/v2 Guide</h2>
+<h2 id="My-Heading"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">My-Heading</ac:parameter></ac:structured-macro>My Heading</h2>
+<p><ac:link ac:anchor="My-Heading"><ac:link-body>slug style</ac:link-body></ac:link> and <ac:link ac:anchor="My-Heading"><ac:link-body>exact style</ac:link-body></ac:link>.</p>
+<h2 id="API/v2-Guide"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">API/v2-Guide</ac:parameter></ac:structured-macro>API/v2 Guide</h2>
 <p>The conventions disagree about which characters survive at all, so matching is
-on the letters and digits: <a href="#API/v2-Guide">dropped punctuation</a>.</p>
+on the letters and digits: <ac:link ac:anchor="API/v2-Guide"><ac:link-body>dropped punctuation</ac:link-body></ac:link>.</p>
 <h2 id="Release-Notes">Release Notes</h2>
 <h2 id="Release.Notes">Release.Notes</h2>
 <p>Two headings whose ids differ only in punctuation that matching drops are one
-key, so <a href="#release-notes">this</a> is left exactly as written rather than guessed
+key, so <ac:link ac:anchor="release-notes"><ac:link-body>this</ac:link-body></ac:link> is left exactly as written rather than guessed
 at.</p>
 <p><a href="https://example.com/#fragment">not an anchor</a> is untouched, and so is
-<a href="#nothing-here">an unknown target</a>.</p>
-<h2 id="概要">概要</h2>
+<ac:link ac:anchor="nothing-here"><ac:link-body>an unknown target</ac:link-body></ac:link>.</p>
+<h2 id="概要"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">概要</ac:parameter></ac:structured-macro>概要</h2>
 <p>A heading with no ASCII in it at all still has to become an id made of its own
-characters rather than the literal word &quot;heading&quot;: <a href="#%E6%A6%82%E8%A6%81">the summary</a>.</p>
+characters rather than the literal word &quot;heading&quot;: <ac:link ac:anchor="概要"><ac:link-body>the summary</ac:link-body></ac:link>.</p>
 <h2 id="詳細">詳細</h2>
 <p>A second such heading is a heading of its own, not the numbered fallback that
 one emptied id forces on the next.</p>
-<h2 id="Heading-with-link-and-code">Heading with <a href="https://example.com">link</a> and code</h2>
+<h2 id="Heading-with-link-and-code"><ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">Heading-with-link-and-code</ac:parameter></ac:structured-macro>Heading with <a href="https://example.com">link</a> and code</h2>
 <p>An id is built from what a reader sees, so the link's label counts and its URL
-does not: <a href="#Heading-with-link-and-code">jump</a>.</p>
+does not: <ac:link ac:anchor="Heading-with-link-and-code"><ac:link-body>jump</ac:link-body></ac:link>.</p>

--- a/transformer/anchors.go
+++ b/transformer/anchors.go
@@ -123,6 +123,63 @@ func (t *AnchorTransformer) Transform(doc *ast.Document, reader text.Reader, pc 
 
 		return ast.WalkContinue, nil
 	})
+
+	markTargetedHeadings(doc)
+}
+
+// AnchorAttribute names the heading attribute that carries the anchor a link
+// on this page points at.
+//
+// Confluence keeps no id on a heading -- it generates its own from the
+// element's text -- so a heading has to say where it is with the Anchor macro,
+// which is what mark already does for footnotes. The macro is only worth
+// emitting for a heading something actually links to: every heading carrying
+// one would be markup nobody reads, on every page.
+//
+// Not an HTML attribute name, so goldmark's HeadingAttributeFilter drops it
+// from the rendered tag rather than publishing it.
+const AnchorAttribute = "mark:anchor"
+
+// markTargetedHeadings records, on each heading, whether a link on this page
+// points at it.
+func markTargetedHeadings(doc *ast.Document) {
+	targets := map[string]bool{}
+
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		if link, ok := node.(*ast.Link); ok {
+			if target, found := strings.CutPrefix(string(link.Destination), "#"); found && target != "" {
+				targets[target] = true
+			}
+		}
+
+		return ast.WalkContinue, nil
+	})
+
+	if len(targets) == 0 {
+		return
+	}
+
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering || node.Kind() != ast.KindHeading {
+			return ast.WalkContinue, nil
+		}
+
+		id, ok := node.AttributeString("id")
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+
+		value := attributeString(id)
+		if targets[value] {
+			node.SetAttributeString(AnchorAttribute, []byte(value))
+		}
+
+		return ast.WalkContinue, nil
+	})
 }
 
 // attributeString renders a node attribute value, which goldmark hands back as

--- a/transformer/autolink_test.go
+++ b/transformer/autolink_test.go
@@ -28,7 +28,7 @@ func TestAutoLinkTransformer(t *testing.T) {
 		goldmark.WithRendererOptions(
 			html.WithUnsafe(),
 			renderer.WithNodeRenderers(
-				util.Prioritized(crenderer.NewConfluenceLinkRenderer(), 100),
+				util.Prioritized(crenderer.NewConfluenceLinkRenderer(nil), 100),
 			),
 		),
 	)


### PR DESCRIPTION
A heading became id="My-Heading" and a link to it became href="#My-Heading".
Both ends named the same thing, every test agreed, and the link went nowhere:
Confluence keeps no id on a heading -- it generates its own from the element's
text -- so the fragment names an anchor that does not exist. The page renders,
the link is clickable, and clicking it does nothing, which is the fault nobody
reports twice.

The storage format has its own way of saying this, and mark has emitted it for
footnotes since they were added: the Anchor macro marks the place, and
<ac:link ac:anchor="..."> goes to it, with no ri:page because the target is on
this page. Headings and links now use the same pair.

Only a heading something actually links to carries a macro. One on every
heading would be markup nobody reads, on every page, and the transformer that
matches the two ends already knows which are targeted -- it records the answer
on the node and the renderer acts on it.

The id attribute stays on the heading. Confluence discards it, but it costs a
few bytes and is the only thing that makes the storage format legible to
anything else that reads it.

Matching is unchanged: a slug-style link still finds the heading mark generated,
an ambiguous one is still left exactly as written, and a link to anything other
than an anchor on this page is untouched.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
