### PR TITLE
feat/cross file anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1763,6 +1763,24 @@ The part after the last `#` is taken as an anchor only if it has no whitespace
 in it, which is true of every anchor mark generates — so a page whose title
 contains a `#`, like `<ac:C# Guide>`, is still just a title.
 
+A relative link to a section of another document works the same way, and is
+written the way every other Markdown tool expects:
+
+```markdown
+[the setup](./other.md#setup-guide)
+```
+
+The slug is folded onto the id mark gave that heading, exactly as a same-page
+link is, and the link is published as an anchor on that page rather than as a
+URL with a fragment — a fragment on a Confluence address names nothing, since
+Confluence keeps a heading's anchor in the macro rather than in the address.
+
+Two limits, both deliberate. The document has to be published to the same space,
+because a page named without a space key is looked for in the current one; a
+link across spaces keeps its URL. And a fragment naming no heading in that
+document is left exactly as written, since guessing which section was meant
+would send the reader somewhere the author did not choose.
+
 ### Linting markdown
 
 We recommend to lint your markdown files with [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) before publishing them to confluence to catch any conversion errors early.

--- a/mark_crossfile_anchor_test.go
+++ b/mark_crossfile_anchor_test.go
@@ -1,0 +1,97 @@
+package mark
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCrossFileAnchorBecomesAPageAnchor: a fragment on a Confluence URL names
+// nothing. Confluence puts a heading's anchor in the Anchor macro, not in the
+// address, so ".../x/abc123#Setup" scrolls nowhere however the fragment is
+// spelled -- and the fragment was the author's own slug, which does not match
+// the id mark generates either.
+//
+// ac:link with ri:page and ac:anchor is how the storage format says "that
+// section of that page", and the slug is folded onto mark's id the same way a
+// same-page link is.
+func TestCrossFileAnchorBecomesAPageAnchor(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "a-other.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Other Page -->
+
+## Setup Guide
+
+Text.
+`)
+	writeFile(t, dir, "b-doc.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Main -->
+
+See [the setup](./a-other.md#setup-guide).
+`)
+
+	require.NoError(t, Run(publishConfig(server.URL, dir+"/*.md")))
+
+	body := bodyOfPageTitled(t, server, "Main")
+
+	assert.Contains(t, body, `<ac:link ac:anchor="Setup-Guide"><ri:page ri:content-title="Other Page"/>`,
+		"the author's slug is folded onto the id mark gave the heading")
+	assert.NotContains(t, body, "#setup-guide", "and no fragment is left on a URL")
+}
+
+// TestCrossFileLinkWithoutAnAnchorIsUnchanged is the control: a link to the
+// document rather than to a section of it still resolves to the page's URL.
+func TestCrossFileLinkWithoutAnAnchorIsUnchanged(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "a-other.md", markdownWithTitle("Other Page"))
+	writeFile(t, dir, "b-doc.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Main -->
+
+See [the page](./a-other.md).
+`)
+
+	require.NoError(t, Run(publishConfig(server.URL, dir+"/*.md")))
+
+	body := bodyOfPageTitled(t, server, "Main")
+
+	assert.Contains(t, body, "<a href=", "a whole-page link is still a link")
+	assert.NotContains(t, body, "ac:anchor")
+}
+
+// TestCrossFileAnchorThatNamesNoHeadingIsLeftAlone: guessing which section was
+// meant would send the reader somewhere the author did not choose, so a
+// fragment that matches nothing keeps the behaviour it had.
+func TestCrossFileAnchorThatNamesNoHeadingIsLeftAlone(t *testing.T) {
+	server, _ := docsSpace(t)
+	dir := t.TempDir()
+
+	writeFile(t, dir, "a-other.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Other Page -->
+
+## Setup Guide
+`)
+	writeFile(t, dir, "b-doc.md", `<!-- Space: DOCS -->
+<!-- Parent: Parent -->
+<!-- Title: Main -->
+
+See [nothing there](./a-other.md#no-such-heading).
+`)
+
+	require.NoError(t, Run(publishConfig(server.URL, dir+"/*.md")))
+
+	body := bodyOfPageTitled(t, server, "Main")
+
+	assert.NotContains(t, body, "ac:anchor")
+	assert.True(t, strings.Contains(body, "#no-such-heading"),
+		"the link keeps the fragment the author wrote")
+}

--- a/page/anchors.go
+++ b/page/anchors.go
@@ -1,0 +1,95 @@
+package page
+
+import (
+	"github.com/kovetskiy/mark/v16/parser"
+	"github.com/kovetskiy/mark/v16/transformer"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	gparser "github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+// headingAnchor returns the anchor a fragment names in another document.
+//
+// The fragment is what the author wrote -- the lowercase-and-hyphens slug every
+// other Markdown tool produces -- and the anchor is the id mark generates for
+// that heading, which keeps its capitals and its punctuation. The same folding
+// that matches the two ends of a same-page link matches them here, so a link
+// across files behaves exactly as one within a file does.
+//
+// Returns "" when the fragment names no heading in that document, which leaves
+// the link as the author wrote it rather than guessing.
+func headingAnchor(document []byte, fragment string) string {
+	if fragment == "" {
+		return ""
+	}
+
+	ids := headingIDs(document)
+
+	// An id written out exactly is already what it names.
+	for _, id := range ids {
+		if id == fragment {
+			return id
+		}
+	}
+
+	key := transformer.AnchorKey(fragment)
+	if key == "" {
+		return ""
+	}
+
+	var found string
+
+	for _, id := range ids {
+		if transformer.AnchorKey(id) != key {
+			continue
+		}
+
+		// Two headings whose ids differ only in punctuation the folding drops
+		// are one key. Choosing either would be a guess, and a link that goes
+		// nowhere is better than one that quietly goes to the wrong section.
+		if found != "" && found != id {
+			return ""
+		}
+
+		found = id
+	}
+
+	return found
+}
+
+// headingIDs lists the ids mark would give the headings of a document, in the
+// order they appear.
+//
+// Parsed with the same id generator the publish uses, since an id that is
+// derived differently here would match the wrong heading -- or none.
+func headingIDs(document []byte) []string {
+	md := goldmark.New(goldmark.WithParserOptions(gparser.WithAutoHeadingID()))
+
+	// The id generator is a context option rather than a parser option, and it
+	// is what makes these the ids the publish will use.
+	ctx := gparser.NewContext(gparser.WithIDs(parser.NewConfluenceIDs()))
+
+	doc := md.Parser().Parse(text.NewReader(document), gparser.WithContext(ctx))
+
+	var ids []string
+
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering || node.Kind() != ast.KindHeading {
+			return ast.WalkContinue, nil
+		}
+
+		if id, ok := node.AttributeString("id"); ok {
+			switch value := id.(type) {
+			case []byte:
+				ids = append(ids, string(value))
+			case string:
+				ids = append(ids, value)
+			}
+		}
+
+		return ast.WalkContinue, nil
+	})
+
+	return ids
+}

--- a/page/link.go
+++ b/page/link.go
@@ -278,7 +278,7 @@ func resolveLink(
 
 		// This helps to determine if found link points to file that's
 		// not markdown or have mark required metadata
-		linkMeta, _, err := metadata.ExtractMeta(linkContents, spaceForLinks, titleFromH1, titleFromFilename, filepath, parents, titleAppendGeneratedHash, "", frontMatterEnabled)
+		linkMeta, linkBody, err := metadata.ExtractMeta(linkContents, spaceForLinks, titleFromH1, titleFromFilename, filepath, parents, titleAppendGeneratedHash, "", frontMatterEnabled)
 		if err != nil {
 			log.Error().
 				Err(err).
@@ -320,6 +320,26 @@ func resolveLink(
 				),
 				transient: true,
 			}, nil
+		}
+
+		// A link naming a section of the other document is written as an
+		// anchor rather than as a URL. A fragment on a Confluence URL names
+		// nothing: Confluence puts a heading's anchor in the Anchor macro, not
+		// in the address, so ".../x/abc123#Setup" scrolls nowhere however the
+		// fragment is spelled. ac:link with ri:page and ac:anchor is how the
+		// storage format says "that section of that page".
+		//
+		// Written only once the page has been found, so that a link to a
+		// document that is not published yet is still reported and still
+		// deferred -- the anchor changes what the link becomes, not whether it
+		// resolves.
+		//
+		// Only within one space: an ri:page with no ri:space-key means this
+		// space, while the URL carries its own space in it.
+		if link.hash != "" && linkMeta.Space == spaceForLinks {
+			if anchor := headingAnchor(linkBody, link.hash); anchor != "" {
+				return "ac:" + linkMeta.Title + "#" + anchor, nil, nil
+			}
 		}
 	}
 

--- a/transformer/anchors.go
+++ b/transformer/anchors.go
@@ -29,7 +29,7 @@ func NewAnchorTransformer() *AnchorTransformer {
 	return &AnchorTransformer{}
 }
 
-// anchorKey reduces an id or a link target to what the two conventions agree
+// AnchorKey reduces an id or a link target to what the two conventions agree
 // on: the letters and digits, in order, folded to lower case.
 //
 // Everything else is discarded rather than mapped, because the conventions do
@@ -42,7 +42,7 @@ func NewAnchorTransformer() *AnchorTransformer {
 // keeps non-ASCII letters in an id, so an a-z test folded every heading written
 // in CJK or Cyrillic down to the empty key -- which is discarded -- and no link
 // to one could ever be matched.
-func anchorKey(s string) string {
+func AnchorKey(s string) string {
 	var b strings.Builder
 	for _, r := range strings.ToLower(s) {
 		if unicode.IsLetter(r) || unicode.IsDigit(r) {
@@ -68,7 +68,7 @@ func (t *AnchorTransformer) Transform(doc *ast.Document, reader text.Reader, pc 
 		}
 
 		value := attributeString(id)
-		key := anchorKey(value)
+		key := AnchorKey(value)
 		if key == "" {
 			return ast.WalkContinue, nil
 		}
@@ -112,7 +112,7 @@ func (t *AnchorTransformer) Transform(doc *ast.Document, reader text.Reader, pc 
 			}
 		}
 
-		key := anchorKey(target)
+		key := AnchorKey(target)
 		if ambiguous[key] {
 			return ast.WalkContinue, nil
 		}

--- a/transformer/anchors_test.go
+++ b/transformer/anchors_test.go
@@ -15,9 +15,9 @@ func TestAnchorKey(t *testing.T) {
 		{"Ünïcödé", "ünïcödé"}, // case folding has to reach past ASCII
 	}
 	for _, pair := range same {
-		if anchorKey(pair[0]) != anchorKey(pair[1]) {
+		if AnchorKey(pair[0]) != AnchorKey(pair[1]) {
 			t.Errorf("%q and %q should reduce alike, got %q and %q",
-				pair[0], pair[1], anchorKey(pair[0]), anchorKey(pair[1]))
+				pair[0], pair[1], AnchorKey(pair[0]), AnchorKey(pair[1]))
 		}
 	}
 
@@ -26,14 +26,14 @@ func TestAnchorKey(t *testing.T) {
 		{"Release-Notes", "Release-Notes-1"}, // goldmark's dedupe suffix is a digit
 	}
 	for _, pair := range differ {
-		if anchorKey(pair[0]) == anchorKey(pair[1]) {
+		if AnchorKey(pair[0]) == AnchorKey(pair[1]) {
 			t.Errorf("%q and %q should not reduce alike, both gave %q",
-				pair[0], pair[1], anchorKey(pair[0]))
+				pair[0], pair[1], AnchorKey(pair[0]))
 		}
 	}
 
 	// Nothing to match on is not a match against everything.
-	if anchorKey("---") != "" {
-		t.Errorf("punctuation alone should reduce to nothing, got %q", anchorKey("---"))
+	if AnchorKey("---") != "" {
+		t.Errorf("punctuation alone should reduce to nothing, got %q", AnchorKey("---"))
 	}
 }

--- a/transformer/anchors_unicode_test.go
+++ b/transformer/anchors_unicode_test.go
@@ -12,7 +12,7 @@ import "testing"
 func TestAnchorKeyKeepsNonASCIILetters(t *testing.T) {
 	kept := []string{"概要", "Обзор", "Über"}
 	for _, value := range kept {
-		if anchorKey(value) == "" {
+		if AnchorKey(value) == "" {
 			t.Errorf("%q should reduce to a key, got nothing", value)
 		}
 	}
@@ -22,15 +22,15 @@ func TestAnchorKeyKeepsNonASCIILetters(t *testing.T) {
 		{"Обзор", "Раздел"},
 	}
 	for _, pair := range differ {
-		if anchorKey(pair[0]) == anchorKey(pair[1]) {
+		if AnchorKey(pair[0]) == AnchorKey(pair[1]) {
 			t.Errorf("%q and %q should not reduce alike, both gave %q",
-				pair[0], pair[1], anchorKey(pair[0]))
+				pair[0], pair[1], AnchorKey(pair[0]))
 		}
 	}
 
 	// The punctuation an id keeps and a slug drops is still dropped on both
 	// sides, in every script.
-	if anchorKey("概要/詳細") != anchorKey("概要-詳細") {
+	if AnchorKey("概要/詳細") != AnchorKey("概要-詳細") {
 		t.Errorf("punctuation should not separate %q from %q", "概要/詳細", "概要-詳細")
 	}
 }


### PR DESCRIPTION
- **feat: link to an anchor on another page, and to one written by hand**
- **feat(page): link to a section of another document**

---

**Depends on #970**, which adds the renderer half — `ac:Page#Anchor` destinations. This branch is based on it, so it carries that commit too; merging #970 first makes this a single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)