### PR TITLE
fix(markdown): drain includes and macros together, before goldmark sees the bytes

### DIFF
--- a/markdown/expand_directives_test.go
+++ b/markdown/expand_directives_test.go
@@ -1,0 +1,91 @@
+package mark_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	mark "github.com/kovetskiy/mark/v16/markdown"
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// write puts a file in dir and returns its path.
+func write(t *testing.T, dir, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+// compileFile compiles a document from disk, which is what the include and
+// macro paths need in order to resolve anything.
+func compileFile(t *testing.T, path string) (string, error) {
+	t.Helper()
+
+	source, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	lib, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	out, _, err := mark.CompileMarkdown(source, lib, path, types.MarkConfig{})
+
+	return out, err
+}
+
+// TestMacroThatIncludesAFile: a macro's expansion may name an include, and
+// includes ran before macros -- so that directive was left for the AST
+// transformers, which splice a sub-document parsed from its own bytes into an
+// AST rendered against the document's. Every node they did not rewrite kept
+// offsets into the wrong buffer: this fenced code block came out with its
+// language read from the middle of the word "Include", a body sliced from
+// wherever those offsets landed, and NUL bytes past the end.
+func TestMacroThatIncludesAFile(t *testing.T) {
+	dir := t.TempDir()
+
+	write(t, dir, "sub.md", "intro text\n\n```go\nfunc main() { fmt.Println(\"XYZZY\") }\n```\n\noutro\n")
+	write(t, dir, "emit.tmpl", "<!-- Include: sub.md -->\n")
+	doc := write(t, dir, "doc.md", "<!-- Macro: GOGO\n     Template: emit.tmpl\n-->\n\nbefore\n\nGOGO\n\nafter\n")
+
+	out, err := compileFile(t, doc)
+	require.NoError(t, err)
+
+	assert.Contains(t, out, `<ac:parameter ac:name="language">go</ac:parameter>`,
+		"the code block keeps its own language")
+	assert.Contains(t, out, `func main() { fmt.Println("XYZZY") }`,
+		"and its own body")
+
+	assert.NotContains(t, out, "\x00", "no bytes read past the end of a buffer")
+	assert.NotContains(t, out, "lude:", "and none read from the middle of the directive")
+	assert.Equal(t, 1, countOf(out, "after"), "the text after the macro is published once")
+}
+
+// TestIncludeThatDefinesAMacro is the other direction: a fragment may define a
+// macro, and macros were extracted only once, before that fragment was read.
+func TestIncludeThatDefinesAMacro(t *testing.T) {
+	dir := t.TempDir()
+
+	write(t, dir, "defs.md", "<!-- Macro: TICKET-(\\d+)\n     Template: #inline\n     inline: \"issue ${1}\" -->\n")
+	doc := write(t, dir, "doc.md", "<!-- Include: defs.md -->\n\nSee TICKET-42.\n")
+
+	out, err := compileFile(t, doc)
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "issue 42", "a macro an include defined is applied")
+}
+
+func countOf(haystack, needle string) int {
+	var n int
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			n++
+		}
+	}
+
+	return n
+}

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -223,6 +223,65 @@ func compileMarkdownWithExtension(markdown []byte, ext goldmark.Extender, logMes
 // without a bound the document grows until the process is killed.
 const maxIncludePasses = 10
 
+// expandDirectives drains every include and macro the document names, and
+// everything they name in turn, before goldmark is given the bytes.
+//
+// The two produce each other's work: an included fragment may define a macro,
+// and a macro's expansion may include a file. Running includes once and then
+// macros once left the second kind unexpanded, and the AST transformers were
+// what picked it up afterwards -- splicing a sub-document, parsed from its own
+// bytes, into an AST that is rendered against the document's. Every node those
+// two did not rewrite kept offsets into the wrong buffer, so a fenced code
+// block in an included fragment came out with its language read from the middle
+// of the directive, a body sliced from wherever those offsets happened to land,
+// and NUL bytes where the slice ran past the end -- illegal in XML, so the page
+// was refused.
+//
+// Draining them here means the AST never sees a directive, which is what
+// invariant 3 in AGENTS.md says should be true.
+func expandDirectives(
+	path string,
+	cfg types.MarkConfig,
+	markdown []byte,
+	tmpl *template.Template,
+) (*template.Template, []byte, error) {
+	for pass := 0; pass < maxIncludePasses; pass++ {
+		before := markdown
+
+		var err error
+
+		tmpl, markdown, err = expandIncludes(path, cfg.IncludePath, markdown, tmpl)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		var macros []macro.Macro
+
+		macros, markdown, err = macro.ExtractMacros(filepath.Dir(path), cfg.IncludePath, markdown, tmpl)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to extract macros: %w", err)
+		}
+
+		for _, m := range macros {
+			markdown, err = m.Apply(markdown)
+			if err != nil {
+				return nil, nil, fmt.Errorf("unable to apply macro %q: %w", m.Regexp.String(), err)
+			}
+		}
+
+		// Nothing left to find. Compared by content rather than by counting
+		// what was applied, since a macro that matches nothing still counts as
+		// applied and would keep the loop going for ever.
+		if bytes.Equal(before, markdown) {
+			return tmpl, markdown, nil
+		}
+	}
+
+	return nil, nil, fmt.Errorf(
+		"includes and macros did not settle after %d passes over %q", maxIncludePasses, path,
+	)
+}
+
 // expandIncludes runs include expansion over the document until it settles,
 // which is what both compile paths need before goldmark ever sees the bytes.
 func expandIncludes(
@@ -260,21 +319,12 @@ func CompileMarkdown(markdown []byte, stdlib *stdlib.Lib, path string, cfg types
 		tmpl = template.New("stdlib")
 	}
 
-	tmpl, markdown, err := expandIncludes(path, cfg.IncludePath, markdown, tmpl)
+	// The template set the expansion built is not carried forward: the
+	// extension takes its templates from the stdlib, as it did when the macro
+	// pass held this set locally.
+	_, markdown, err := expandDirectives(path, cfg, markdown, tmpl)
 	if err != nil {
 		return "", nil, err
-	}
-
-	var macros []macro.Macro
-	macros, markdown, err = macro.ExtractMacros(filepath.Dir(path), cfg.IncludePath, markdown, tmpl)
-	if err != nil {
-		return "", nil, fmt.Errorf("unable to extract macros: %w", err)
-	}
-	for _, m := range macros {
-		markdown, err = m.Apply(markdown)
-		if err != nil {
-			return "", nil, fmt.Errorf("unable to apply macro %q: %w", m.Regexp.String(), err)
-		}
 	}
 
 	ghAlertsExtension := NewConfluenceExtension(stdlib, path, cfg)
@@ -303,21 +353,12 @@ func CompileMarkdownLegacy(markdown []byte, stdlib *stdlib.Lib, path string, cfg
 		tmpl = template.New("stdlib")
 	}
 
-	tmpl, markdown, err := expandIncludes(path, cfg.IncludePath, markdown, tmpl)
+	// The template set the expansion built is not carried forward: the
+	// extension takes its templates from the stdlib, as it did when the macro
+	// pass held this set locally.
+	_, markdown, err := expandDirectives(path, cfg, markdown, tmpl)
 	if err != nil {
 		return "", nil, err
-	}
-
-	var macros []macro.Macro
-	macros, markdown, err = macro.ExtractMacros(filepath.Dir(path), cfg.IncludePath, markdown, tmpl)
-	if err != nil {
-		return "", nil, fmt.Errorf("unable to extract macros: %w", err)
-	}
-	for _, m := range macros {
-		markdown, err = m.Apply(markdown)
-		if err != nil {
-			return "", nil, fmt.Errorf("unable to apply macro %q: %w", m.Regexp.String(), err)
-		}
 	}
 
 	confluenceExtension := NewConfluenceLegacyExtension(stdlib, path, cfg)


### PR DESCRIPTION
Includes ran once, then macros ran once. But the two produce each other's work:
an included fragment may define a macro, and a macro's expansion may name an
include. The second kind was left in the document, and the AST transformers
picked it up afterwards -- splicing a sub-document, parsed from its own bytes,
into an AST that is rendered against the document's.

Only three node kinds were rewritten to carry their own text across. Everything
else kept offsets into the wrong buffer, so a fenced code block inside an
included fragment was published with its language read from the middle of the
word "Include", a body sliced from wherever those offsets happened to land, the
text after the macro repeated, and NUL bytes where the slice ran past the end:

    <ac:parameter ac:name="language">In</ac:parameter>
    <ac:plain-text-body><![CDATA[lude: sub.md -->

NUL is illegal in XML 1.0, so the page was refused -- loudly, since the
well-formedness check went in, and silently before that.

Both are now drained in one loop over the raw bytes, until a pass changes
nothing. That is what invariant 3 in AGENTS.md describes, and the AST
transformers no longer see a directive to mishandle. Settling is judged by
comparing the bytes rather than by counting what was applied, because a macro
that matches nothing still counts as applied and would keep the loop going for
ever; the existing pass limit still bounds it.

The AST transformers are left registered and are now unreachable. Removing them
touches exported API and the error plumbing built around the pipeline, which is
worth doing on its own rather than here.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
