### PR TITLE
feat: let a library caller stop a run, and shut the browser down after one

### DIFF
--- a/confluence/transport.go
+++ b/confluence/transport.go
@@ -91,6 +91,32 @@ type retryTransport struct {
 	sleep func(time.Duration)
 }
 
+// wait sleeps for the backoff, or stops early if the request is cancelled.
+//
+// t.sleep is what the tests replace, so the timer is built from it rather than
+// from time.After: a test that makes the wait instant would otherwise still
+// wait for a real one here.
+func (t *retryTransport) wait(ctx context.Context, d time.Duration) error {
+	if ctx == nil || ctx.Done() == nil {
+		t.sleep(d)
+
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		t.sleep(d)
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-done:
+		return nil
+	}
+}
+
 // retryableStatus reports whether a response status is worth retrying for the
 // given method.
 //
@@ -227,7 +253,12 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 		event.Msg("Confluence request failed, retrying")
 
-		t.sleep(wait)
+		// The wait respects the request's context, so a cancelled run stops
+		// waiting instead of finishing its backoff first. Three retries at the
+		// cap is a minute and a half a caller could not otherwise escape.
+		if err := t.wait(req.Context(), wait); err != nil {
+			return nil, err
+		}
 	}
 
 	if lastErr != nil {

--- a/confluence/transport_test.go
+++ b/confluence/transport_test.go
@@ -2,6 +2,7 @@ package confluence
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -360,4 +361,33 @@ func TestNewHTTPClientSetsTimeouts(t *testing.T) {
 	assert.Equal(t, tlsHandshakeTimeout, transport.TLSHandshakeTimeout)
 	assert.Zero(t, client.Timeout,
 		"a whole-exchange timeout would cut off large attachment uploads")
+}
+
+// TestRetryBackoffStopsWhenTheRequestIsCancelled: the backoff slept
+// unconditionally, so three retries at the cap held a cancelled request for a
+// minute and a half it could not escape.
+func TestRetryBackoffStopsWhenTheRequestIsCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	transport := &retryTransport{
+		base: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return respond(http.StatusTooManyRequests, nil), nil
+		}),
+		// Cancels while the backoff is waiting, which is what a caller giving
+		// up mid-run looks like from here.
+		sleep: func(time.Duration) {
+			cancel()
+			time.Sleep(10 * time.Millisecond)
+		},
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
+	require.NoError(t, err)
+
+	response, err := transport.RoundTrip(request)
+	if response != nil {
+		defer response.Body.Close()
+	}
+
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/mark.go
+++ b/mark.go
@@ -2,6 +2,7 @@ package mark
 
 import (
 	"bytes"
+	"context"
 	// SHA-1 is used only as a content fingerprint for --changes-only, never as
 	// a security primitive. The digest is embedded in the page version message
 	// and matched back with a 40-hex-character regex, so widening it would stop
@@ -107,8 +108,33 @@ func (c Config) output() io.Writer {
 	return io.Discard
 }
 
-// Run processes all files matching Config.Files and publishes them to Confluence.
+// Run processes all files matching Config.Files and publishes them to
+// Confluence, and is RunContext with a context that is never cancelled.
 func Run(config Config) error {
+	return RunContext(context.Background(), config)
+}
+
+// RunContext is Run, stoppable.
+//
+// Cancellation is checked between files and before the second pass, so a run
+// stops at the next boundary rather than part way through publishing a page --
+// which is the one place stopping would leave a page half written. It does not
+// abort a request already in flight: the Confluence client builds its own
+// requests, so the context reaches the retry backoff and no further.
+//
+// Whatever the run did before it stopped stands, including the page manifest,
+// which is saved on the way out as it is for any other ending.
+func RunContext(ctx context.Context, config Config) error {
+	// The browser is shared for the life of the process and is started lazily
+	// by the first diagram or formula. A library caller has no other way to
+	// know it exists, so a run that started one shuts it down; the CLI's own
+	// call is harmless, since closing it twice is.
+	defer Cleanup()
+
+	return run(ctx, config)
+}
+
+func run(ctx context.Context, config Config) error {
 	// Settings are checked before anything else happens. A value that cannot be
 	// acted on should be said so plainly, not after a glob has been resolved
 	// and a connection opened -- and least of all part way through publishing.
@@ -274,6 +300,10 @@ func Run(config Config) error {
 
 	var hasErrors bool
 	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		log.Info().Msgf("processing %s", file)
 
 		target, placement, err := processFile(file, api, config, std, tracker, ancestryTracker, checker, globalProperties, deferrals, results)
@@ -320,6 +350,10 @@ func Run(config Config) error {
 		)
 
 		for _, file := range waiting {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
 			log.Info().Msgf("processing %s again", file)
 
 			// Nil deferrals: this is the last look, so a link that still does
@@ -406,6 +440,27 @@ func Run(config Config) error {
 // Callers processing several files should prefer Run, which builds the standard
 // library once instead of once per file.
 func ProcessFile(file string, api *confluence.API, config Config) (*confluence.PageInfo, error) {
+	return ProcessFileContext(context.Background(), file, api, config)
+}
+
+// ProcessFileContext is ProcessFile, stoppable.
+//
+// One file is one page, so there is no boundary inside it to stop at: the
+// context is checked before the work begins and not again. A caller looping
+// over files gets the same effect as RunContext by checking between them.
+//
+// Unlike RunContext this does not shut the shared browser down, since a caller
+// publishing several files would pay to start it again for each. Call Cleanup
+// when the last one is done.
+func ProcessFileContext(ctx context.Context, file string, api *confluence.API, config Config) (*confluence.PageInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	return processOneFile(file, api, config)
+}
+
+func processOneFile(file string, api *confluence.API, config Config) (*confluence.PageInfo, error) {
 	std, err := stdlib.New(api)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve standard library: %w", err)

--- a/mark_context_test.go
+++ b/mark_context_test.go
@@ -1,0 +1,71 @@
+package mark
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunContextStopsBetweenFiles: Run is an exported entry point, so a library
+// caller can be publishing hundreds of documents with no way to ask it to stop.
+// Cancellation is checked between files rather than inside one, since part way
+// through a page is the one place stopping would leave a page half written.
+func TestRunContextStopsBetweenFiles(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "a.md", markdownWithTitle("First"))
+	writeFile(t, dir, "b.md", markdownWithTitle("Second"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := RunContext(ctx, publishConfig(server.URL, filepath.Join(dir, "*.md")))
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, countPagesTitled(t, server, "First"),
+		"a run cancelled before it starts publishes nothing")
+}
+
+// TestRunContextPublishesWhenNotCancelled is the control.
+func TestRunContextPublishesWhenNotCancelled(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	file := writeFile(t, dir, "doc.md", markdownWithTitle("Published"))
+
+	require.NoError(t, RunContext(context.Background(), publishConfig(server.URL, file)))
+	assert.Equal(t, 1, countPagesTitled(t, server, "Published"))
+}
+
+// TestProcessFileContextIsCancellable covers the single-file entry point, which
+// a caller loops over itself.
+func TestProcessFileContextIsCancellable(t *testing.T) {
+	server, api := docsSpace(t)
+	dir := t.TempDir()
+
+	file := writeFile(t, dir, "doc.md", markdownWithTitle("Not Published"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ProcessFileContext(ctx, file, api, publishConfig(server.URL, file))
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, countPagesTitled(t, server, "Not Published"))
+}
+
+// TestRunStillWorksWithoutAContext: the old entry points keep their signatures,
+// since they are what every existing caller uses.
+func TestRunStillWorksWithoutAContext(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	file := writeFile(t, dir, "doc.md", markdownWithTitle("Plain Run"))
+
+	require.NoError(t, Run(publishConfig(server.URL, file)))
+	assert.Equal(t, 1, countPagesTitled(t, server, "Plain Run"))
+}


### PR DESCRIPTION
Run and ProcessFile are exported entry points, and neither took a context. An
embedder publishing several hundred documents had no way to ask for the run to
stop, and a run that rendered a diagram left the headless Chrome it started
alive for the life of the host process -- Cleanup was called only from the CLI
wiring, which a library caller never reaches.

RunContext and ProcessFileContext take one; Run and ProcessFile keep their
signatures and pass a background context, since they are what every existing
caller uses.

Cancellation is checked between files and before the deferred second pass, not
inside a file. Part way through publishing a page is the one place stopping
would leave a page half written, and the boundary between files is where a run
already decides what to do next. Whatever the run did before it stopped stands,
including the manifest, which is saved on the way out as it is for any other
ending.

It does not abort a request already in flight. The Confluence client builds its
own requests, so a context reaches the retry backoff and no further -- which is
worth having on its own, since three retries at the cap held a cancelled request
for a minute and a half it could not escape. Threading a context through every
API call is a larger change and belongs in its own.

RunContext shuts the browser down on the way out. ProcessFileContext does not: a
caller publishing several files would pay to start it again for each, so that
one is the caller's to call. Closing it twice is harmless, so the CLI's own
deferred Cleanup still costs nothing.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
