### PR TITLE
feat(renderer): publish a mixed task list as runs instead of as text

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,14 @@ Task lists are automatically converted to Confluence `ac:task-list` elements.
 - [ ] Unfinished task
 ```
 
-If a list is "mixed" (contains both tasks and regular list items), it will fall back to a standard HTML list with textual markers like `[x]` or `[ ]` to ensure validity in Confluence storage format.
+A list holding both kinds is published as one Confluence task list per run of
+checkboxes and one ordinary list per run of bullets, in the order they were
+written — mixing `<ac:task>` and `<li>` inside a single container is not
+something the storage format allows.
+
+An *ordered* mixed list is the exception: splitting it would restart the
+numbering at every run, so it falls back to a standard list with textual `[x]`
+and `[ ]` markers, which keeps the completion state visible if not actionable.
 
 ## Template & Macros
 

--- a/renderer/tasklist.go
+++ b/renderer/tasklist.go
@@ -29,18 +29,79 @@ func (r *ConfluenceTaskListRenderer) RegisterFuncs(reg renderer.NodeRendererFunc
 }
 
 // isTaskList returns true only if every top-level list item is a task item.
-// A mixed list (some task items, some regular items) is not considered a task
-// list, because rendering it as <ac:task-list> while falling back to <li> for
-// non-task items produces invalid Confluence storage XML.
 func isTaskList(list *ast.List) bool {
 	hasChildren := false
 	for child := list.FirstChild(); child != nil; child = child.NextSibling() {
 		hasChildren = true
-		if getTaskCheckBox(child) == nil {
+		if !isTaskItem(child) {
 			return false
 		}
 	}
 	return hasChildren
+}
+
+// isTaskItem reports whether a list item carries a checkbox.
+func isTaskItem(item ast.Node) bool {
+	return getTaskCheckBox(item) != nil
+}
+
+// splitsIntoRuns reports whether a list holds both kinds of item and can be
+// published as one run of each.
+//
+// Mixing <ac:task> and <li> inside one container is not something the storage
+// format allows, so a list with an explanatory bullet among its checkboxes used
+// to fall back wholesale: every item became an <li> and every checkbox became
+// the literal text "[x]", losing every task on the page. Splitting the list at
+// the boundaries -- a task list per run of checkboxes, a plain list per run of
+// bullets -- keeps both, and is what the author wrote anyway.
+//
+// Only unordered lists. Splitting an ordered one restarts its numbering at each
+// run, and quietly renumbering somebody's list is worse than the fallback.
+func splitsIntoRuns(list *ast.List) bool {
+	if list.IsOrdered() {
+		return false
+	}
+
+	var tasks, plain bool
+	for child := list.FirstChild(); child != nil; child = child.NextSibling() {
+		if isTaskItem(child) {
+			tasks = true
+		} else {
+			plain = true
+		}
+	}
+
+	return tasks && plain
+}
+
+// rendersAsTask reports whether an item is published as an ac:task, which is
+// true in a list of nothing but tasks and in the task runs of a split one.
+func rendersAsTask(item ast.Node) bool {
+	if !isTaskItem(item) {
+		return false
+	}
+
+	list, ok := item.Parent().(*ast.List)
+	if !ok {
+		return false
+	}
+
+	return isTaskList(list) || splitsIntoRuns(list)
+}
+
+// opensRun reports whether an item begins a run of its own kind, and closesRun
+// whether it ends one. A run's container is written by its first and last item,
+// since the list itself spans several.
+func opensRun(item ast.Node) bool {
+	previous := item.PreviousSibling()
+
+	return previous == nil || isTaskItem(previous) != isTaskItem(item)
+}
+
+func closesRun(item ast.Node) bool {
+	next := item.NextSibling()
+
+	return next == nil || isTaskItem(next) != isTaskItem(item)
 }
 
 // getTaskCheckBox returns the TaskCheckBox node for a ListItem, or nil if not a task item.
@@ -63,6 +124,13 @@ func getTaskCheckBox(item ast.Node) *ext_ast.TaskCheckBox {
 
 func (r *ConfluenceTaskListRenderer) renderList(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	n := node.(*ast.List)
+
+	// A split list has no container of its own: each run opens and closes one,
+	// written by the item that begins and the item that ends it.
+	if splitsIntoRuns(n) {
+		return ast.WalkContinue, nil
+	}
+
 	if !isTaskList(n) {
 		return r.goldmarkRenderList(w, source, node, entering)
 	}
@@ -79,22 +147,78 @@ func (r *ConfluenceTaskListRenderer) renderList(w util.BufWriter, source []byte,
 }
 
 func (r *ConfluenceTaskListRenderer) renderListItem(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
-	checkbox := getTaskCheckBox(node)
 	parentList, _ := node.Parent().(*ast.List)
-	if checkbox == nil || parentList == nil || !isTaskList(parentList) {
+	if parentList == nil {
 		return r.goldmarkRenderListItem(w, source, node, entering)
 	}
+
+	// In a split list the item carries its run's container.
+	if splitsIntoRuns(parentList) {
+		return r.renderRunItem(w, source, node, entering)
+	}
+
+	checkbox := getTaskCheckBox(node)
+	if checkbox == nil || !isTaskList(parentList) {
+		return r.goldmarkRenderListItem(w, source, node, entering)
+	}
+
 	if entering {
-		r.taskID++
-		status := "incomplete"
-		if checkbox.IsChecked {
-			status = "complete"
-		}
-		_, _ = fmt.Fprintf(w, "<ac:task>\n<ac:task-id>%d</ac:task-id>\n<ac:task-status>%s</ac:task-status>\n<ac:task-body>", r.taskID, status)
+		r.writeTaskOpening(w, checkbox)
 	} else {
 		_, _ = w.WriteString("</ac:task-body>\n</ac:task>\n")
 	}
 	return ast.WalkContinue, nil
+}
+
+// renderRunItem publishes one item of a list that holds both kinds, opening the
+// run's container before the first item of the run and closing it after the
+// last.
+func (r *ConfluenceTaskListRenderer) renderRunItem(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	task := isTaskItem(node)
+
+	if entering && opensRun(node) {
+		if task {
+			_, _ = w.WriteString("<ac:task-list>\n")
+		} else {
+			_, _ = w.WriteString("<ul>\n")
+		}
+	}
+
+	if task {
+		if entering {
+			r.writeTaskOpening(w, getTaskCheckBox(node))
+		} else {
+			_, _ = w.WriteString("</ac:task-body>\n</ac:task>\n")
+		}
+	} else if _, err := r.goldmarkRenderListItem(w, source, node, entering); err != nil {
+		return ast.WalkStop, err
+	}
+
+	if !entering && closesRun(node) {
+		if task {
+			_, _ = w.WriteString("</ac:task-list>\n")
+		} else {
+			_, _ = w.WriteString("</ul>\n")
+		}
+	}
+
+	return ast.WalkContinue, nil
+}
+
+// writeTaskOpening writes everything an ac:task needs before its body.
+func (r *ConfluenceTaskListRenderer) writeTaskOpening(w util.BufWriter, checkbox *ext_ast.TaskCheckBox) {
+	r.taskID++
+
+	status := "incomplete"
+	if checkbox != nil && checkbox.IsChecked {
+		status = "complete"
+	}
+
+	_, _ = fmt.Fprintf(
+		w,
+		"<ac:task>\n<ac:task-id>%d</ac:task-id>\n<ac:task-status>%s</ac:task-status>\n<ac:task-body>",
+		r.taskID, status,
+	)
 }
 
 // renderTaskCheckBox skips checkbox rendering when inside an ac:task-list (status
@@ -102,16 +226,12 @@ func (r *ConfluenceTaskListRenderer) renderListItem(w util.BufWriter, source []b
 // fall back to plain <ul>/<ol>), a textual "[x]"/"[ ]" marker is emitted so that
 // completion state is not silently lost.
 func (r *ConfluenceTaskListRenderer) renderTaskCheckBox(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
-	// Traverse up: TaskCheckBox -> TextBlock -> ListItem -> List
-	var parentList *ast.List
-	if tb := node.Parent(); tb != nil {
-		if li := tb.Parent(); li != nil {
-			parentList, _ = li.Parent().(*ast.List)
+	// Traverse up: TaskCheckBox -> TextBlock -> ListItem
+	if block := node.Parent(); block != nil {
+		if item := block.Parent(); item != nil && rendersAsTask(item) {
+			// Status is encoded by renderListItem; nothing to emit here.
+			return ast.WalkSkipChildren, nil
 		}
-	}
-	if parentList != nil && isTaskList(parentList) {
-		// Status is encoded by renderListItem; nothing to emit here.
-		return ast.WalkSkipChildren, nil
 	}
 	// Fallback: emit a textual marker so completion state is preserved.
 	if entering {

--- a/renderer/tasklist_test.go
+++ b/renderer/tasklist_test.go
@@ -134,3 +134,79 @@ func TestTaskListCheckedState(t *testing.T) {
 	assert.Contains(t, got, "<ac:task-status>incomplete</ac:task-status>")
 	assert.Equal(t, 1, strings.Count(got, "<ac:task-list>"))
 }
+
+// renderTaskList compiles with the task-list extension and mark's renderer,
+// which is the pair every test here needs.
+func renderTaskList(t *testing.T, input string) string {
+	t.Helper()
+
+	gm := goldmark.New(
+		goldmark.WithExtensions(extension.TaskList),
+		goldmark.WithRendererOptions(
+			renderer.WithNodeRenderers(
+				util.Prioritized(crenderer.NewConfluenceTaskListRenderer(), 100),
+			),
+		),
+	)
+
+	var buf bytes.Buffer
+	require.NoError(t, gm.Convert([]byte(input), &buf))
+
+	return buf.String()
+}
+
+// TestMixedListSplitsIntoRuns is what this replaced. Mixing <ac:task> and <li>
+// in one container is not something the storage format allows, so a list with
+// one explanatory bullet among its checkboxes fell back wholesale: every task
+// became an <li> and every checkbox the literal text "[x]". A checklist with a
+// note in it lost every task on the page.
+func TestMixedListSplitsIntoRuns(t *testing.T) {
+	actual := renderTaskList(t, "- [x] done\n- plain bullet\n- [ ] todo\n")
+	assertWellFormed(t, actual)
+
+	assert.Equal(t, 2, strings.Count(actual, "<ac:task-list>"), "one per run of tasks")
+	assert.Equal(t, 1, strings.Count(actual, "<ul>"), "and one for the bullet between them")
+
+	assert.Contains(t, actual, "<ac:task-status>complete</ac:task-status>")
+	assert.Contains(t, actual, "<ac:task-status>incomplete</ac:task-status>")
+	assert.Contains(t, actual, "<li>plain bullet</li>")
+
+	assert.NotContains(t, actual, "[x]", "no task is published as its marker")
+	assert.NotContains(t, actual, "[ ]")
+}
+
+// TestMixedListTaskIdsStayUnique: the ids number the tasks on the page, and a
+// split list must not restart or repeat them.
+func TestMixedListTaskIdsStayUnique(t *testing.T) {
+	actual := renderTaskList(t, "- [x] one\n- note\n- [ ] two\n- note\n- [ ] three\n")
+	assertWellFormed(t, actual)
+
+	for _, id := range []string{"<ac:task-id>1<", "<ac:task-id>2<", "<ac:task-id>3<"} {
+		assert.Equal(t, 1, strings.Count(actual, id), id)
+	}
+}
+
+// TestOrderedMixedListIsNotSplit: splitting an ordered list restarts its
+// numbering at every run, and renumbering somebody's list quietly is worse than
+// the fallback that keeps the state as text.
+func TestOrderedMixedListIsNotSplit(t *testing.T) {
+	actual := renderTaskList(t, "1. [x] done\n1. plain\n1. [ ] todo\n")
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "<ol>")
+	assert.NotContains(t, actual, "<ac:task-list>")
+	assert.Contains(t, actual, "[x]", "completion state is kept as text")
+}
+
+// TestPureListsAreUnchanged is the control for both shapes that already worked.
+func TestPureListsAreUnchanged(t *testing.T) {
+	tasks := renderTaskList(t, "- [x] one\n- [ ] two\n")
+	assertWellFormed(t, tasks)
+	assert.Equal(t, 1, strings.Count(tasks, "<ac:task-list>"))
+	assert.NotContains(t, tasks, "<ul>")
+
+	plain := renderTaskList(t, "- one\n- two\n")
+	assertWellFormed(t, plain)
+	assert.Equal(t, 1, strings.Count(plain, "<ul>"))
+	assert.NotContains(t, plain, "ac:task")
+}

--- a/testdata/tasklists-mixed.html
+++ b/testdata/tasklists-mixed.html
@@ -1,5 +1,17 @@
+<ac:task-list>
+<ac:task>
+<ac:task-id>1</ac:task-id>
+<ac:task-status>complete</ac:task-status>
+<ac:task-body>task item</ac:task-body>
+</ac:task>
+</ac:task-list>
 <ul>
-<li>[x] task item</li>
 <li>regular item</li>
-<li>[ ] another task item</li>
 </ul>
+<ac:task-list>
+<ac:task>
+<ac:task-id>2</ac:task-id>
+<ac:task-status>incomplete</ac:task-status>
+<ac:task-body>another task item</ac:task-body>
+</ac:task>
+</ac:task-list>


### PR DESCRIPTION
Mixing <ac:task> and <li> inside one container is not something the storage
format allows, so a list holding both fell back wholesale: every item became an
<li> and every checkbox became the literal text "[x]". One explanatory bullet
among the checkboxes cost the page every task on it -- nothing checkable, and
nothing said so.

The fallback was right about the constraint and wrong about the remedy. The list
is now published as one ac:task-list per run of checkboxes and one ordinary list
per run of bullets, in the order they were written, which is both valid and what
the author wrote. A run's container is opened by the item that begins it and
closed by the item that ends it, since the list itself spans several.

Ordered lists keep the old fallback. Splitting one restarts its numbering at
every run, and renumbering somebody's list quietly is worse than markers that
are visible but not actionable.

ac:task-id still numbers the tasks on the page rather than in the list, so a
split list does not restart or repeat them.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
