### PR TITLE
feat(renderer): publish a definition list as a two-column table

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,6 @@ Block Quotes are converted to Confluence Info/Warn/Note box when the following c
 
 In any other case the default behaviour will be resumed and html `<blockquote>` tag will be used
 
-
 ### Definition Lists
 
 A definition list is published as a two-column table, with each term heading its

--- a/README.md
+++ b/README.md
@@ -474,6 +474,29 @@ Block Quotes are converted to Confluence Info/Warn/Note box when the following c
 
 In any other case the default behaviour will be resumed and html `<blockquote>` tag will be used
 
+
+### Definition Lists
+
+A definition list is published as a two-column table, with each term heading its
+own row:
+
+```markdown
+Term
+: What it means
+
+Another term
+: One definition
+: And a second
+```
+
+Confluence storage format has no `<dl>`, `<dt>` or `<dd>` — its sanitiser drops
+all three, which left the list as an unstructured run of text with the terms no
+longer distinguishable from what defined them. A table is what the Confluence
+editor produces for this shape, and it is what the elements mean.
+
+Several definitions of one term share its cell rather than each taking a row,
+since a row with no term to head it reads as though something is missing.
+
 ### Task Lists
 
 Mark supports [GitHub Flavored Markdown task lists](https://github.github.com/gfm/#task-list-items-extension-).

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -65,6 +65,7 @@ func (c *ConfluenceLegacyExtension) Extend(m goldmark.Markdown) {
 		util.Prioritized(crenderer.NewConfluenceParagraphRenderer(), 100),
 		util.Prioritized(crenderer.NewConfluenceLinkRenderer(), 100),
 		util.Prioritized(crenderer.NewConfluenceTaskListRenderer(), 100),
+		util.Prioritized(crenderer.NewConfluenceDefinitionListRenderer(), 100),
 	))
 
 	// <details> reaches here only because the document wrote the tag, and the
@@ -391,6 +392,7 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 		util.Prioritized(crenderer.NewConfluenceParagraphRenderer(), 100),
 		util.Prioritized(crenderer.NewConfluenceLinkRenderer(), 100),
 		util.Prioritized(crenderer.NewConfluenceTaskListRenderer(), 100),
+		util.Prioritized(crenderer.NewConfluenceDefinitionListRenderer(), 100),
 	))
 
 	// Add GitHub Alerts specific renderers with higher priority to override defaults

--- a/renderer/definitionlist.go
+++ b/renderer/definitionlist.go
@@ -1,0 +1,126 @@
+package renderer
+
+import (
+	"github.com/yuin/goldmark/ast"
+	ext_ast "github.com/yuin/goldmark/extension/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/util"
+)
+
+// ConfluenceDefinitionListRenderer publishes a definition list as a two-column
+// table.
+//
+// The definition list extension is enabled, so "Term\n: Definition" parses --
+// and nothing rendered it, so goldmark's own renderer emitted <dl>, <dt> and
+// <dd> at the end of the chain. Confluence storage format has no equivalent for
+// any of the three: its sanitiser drops the elements and the list arrives as an
+// unstructured run of text, with the terms no longer distinguishable from what
+// defines them.
+//
+// A two-column table is the mapping the Confluence editor itself produces for
+// this shape, and it is what the elements mean: the term is a heading for its
+// row, the definition is the row's content.
+type ConfluenceDefinitionListRenderer struct {
+	html.Config
+
+	// inRow and inCell track how much of the current row has been written.
+	// A row spans several nodes -- one term, then any number of descriptions --
+	// so the closing tags belong to whatever node comes next rather than to the
+	// node that opened them.
+	inRow  bool
+	inCell bool
+}
+
+func NewConfluenceDefinitionListRenderer(opts ...html.Option) renderer.NodeRenderer {
+	return &ConfluenceDefinitionListRenderer{
+		Config: html.NewConfig(),
+	}
+}
+
+func (r *ConfluenceDefinitionListRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(ext_ast.KindDefinitionList, r.renderList)
+	reg.Register(ext_ast.KindDefinitionTerm, r.renderTerm)
+	reg.Register(ext_ast.KindDefinitionDescription, r.renderDescription)
+}
+
+func (r *ConfluenceDefinitionListRenderer) renderList(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		r.inRow = false
+		r.inCell = false
+
+		_, _ = w.WriteString("<table>\n<tbody>\n")
+
+		return ast.WalkContinue, nil
+	}
+
+	r.closeRow(w)
+	_, _ = w.WriteString("</tbody>\n</table>\n")
+
+	return ast.WalkContinue, nil
+}
+
+func (r *ConfluenceDefinitionListRenderer) renderTerm(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		// A term begins a row, so whatever row is open ends here.
+		r.closeRow(w)
+
+		_, _ = w.WriteString("<tr>\n<th>")
+		r.inRow = true
+
+		return ast.WalkContinue, nil
+	}
+
+	_, _ = w.WriteString("</th>\n")
+
+	return ast.WalkContinue, nil
+}
+
+func (r *ConfluenceDefinitionListRenderer) renderDescription(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+
+	// A definition written before any term -- which the syntax allows -- still
+	// needs a row to sit in.
+	if !r.inRow {
+		_, _ = w.WriteString("<tr>\n<th></th>\n")
+		r.inRow = true
+	}
+
+	// Several definitions of one term share its cell rather than each claiming
+	// a row of their own, which would leave rows with no term to head them.
+	if !r.inCell {
+		_, _ = w.WriteString("<td>")
+		r.inCell = true
+
+		return ast.WalkContinue, nil
+	}
+
+	// A second definition needs something between it and the one before. A
+	// loose description brings its own paragraph; a tight one is bare text, and
+	// without a break the two definitions run into each other as one word.
+	if description, ok := node.(*ext_ast.DefinitionDescription); ok && description.IsTight {
+		_, _ = w.WriteString("<br/>")
+	}
+
+	return ast.WalkContinue, nil
+}
+
+// closeRow finishes whatever row is open, giving a term with no definition an
+// empty cell so that every row has both columns.
+func (r *ConfluenceDefinitionListRenderer) closeRow(w util.BufWriter) {
+	if !r.inRow {
+		return
+	}
+
+	if r.inCell {
+		_, _ = w.WriteString("</td>\n")
+		r.inCell = false
+	} else {
+		_, _ = w.WriteString("<td></td>\n")
+	}
+
+	_, _ = w.WriteString("</tr>\n")
+	r.inRow = false
+}

--- a/renderer/definitionlist_test.go
+++ b/renderer/definitionlist_test.go
@@ -1,0 +1,81 @@
+package renderer_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	crenderer "github.com/kovetskiy/mark/v16/renderer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+// renderDefinitionList compiles with the definition-list extension and mark's
+// renderer for it, which is the pair every test here needs.
+func renderDefinitionList(t *testing.T, input string) string {
+	t.Helper()
+
+	gm := goldmark.New(
+		goldmark.WithExtensions(extension.DefinitionList),
+		goldmark.WithRendererOptions(
+			renderer.WithNodeRenderers(
+				util.Prioritized(crenderer.NewConfluenceDefinitionListRenderer(), 100),
+			),
+		),
+	)
+
+	var buf bytes.Buffer
+	require.NoError(t, gm.Convert([]byte(input), &buf))
+
+	return buf.String()
+}
+
+// TestDefinitionListIsATable: storage format has no <dl>, <dt> or <dd>, so a
+// definition list arrived as an unstructured run of text with its terms no
+// longer distinguishable from what defines them. A two-column table is what the
+// Confluence editor produces for this shape and what the elements mean.
+func TestDefinitionListIsATable(t *testing.T) {
+	actual := renderDefinitionList(t, "Term\n: Definition\n")
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "<th>Term</th>")
+	assert.Contains(t, actual, "<td>Definition</td>")
+	assert.Contains(t, actual, "<table>")
+
+	for _, gone := range []string{"<dl>", "<dt>", "<dd>"} {
+		assert.NotContains(t, actual, gone)
+	}
+}
+
+// TestDefinitionListRowPerTerm: each term heads its own row.
+func TestDefinitionListRowPerTerm(t *testing.T) {
+	actual := renderDefinitionList(t, "One\n: First\n\nTwo\n: Second\n")
+	assertWellFormed(t, actual)
+
+	assert.Equal(t, 2, strings.Count(actual, "<tr>"))
+	assert.Equal(t, 1, strings.Count(actual, "<table>"))
+}
+
+// TestSeveralDefinitionsShareACell: a term may be defined more than once, and
+// giving each definition a row of its own would leave rows with no term to head
+// them. Without a separator the two definitions run together as one word.
+func TestSeveralDefinitionsShareACell(t *testing.T) {
+	actual := renderDefinitionList(t, "Term\n: First\n: Second\n")
+	assertWellFormed(t, actual)
+
+	assert.Equal(t, 1, strings.Count(actual, "<tr>"))
+	assert.Contains(t, actual, "First<br/>Second")
+}
+
+// TestDefinitionListKeepsInlineMarkup: the cells hold ordinary inline content.
+func TestDefinitionListKeepsInlineMarkup(t *testing.T) {
+	actual := renderDefinitionList(t, "**Bold** term\n: A `code` definition\n")
+	assertWellFormed(t, actual)
+
+	assert.Contains(t, actual, "<strong>Bold</strong>")
+	assert.Contains(t, actual, "<code>code</code>")
+}

--- a/testdata/definitionlist.html
+++ b/testdata/definitionlist.html
@@ -1,0 +1,16 @@
+<table>
+<tbody>
+<tr>
+<th>Term one</th>
+<td>First definition</td>
+</tr>
+<tr>
+<th>Term two</th>
+<td>Second definition<br/>And another</td>
+</tr>
+<tr>
+<th><strong>Bold</strong> term</th>
+<td>A <code>code</code> definition</td>
+</tr>
+</tbody>
+</table>

--- a/testdata/definitionlist.md
+++ b/testdata/definitionlist.md
@@ -1,0 +1,9 @@
+Term one
+: First definition
+
+Term two
+: Second definition
+: And another
+
+**Bold** term
+: A `code` definition


### PR DESCRIPTION
The definition list extension is registered, so "Term\n: Definition" parses --
and nothing rendered it, so goldmark's own renderer emitted <dl>, <dt> and <dd>
at the end of the chain. Confluence storage format has no equivalent for any of
the three: the sanitiser drops the elements, and the list arrives as an
unstructured run of text with the terms no longer distinguishable from what
defines them.

A two-column table is what the Confluence editor produces for this shape, and it
is what the elements mean -- the term heads its row, the definition is the row's
content.

A row spans several nodes, one term and then any number of definitions, so the
closing tags belong to whatever node comes next rather than to the node that
opened them. Three shapes the syntax allows are handled explicitly: a term with
no definition gets an empty cell so every row has both columns; a definition
written before any term gets a row with an empty heading; and several
definitions of one term share its cell, separated by a break, since giving each
a row would leave rows with no term to head them and running them together
turned two definitions into one word.

Registered on both compile paths, so the two do not drift further apart than
they already have.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
