### PR TITLE
fix(includes): an include names the file beside the document, not the first one read

### DIFF
--- a/includes/templates.go
+++ b/includes/templates.go
@@ -113,6 +113,40 @@ func ParseIncludeDirective(raw []byte) (*IncludeDirective, error) {
 	return dir, nil
 }
 
+// resolveTemplatePath names the file a directive refers to.
+//
+// The document's own directory first, then --include-path, which is the order
+// the read used to try them in. A name that matches nothing resolves against
+// the document's directory anyway, so the failure to read it names the place
+// the author would look first.
+func resolveTemplatePath(base, includePath, path string) string {
+	candidate := filepath.Join(base, path)
+	if _, err := os.Stat(candidate); err == nil {
+		return absolute(candidate)
+	}
+
+	if includePath != "" {
+		fallback := filepath.Join(includePath, path)
+		if _, err := os.Stat(fallback); err == nil {
+			return absolute(fallback)
+		}
+	}
+
+	return absolute(candidate)
+}
+
+// absolute makes a path the key of exactly one file, whatever directory the
+// run was started from. A path that cannot be made absolute is returned as it
+// was: it is still a better key than the bare name, and the read that follows
+// will report whatever is wrong with it.
+func absolute(path string) string {
+	if abs, err := filepath.Abs(path); err == nil {
+		return abs
+	}
+
+	return path
+}
+
 func LoadTemplate(
 	base string,
 	includePath string,
@@ -131,29 +165,29 @@ func LoadTemplate(
 		return template, nil
 	}
 
-	// For file-backed templates the delimiters are part of what makes the parse,
-	// so they belong in the cache key. Keying on the path alone meant a file
-	// included twice with different Delims: reused the first parse and silently
-	// discarded the second set, rendering the wrong output with no error.
-	cacheName := name
+	// Which file this is, decided before the cache is consulted rather than
+	// after. One template set is shared by every document in a run, so keying
+	// on the name a directive wrote made "partial.md" beside one document the
+	// same entry as "partial.md" beside another: the first one read was then
+	// served to every document that asked for that name, publishing one page's
+	// fragment onto another's, silently and with no error anywhere.
+	resolved := resolveTemplatePath(base, includePath, path)
+
+	// The delimiters are part of what makes the parse, so they belong in the
+	// key too. Without them a file included twice with different Delims: reused
+	// the first parse and silently discarded the second set.
+	cacheName := resolved
 	if left != "" || right != "" {
-		cacheName = name + "\x00" + left + "\x00" + right
+		cacheName = resolved + "\x00" + left + "\x00" + right
 	}
 
 	if template := templates.Lookup(cacheName); template != nil {
 		return template, nil
 	}
 
-	var body []byte
-
-	body, err := os.ReadFile(filepath.Join(base, path))
+	body, err := os.ReadFile(resolved)
 	if err != nil {
-		if includePath != "" {
-			body, err = os.ReadFile(filepath.Join(includePath, path))
-		}
-		if err != nil {
-			return nil, fmt.Errorf("unable to read template file %q: %w", path, err)
-		}
+		return nil, fmt.Errorf("unable to read template file %q: %w", path, err)
 	}
 
 	body = bytes.ReplaceAll(

--- a/includes/templates_test.go
+++ b/includes/templates_test.go
@@ -64,15 +64,48 @@ func TestLoadTemplateScopedBySubdirectory(t *testing.T) {
 	tmpl, err = LoadTemplate(tempDir, "", "dirB/header.md", "", "", tmpl)
 	require.NoError(t, err)
 
-	assert.NotNil(t, tmpl.Lookup("dirA/header"))
-	assert.NotNil(t, tmpl.Lookup("dirB/header"))
+	// Rendered through the includes, since what the entry is called is an
+	// implementation detail and what it holds is not.
+	tmpl, a, _, err := ProcessIncludes(tempDir, "", []byte("<!-- Include: dirA/header.md -->\n"), tmpl)
+	require.NoError(t, err)
 
-	var bufA, bufB bytes.Buffer
-	require.NoError(t, tmpl.Lookup("dirA/header").Execute(&bufA, nil))
-	require.NoError(t, tmpl.Lookup("dirB/header").Execute(&bufB, nil))
+	_, b, _, err := ProcessIncludes(tempDir, "", []byte("<!-- Include: dirB/header.md -->\n"), tmpl)
+	require.NoError(t, err)
 
-	assert.Equal(t, "Header A", bufA.String())
-	assert.Equal(t, "Header B", bufB.String())
+	assert.Contains(t, string(a), "Header A")
+	assert.Contains(t, string(b), "Header B")
+}
+
+// TestSameNameInDifferentDirectories is the bug the test above only half
+// covered. One template set is shared by every document in a run, and the cache
+// key was the name the directive wrote -- so "partial.md" beside one document
+// was the same entry as "partial.md" beside another, and the first one read was
+// served to every document that asked. A repository keeping a partial per
+// directory published the first one on every page, silently.
+func TestSameNameInDifferentDirectories(t *testing.T) {
+	tempDir := t.TempDir()
+
+	dirA := filepath.Join(tempDir, "a")
+	dirB := filepath.Join(tempDir, "b")
+	require.NoError(t, os.MkdirAll(dirA, 0755))
+	require.NoError(t, os.MkdirAll(dirB, 0755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dirA, "partial.md"), []byte("CONTENT-FROM-A"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dirB, "partial.md"), []byte("CONTENT-FROM-B"), 0644))
+
+	// One set, as a run has: the documents are in different directories and
+	// each writes the same name.
+	tmpl := template.New("stdlib")
+
+	tmpl, fromA, _, err := ProcessIncludes(dirA, "", []byte("<!-- Include: partial.md -->\n"), tmpl)
+	require.NoError(t, err)
+
+	_, fromB, _, err := ProcessIncludes(dirB, "", []byte("<!-- Include: partial.md -->\n"), tmpl)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(fromA), "CONTENT-FROM-A")
+	assert.Contains(t, string(fromB), "CONTENT-FROM-B",
+		"each document includes the file beside it, not the first one read")
 }
 
 func TestProcessIncludesInlineCodeTemplateVar(t *testing.T) {


### PR DESCRIPTION
One template set is shared by every document in a run -- mark builds a stdlib
once and hands it to each file -- and the cache key was the name the directive
wrote. So "partial.md" beside one document was the same entry as "partial.md"
beside another, and whichever was read first was served to every document that
asked for that name afterwards.

A repository that keeps a header.md or partial.md per directory therefore
published the first one on every page. No error, no warning, and nothing in the
output to suggest the fragment did not belong to the page it was on.

The key is now the resolved file: the document's own directory first, then
--include-path, which is the order the read already tried them in, made absolute
so it names exactly one file whatever directory the run was started from. The
delimiters stay in the key for the reason they were added.

Resolving before the lookup rather than after also means the file is chosen
once. The read that follows can no longer disagree with the entry that was
cached.

The subdirectory test asserted the entry's name, which is an implementation
detail; it now renders both includes and asserts what came out, and a second
test covers the case it did not: the same name in two directories, through one
shared set.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
