### PR TITLE
fix(confluence): a short page is not the end of a listing

### DIFF
--- a/confluence/api.go
+++ b/confluence/api.go
@@ -931,7 +931,13 @@ func (api *API) GetAttachments(pageID string) ([]AttachmentInfo, error) {
 
 		all = append(all, result.Results...)
 
-		if len(result.Results) < pageSize || result.Links.Next == "" {
+		// A short page does not mean the end: Confluence caps limit at its
+		// max-results setting and answers a capped request with a short page
+		// and a next link both. Nor does a missing link, since deployments that
+		// omit it only ever go short. Stop when neither says there is more, and
+		// on an empty page whatever they say.
+		if len(result.Results) == 0 ||
+			(result.Links.Next == "" && len(result.Results) < pageSize) {
 			break
 		}
 
@@ -988,7 +994,13 @@ func (api *API) GetInlineComments(pageID string) (*InlineComments, error) {
 
 		all.Results = append(all.Results, result.Results...)
 
-		if len(result.Results) < pageSize || result.Links.Next == "" {
+		// A short page does not mean the end: Confluence caps limit at its
+		// max-results setting and answers a capped request with a short page
+		// and a next link both. Nor does a missing link, since deployments that
+		// omit it only ever go short. Stop when neither says there is more, and
+		// on an empty page whatever they say.
+		if len(result.Results) == 0 ||
+			(result.Links.Next == "" && len(result.Results) < pageSize) {
 			break
 		}
 
@@ -1297,7 +1309,13 @@ func (api *API) GetPageLabels(page *PageInfo, prefix string) (*LabelInfo, error)
 
 		all = append(all, result.Labels...)
 
-		if len(result.Labels) < pageSize || result.Links.Next == "" {
+		// A short page does not mean the end: Confluence caps limit at its
+		// max-results setting and answers a capped request with a short page
+		// and a next link both. Nor does a missing link, since deployments that
+		// omit it only ever go short. Stop when neither says there is more, and
+		// on an empty page whatever they say.
+		if len(result.Labels) == 0 ||
+			(result.Links.Next == "" && len(result.Labels) < pageSize) {
 			break
 		}
 
@@ -1790,6 +1808,13 @@ func (api *API) GetChildPages(parentID string) ([]PageInfo, error) {
 	for {
 		result := struct {
 			Results []PageInfo `json:"results"`
+
+			// The listing's own word on whether more exist. Without it this
+			// loop stopped on a short page, which is what a deployment that
+			// caps max-results answers a full request with.
+			Links struct {
+				Next string `json:"next"`
+			} `json:"_links"`
 		}{}
 
 		request, err := api.v1().Res(
@@ -1807,9 +1832,17 @@ func (api *API) GetChildPages(parentID string) ([]PageInfo, error) {
 		}
 
 		all = append(all, result.Results...)
-		if len(result.Results) < pageSize {
+
+		// A short page does not mean the end: Confluence caps limit at its
+		// max-results setting and answers a capped request with a short page
+		// and a next link both. Nor does a missing link, since deployments that
+		// omit it only ever go short. Stop when neither says there is more, and
+		// on an empty page whatever they say.
+		if len(result.Results) == 0 ||
+			(result.Links.Next == "" && len(result.Results) < pageSize) {
 			break
 		}
+
 		start += len(result.Results)
 	}
 

--- a/confluence/property.go
+++ b/confluence/property.go
@@ -218,10 +218,19 @@ func (api *API) ListContentProperties(contentID string) ([]Property, error) {
 
 		all = append(all, result.Results...)
 
-		// _links.next is the server's own word on whether more exist; the short
-		// page is the second condition because a deployment that omits the link
-		// would otherwise be asked for the same page forever.
-		if result.Links.Next == "" || len(result.Results) < propertyPageSize {
+		// Two ways a listing says it is finished, and a deployment may use
+		// either. Confluence caps limit at its max-results setting and answers
+		// a capped request with a short page *and* a next link, so a short page
+		// alone does not mean the end -- that is how the tail of a listing was
+		// being thrown away, silently, on exactly the instances configured to
+		// hand out less than they were asked for. Other deployments omit the
+		// link entirely and only ever go short.
+		//
+		// So: keep going while either says there is more, and stop on an empty
+		// page whatever they say, which is what keeps a server that does
+		// neither from being asked for the same offset forever.
+		if len(result.Results) == 0 ||
+			(result.Links.Next == "" && len(result.Results) < propertyPageSize) {
 			break
 		}
 		start += len(result.Results)

--- a/confluence/property_test.go
+++ b/confluence/property_test.go
@@ -2,6 +2,8 @@ package confluence_test
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/kovetskiy/mark/v16/confluence"
@@ -124,4 +126,61 @@ func TestStalePropertyUpdateStaysAConflict(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, confluence.ErrPropertyConflict)
 	assert.NotErrorIs(t, err, confluence.ErrPropertyUnseen)
+}
+
+// TestListingContinuesPastAShortPageWithANextLink: Confluence caps limit at the
+// deployment's max-results setting and answers a capped request with a short
+// page *and* a next link. Stopping on the short page threw the rest of the
+// listing away -- silently, and on exactly the instances configured to hand out
+// less than they were asked for. For the manifest that means shards treated as
+// absent, and the mappings they held lost.
+func TestListingContinuesPastAShortPageWithANextLink(t *testing.T) {
+	var pages int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pages++
+
+		// Two short pages, the first advertising a next: a server that caps at
+		// less than the client asked for.
+		body := `{"results":[{"id":"1","key":"mark.manifest.0","value":{}}],` +
+			`"_links":{"next":"/rest/api/content/1/property?start=1"}}`
+		if pages > 1 {
+			body = `{"results":[{"id":"2","key":"mark.manifest.1","value":{}}],"_links":{}}`
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	properties, err := api.ListContentProperties("1")
+	require.NoError(t, err)
+
+	assert.Len(t, properties, 2, "the second page has to be read")
+	assert.Equal(t, 2, pages)
+}
+
+// TestListingStopsWithoutANextLink covers the other kind of deployment, which
+// omits the link and only ever goes short. Depending on the link alone would
+// truncate those at the first page.
+func TestListingStopsWithoutANextLink(t *testing.T) {
+	var pages int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pages++
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"id":"1","key":"mark.manifest.0","value":{}}],"_links":{}}`))
+	}))
+	defer server.Close()
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	properties, err := api.ListContentProperties("1")
+	require.NoError(t, err)
+
+	assert.Len(t, properties, 1)
+	assert.Equal(t, 1, pages, "a short page with no next link is the end")
 }


### PR DESCRIPTION
Every v1 listing stopped when a page came back shorter than it asked for.
Confluence caps limit at the deployment's max-results setting, and a capped
request is answered with a short page *and* a next link -- so the tail of the
listing was thrown away, silently, on exactly the instances configured to hand
out less than they were asked for.

What that costs depends on the listing. A truncated GetAttachments classifies
everything past the cap as new and re-POSTs files that already exist, which
Confluence refuses. A truncated GetPageLabels re-adds labels the page already
has. A truncated property listing loses manifest shards, and this package's own
ErrPropertyUnseen exists to describe what happens next: the mappings they held
are treated as absent, and the write that follows collides with a key nobody
saw.

The comment claimed the short page was there to stop a deployment that omits
_links.next from being asked for the same offset forever. It is not needed for
that -- an empty page is -- and the two behaviours are both real: some
deployments cap and send the link, others omit the link and only ever go short.
The loops now continue while either says there is more, and stop on an empty
page whatever they say.

GetChildPages had no next-link check at all, so it only ever stopped short. It
gets both, and the struct gains the _links it was throwing away.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
