### PR TITLE
feat: link to an anchor on another page, and to one written by hand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1743,6 +1743,26 @@ clickable, and does nothing.
 Only a heading something links to carries an anchor; the rest are left as they
 were.
 
+To mark a place no heading names, write an anchor by hand — Confluence keeps
+neither the `name` nor the `id`, so mark turns it into the same macro a heading
+gets:
+
+```markdown
+<a name="details"></a>
+
+...later: [see the details](#details)
+```
+
+An anchor on *another* page is written after the page's title:
+
+```markdown
+[the setup](<ac:Other Page#Setup>)
+```
+
+The part after the last `#` is taken as an anchor only if it has no whitespace
+in it, which is true of every anchor mark generates — so a page whose title
+contains a `#`, like `<ac:C# Guide>`, is still just a title.
+
 ### Linting markdown
 
 We recommend to lint your markdown files with [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) before publishing them to confluence to catch any conversion errors early.

--- a/markdown/anchors_elsewhere_test.go
+++ b/markdown/anchors_elsewhere_test.go
@@ -1,0 +1,96 @@
+package mark
+
+import (
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func compileLinkDoc(t *testing.T, src string) string {
+	t.Helper()
+
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	out, _, err := CompileMarkdown([]byte(src), std, "test.md", types.MarkConfig{})
+	require.NoError(t, err)
+
+	return out
+}
+
+// TestLinkToAnAnchorOnAnotherPage: a "#" in an ac: destination names a section,
+// not part of the title -- and there was no way to write one, though storage
+// format has said it with ac:anchor beside ri:page all along.
+func TestLinkToAnAnchorOnAnotherPage(t *testing.T) {
+	out := compileLinkDoc(t, "See [the setup](<ac:Other Page#Setup>).\n")
+
+	assert.Contains(t, out, `<ac:link ac:anchor="Setup"><ri:page ri:content-title="Other Page"/>`)
+	assert.NotContains(t, out, `content-title="Other Page#Setup"`,
+		"the anchor is not part of the title")
+}
+
+// TestPageLinkWithoutAnAnchorIsUnchanged is the control.
+func TestPageLinkWithoutAnAnchorIsUnchanged(t *testing.T) {
+	out := compileLinkDoc(t, "See [the page](<ac:Other Page>).\n")
+
+	assert.Contains(t, out, `<ac:link><ri:page ri:content-title="Other Page"/>`)
+	assert.NotContains(t, out, "ac:anchor")
+}
+
+// TestPageTitleMayContainAHash: a "#" alone cannot be the separator. "C# Guide"
+// is a page title, and reading it as a page called "C" with an anchor called
+// " Guide" would break a link that works today -- so the part after the last
+// "#" has to look like an anchor, which means no whitespace in it.
+func TestPageTitleMayContainAHash(t *testing.T) {
+	alone := compileLinkDoc(t, "[x](<ac:C# Guide>)\n")
+
+	assert.Contains(t, alone, `ri:content-title="C# Guide"`)
+	assert.NotContains(t, alone, "ac:anchor")
+}
+
+// TestAnchorWithWhitespaceIsPartOfTheTitle is the same rule from the other
+// side: an author who means an anchor writes one without spaces, because that
+// is what every id mark generates looks like.
+func TestAnchorWithWhitespaceIsPartOfTheTitle(t *testing.T) {
+	out := compileLinkDoc(t, "[x](<ac:Release Notes#Q1 2026>)\n")
+
+	assert.Contains(t, out, `ri:content-title="Release Notes#Q1 2026"`)
+	assert.NotContains(t, out, "ac:anchor")
+}
+
+// TestManualAnchorBecomesTheMacro: "<a name=...>" is how an author marks a spot
+// no heading names. Confluence keeps neither the name nor the id -- the element
+// survives stripped of both -- so the anchor was published as an empty <a> and
+// nothing could reach it.
+func TestManualAnchorBecomesTheMacro(t *testing.T) {
+	out := compileLinkDoc(t, `<a name="details"></a>
+
+Text. See [details](#details).
+`)
+
+	assert.Contains(t, out,
+		`<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">details</ac:parameter></ac:structured-macro>`)
+	assert.Contains(t, out, `<ac:link ac:anchor="details">`)
+	assert.NotContains(t, out, "<a name=")
+	assert.NotContains(t, out, "</a>")
+}
+
+// TestManualAnchorWrittenWithAnID covers the other spelling, and the escaping
+// the name needs on its way into a macro parameter.
+func TestManualAnchorWrittenWithAnID(t *testing.T) {
+	out := compileLinkDoc(t, "<a id=\"a&b\"></a>\n\nText.\n")
+
+	assert.Contains(t, out, `<ac:parameter ac:name="">a&amp;b</ac:parameter>`)
+}
+
+// TestOrdinaryLinksAreNotAnchors is the control: an <a> with an href is a link,
+// and its closing tag is not the macro's to take.
+func TestOrdinaryLinksAreNotAnchors(t *testing.T) {
+	out := compileLinkDoc(t, `<a href="https://example.com">text</a>`+"\n")
+
+	assert.Contains(t, out, `<a href="https://example.com">text</a>`)
+	assert.NotContains(t, out, "ac:name=\"anchor\"")
+}

--- a/markdown/markdown.go
+++ b/markdown/markdown.go
@@ -411,6 +411,9 @@ func (c *ConfluenceExtension) Extend(m goldmark.Markdown) {
 		// well as the ones written in the file, and so that heading ids have
 		// already been assigned.
 		util.Prioritized(ctransformer.NewAnchorTransformer(), 900),
+		// After the anchor transformer, so a heading that a manual anchor sits
+		// beside has already been matched to the links that name it.
+		util.Prioritized(ctransformer.NewManualAnchorTransformer(), 901),
 		// After includes and macros have brought their content in, so links
 		// inside an included fragment are resolved too.
 		// Before link resolution, so that a path a document declared as an

--- a/renderer/link.go
+++ b/renderer/link.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kovetskiy/mark/v16/stdlib"
 	stdhtml "html"
 	"strings"
+	"unicode"
 
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/renderer"
@@ -27,6 +28,30 @@ func NewConfluenceLinkRenderer(lib *stdlib.Lib, opts ...html.Option) renderer.No
 // RegisterFuncs implements NodeRenderer.RegisterFuncs .
 func (r *ConfluenceLinkRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
 	reg.Register(ast.KindLink, r.renderLink)
+}
+
+// splitPageAnchor separates a page title from the anchor written after it.
+//
+// A "#" alone is not enough to split on: "ac:C# Guide" is a page whose title
+// contains one, and reading it as a page called "C" with an anchor called
+// " Guide" would break a link that works today. So the part after the last "#"
+// has to look like an anchor -- present, and with no whitespace in it, which is
+// true of every id mark generates, since a heading's spaces become hyphens.
+//
+// The last "#" rather than the first, so a title containing one can still be
+// given an anchor.
+func splitPageAnchor(destination string) (title, anchor string) {
+	at := strings.LastIndex(destination, "#")
+	if at <= 0 || at == len(destination)-1 {
+		return destination, ""
+	}
+
+	candidate := destination[at+1:]
+	if strings.ContainsFunc(candidate, unicode.IsSpace) {
+		return destination, ""
+	}
+
+	return destination[:at], candidate
 }
 
 // renderLink renders links specifically for confluence
@@ -60,7 +85,19 @@ func (r *ConfluenceLinkRenderer) renderLink(writer util.BufWriter, source []byte
 
 	if len(n.Destination) >= 3 && string(n.Destination[0:3]) == "ac:" {
 		if entering {
-			_, err := writer.Write([]byte("<ac:link><ri:page ri:content-title=\""))
+			// A "#" in the destination names an anchor on the page rather than
+			// part of its title: "ac:Other Page#Setup" is the section, not a
+			// page called "Other Page#Setup". Storage format says so with the
+			// same ac:anchor a same-page link uses, alongside the ri:page that
+			// says which page.
+			title, anchor := splitPageAnchor(string(n.Destination[min(3, len(n.Destination)):]))
+
+			opening := "<ac:link>"
+			if anchor != "" {
+				opening = `<ac:link ac:anchor="` + xmlAttrEscape(anchor) + `">`
+			}
+
+			_, err := writer.Write([]byte(opening + "<ri:page ri:content-title=\""))
 			if err != nil {
 				return ast.WalkStop, err
 			}
@@ -75,7 +112,7 @@ func (r *ConfluenceLinkRenderer) renderLink(writer util.BufWriter, source []byte
 					return ast.WalkStop, err
 				}
 			} else {
-				_, err := writer.WriteString(xmlAttrEscape(string(n.Destination[3:])))
+				_, err := writer.WriteString(xmlAttrEscape(title))
 				if err != nil {
 					return ast.WalkStop, err
 				}

--- a/transformer/manual_anchors.go
+++ b/transformer/manual_anchors.go
@@ -1,0 +1,157 @@
+package transformer
+
+import (
+	"bytes"
+	"html"
+	"regexp"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+// manualAnchor matches an anchor written by hand: an <a> carrying a name or an
+// id and no href, which is how a Markdown author marks a spot to link to when
+// the spot is not a heading.
+//
+// Anything with an href is a link and is left alone.
+var manualAnchor = regexp.MustCompile(
+	`(?i)^<a\s+(?:name|id)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))\s*/?>$`,
+)
+
+// manualAnchorClose matches the </a> that closes one.
+var manualAnchorClose = regexp.MustCompile(`(?i)^</a\s*>$`)
+
+// ManualAnchorTransformer turns a hand-written anchor into the Anchor macro.
+//
+// `<a name="details"></a>` is the ordinary way to mark a place in a Markdown
+// document that no heading names. Confluence keeps neither the name nor the id
+// -- the element survives, stripped of both -- so the anchor was published as
+// an empty <a> and nothing could link to it.
+//
+// The macro is what a link can reach, and is the same one a heading gets, so a
+// link written "#details" finds it exactly as it finds a heading.
+type ManualAnchorTransformer struct{}
+
+func NewManualAnchorTransformer() *ManualAnchorTransformer {
+	return &ManualAnchorTransformer{}
+}
+
+// Transform implements parser.ASTTransformer.
+func (t *ManualAnchorTransformer) Transform(doc *ast.Document, reader text.Reader, pc parser.Context) {
+	source := reader.Source()
+
+	type replacement struct {
+		node  ast.Node
+		value []byte
+	}
+
+	var found []replacement
+
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		raw, ok := node.(*ast.RawHTML)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+
+		tag := bytes.TrimSpace(rawHTMLBytes(raw, source))
+
+		if groups := manualAnchor.FindSubmatch(tag); groups != nil {
+			name := firstNonEmpty(groups[1:])
+			if len(name) > 0 {
+				found = append(found, replacement{node: node, value: anchorMacro(string(name))})
+			}
+
+			return ast.WalkContinue, nil
+		}
+
+		// The closer belongs to the element that is going away. Dropping it is
+		// what keeps the body well-formed, since the macro closes itself.
+		if manualAnchorClose.Match(tag) && closesAManualAnchor(node, source) {
+			found = append(found, replacement{node: node, value: nil})
+		}
+
+		return ast.WalkContinue, nil
+	})
+
+	for _, item := range found {
+		parent := item.node.Parent()
+		if parent == nil {
+			continue
+		}
+
+		if item.value == nil {
+			parent.RemoveChild(parent, item.node)
+
+			continue
+		}
+
+		macro := ast.NewString(item.value)
+		macro.SetCode(true)
+
+		parent.InsertBefore(parent, item.node, macro)
+		parent.RemoveChild(parent, item.node)
+	}
+}
+
+// closesAManualAnchor reports whether the nearest opening tag before this one
+// was an anchor being replaced, so that an ordinary link's </a> is left alone.
+func closesAManualAnchor(node ast.Node, source []byte) bool {
+	for previous := node.PreviousSibling(); previous != nil; previous = previous.PreviousSibling() {
+		raw, ok := previous.(*ast.RawHTML)
+		if !ok {
+			continue
+		}
+
+		tag := bytes.TrimSpace(rawHTMLBytes(raw, source))
+		if manualAnchorClose.Match(tag) {
+			return false
+		}
+
+		if bytes.HasPrefix(bytes.ToLower(tag), []byte("<a")) {
+			return manualAnchor.Match(tag)
+		}
+	}
+
+	return false
+}
+
+// anchorMacro is the Anchor macro for a name, escaped as the stdlib template
+// escapes it -- html.EscapeString is what xmlesc calls. Written here rather
+// than rendered from the template because a transformer has no stdlib, and the
+// bytes are inserted into the tree rather than into a stream.
+func anchorMacro(name string) []byte {
+	return []byte(
+		`<ac:structured-macro ac:name="anchor"><ac:parameter ac:name="">` +
+			html.EscapeString(name) +
+			`</ac:parameter></ac:structured-macro>`,
+	)
+}
+
+// rawHTMLBytes joins the segments of a raw HTML node.
+func rawHTMLBytes(node *ast.RawHTML, source []byte) []byte {
+	var buf bytes.Buffer
+
+	for i := 0; i < node.Segments.Len(); i++ {
+		segment := node.Segments.At(i)
+		buf.Write(segment.Value(source))
+	}
+
+	return buf.Bytes()
+}
+
+// firstNonEmpty returns the first group that matched, since the pattern offers
+// three ways to quote the value.
+func firstNonEmpty(groups [][]byte) []byte {
+	for _, group := range groups {
+		if len(group) > 0 {
+			return group
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Two anchors the storage format has always been able to express and mark could
not write.

**An anchor on another page.** A "#" in an ac: destination names a section:
"ac:Other Page#Setup" is a section of that page, not a page called "Other
Page#Setup". It is said with the ac:anchor a same-page link already uses,
alongside the ri:page that says which page.

A "#" alone cannot be the separator, though. "C# Guide" is a page title, and
reading it as a page called "C" with an anchor called " Guide" would break a
link that works today -- so the part after the last "#" is taken as an anchor
only when it has no whitespace in it, which is true of every anchor mark
generates, a heading's spaces having become hyphens. The last "#" rather than
the first, so a title containing one can still be given an anchor.

**An anchor written by hand.** `<a name="details"></a>` is how an author marks
a place no heading names. Confluence keeps neither the name nor the id -- the
element survives stripped of both -- so it was published as an empty <a> that
nothing could reach. It becomes the same Anchor macro a heading gets, and its
closing tag goes with it, so "#details" finds it exactly as it finds a heading.

An <a> carrying an href is a link and is left alone, closing tag included.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
