### PR TITLE
fix(attachment): refuse a file that resolves outside the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1207,6 +1207,21 @@ The width will be the commented html after the image (in this case 300px).
 
 Currently this is not compatible with the automated upload of inline images.
 
+#### Where an attachment may come from
+
+A file is attached when it is inside the directory Mark is running in, or inside
+the document's own directory. An upward path is ordinary — `../images/logo.png`
+from a `docs` folder is how a repository refers to shared assets — and stays
+inside the repository when Mark is run at its root.
+
+A path that resolves outside both, `../../../etc/passwd` or a symlink pointing
+out of the repository, fails the file rather than being uploaded. A document
+says which files to publish, and on a repository that accepts pull requests a
+document is something a contributor writes.
+
+If a legitimate attachment lives outside, publish from a directory that contains
+both it and the documents.
+
 ### Use HTML img tags for sizing
 
 Standard HTML `<img>` tags (inline, block, single-line, or multi-line) are converted into `<ac:image>` macros. This allows you to specify sizing while keeping the document readable in standard Markdown renderers like GitHub:

--- a/attachment/attachment.go
+++ b/attachment/attachment.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"image"
 	_ "image/gif"
@@ -11,6 +12,7 @@ import (
 	_ "image/png"
 	"io"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -223,9 +225,102 @@ func prepareAttachments(opener vfs.Opener, base string, replacements []string) (
 	return attachments, nil
 }
 
+// ErrOutsideProject reports an attachment that resolves outside the directories
+// mark is publishing from.
+var ErrOutsideProject = errors.New("attachment is outside the project")
+
+// checkAttachmentPath refuses an attachment that resolves outside both the
+// document's own directory and the directory mark is running in.
+//
+// A document says which files to upload, and a document is content: on a
+// repository that takes pull requests, a contributor could point an image at
+// "../../../../home/runner/.aws/credentials" and have its contents published as
+// a page attachment, under a flattened filename that looks like anything else.
+//
+// Upward paths themselves are ordinary -- "../images/logo.png" is how a docs
+// directory refers to shared assets, and README documents it -- so the boundary
+// is not the document's directory. It is that directory or the one mark was run
+// in, which for a run at the root of a repository is the repository.
+//
+// Symlinks are resolved before the comparison, since a link committed to the
+// repository is as good as a path for reaching outside it. A link that cannot
+// be resolved is left to the open below to report.
+func checkAttachmentPath(base, name string) error {
+	path := filepath.Join(base, name)
+
+	roots := []string{base}
+	if cwd, err := os.Getwd(); err == nil {
+		roots = append(roots, cwd)
+	}
+
+	candidates := []string{path}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		candidates = append(candidates, resolved)
+	}
+
+	for _, candidate := range candidates {
+		if withinAny(candidate, roots) {
+			continue
+		}
+
+		// Reported as an absolute path: "docs/../../id_rsa" cleans down to
+		// "../id_rsa", which says less about where the file actually is than
+		// the reader needs in order to judge it.
+		shown := candidate
+		if absolute, err := filepath.Abs(candidate); err == nil {
+			shown = absolute
+		}
+
+		return fmt.Errorf(
+			"%w: %q resolves to %s, which is outside both %q and the directory mark is "+
+				"running in; publish from a directory that contains it",
+			ErrOutsideProject, name, shown, base,
+		)
+	}
+
+	return nil
+}
+
+// withinAny reports whether a path is inside any of the roots.
+func withinAny(path string, roots []string) bool {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+
+	for _, root := range roots {
+		absoluteRoot, err := filepath.Abs(root)
+		if err != nil {
+			continue
+		}
+
+		// EvalSymlinks on the root as well, or a repository reached through a
+		// symlinked path would put every file in it outside itself.
+		if resolved, err := filepath.EvalSymlinks(absoluteRoot); err == nil {
+			absoluteRoot = resolved
+		}
+
+		relative, err := filepath.Rel(absoluteRoot, absolute)
+		if err != nil {
+			continue
+		}
+
+		if relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // prepareAttachement opens the file, reads its content and creates an attachement object
 func prepareAttachment(opener vfs.Opener, base, name string) (Attachment, error) {
 	attachmentPath := filepath.Join(base, name)
+
+	if err := checkAttachmentPath(base, name); err != nil {
+		return Attachment{}, err
+	}
+
 	file, err := opener.Open(attachmentPath)
 	if err != nil {
 		return Attachment{}, fmt.Errorf("unable to open file %q: %w", attachmentPath, err)

--- a/attachment/attachment_test.go
+++ b/attachment/attachment_test.go
@@ -34,17 +34,21 @@ func (o *virtualOpener) Open(name string) (io.ReadCloser, error) {
 	return nil, os.ErrNotExist
 }
 
+// The base is a directory below the one mark is running in, which is the
+// ordinary shape: a docs folder inside a repository. An upward reference from
+// there is still inside the repository, which is what makes "../image3.jpg"
+// resolvable.
 func TestPrepareAttachmentsWithWorkDirBase(t *testing.T) {
 
 	testingOpener := &virtualOpener{
 		PathToBuf: map[string]*bufferCloser{
-			"image1.jpg":        {bytes.NewBuffer(nil)},
-			"images/image2.jpg": {bytes.NewBuffer(nil)},
-			"../image3.jpg":     {bytes.NewBuffer(nil)},
+			"docs/image1.jpg":        {bytes.NewBuffer(nil)},
+			"docs/images/image2.jpg": {bytes.NewBuffer(nil)},
+			"image3.jpg":             {bytes.NewBuffer(nil)},
 		},
 	}
 
-	attaches, err := prepareAttachments(testingOpener, ".", replacements)
+	attaches, err := prepareAttachments(testingOpener, "docs", replacements)
 	t.Logf("attaches: %v", err)
 	if err != nil {
 		println(err.Error())

--- a/attachment/traversal_test.go
+++ b/attachment/traversal_test.go
@@ -1,0 +1,99 @@
+package attachment
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/vfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// project builds a repository with a document directory inside it, and returns
+// the two paths. The test runs from the repository, as a publish does.
+func project(t *testing.T) (root, docs string) {
+	t.Helper()
+
+	root = t.TempDir()
+	docs = filepath.Join(root, "docs")
+	require.NoError(t, os.MkdirAll(docs, 0o755))
+
+	before, err := os.Getwd()
+	require.NoError(t, err)
+
+	require.NoError(t, os.Chdir(root))
+	t.Cleanup(func() { _ = os.Chdir(before) })
+
+	// t.TempDir may hand back a path through a symlink (/tmp on macOS), and the
+	// boundary is compared after resolving them.
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
+
+	return root, docs
+}
+
+// TestAttachmentOutsideTheProjectIsRefused: a document says which files to
+// upload, and a document is content. On a repository that takes pull requests a
+// contributor could point an image at a deploy key or a credentials file and
+// have its contents published as a page attachment -- under a flattened name
+// that looks like any other.
+func TestAttachmentOutsideTheProjectIsRefused(t *testing.T) {
+	root, docs := project(t)
+
+	secret := filepath.Join(filepath.Dir(root), "id_rsa")
+	require.NoError(t, os.WriteFile(secret, []byte("PRIVATE KEY"), 0o600))
+
+	_, err := ResolveLocalAttachments(vfs.LocalOS, docs, []string{"../../id_rsa"})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrOutsideProject)
+	assert.Contains(t, err.Error(), "id_rsa", "the message names the file")
+}
+
+// TestSymlinkOutOfTheProjectIsRefused: a link committed to the repository
+// reaches outside it as well as a path does, and the path itself looks
+// innocent, so the check is made after resolving links.
+func TestSymlinkOutOfTheProjectIsRefused(t *testing.T) {
+	root, docs := project(t)
+
+	secret := filepath.Join(filepath.Dir(root), "credentials")
+	require.NoError(t, os.WriteFile(secret, []byte("aws_secret_access_key = x"), 0o600))
+	require.NoError(t, os.Symlink(secret, filepath.Join(docs, "logo.png")))
+
+	_, err := ResolveLocalAttachments(vfs.LocalOS, docs, []string{"logo.png"})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrOutsideProject)
+}
+
+// TestUpwardPathInsideTheProjectStillWorks is the layout README documents: a
+// docs directory referring to shared assets beside it. Refusing upward paths
+// outright would have broken it.
+func TestUpwardPathInsideTheProjectStillWorks(t *testing.T) {
+	root, docs := project(t)
+
+	images := filepath.Join(root, "images")
+	require.NoError(t, os.MkdirAll(images, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(images, "logo.png"), []byte("png"), 0o600))
+
+	attachments, err := ResolveLocalAttachments(vfs.LocalOS, docs, []string{"../images/logo.png"})
+
+	require.NoError(t, err)
+	require.Len(t, attachments, 1)
+	assert.Equal(t, "../images/logo.png", attachments[0].Replace)
+}
+
+// TestAttachmentBesideTheDocumentStillWorks covers a document published from
+// outside the working directory, which is what a run given an absolute path
+// does -- the document's own directory is a boundary of its own.
+func TestAttachmentBesideTheDocumentStillWorks(t *testing.T) {
+	elsewhere := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(elsewhere, "logo.png"), []byte("png"), 0o600))
+
+	attachments, err := ResolveLocalAttachments(vfs.LocalOS, elsewhere, []string{"logo.png"})
+
+	require.NoError(t, err)
+	require.Len(t, attachments, 1)
+}

--- a/renderer/image.go
+++ b/renderer/image.go
@@ -2,6 +2,7 @@ package renderer
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math"
 	"path/filepath"
@@ -152,6 +153,17 @@ func (r *ConfluenceImageRenderer) renderImage(writer util.BufWriter, source []by
 	}
 
 	attachments, err := attachment.ResolveLocalAttachments(vfs.LocalOS, filepath.Dir(r.Path), []string{string(n.Destination)})
+
+	// A path that reaches outside the project is refused rather than quietly
+	// treated as a URL. The file is not uploaded either way, but publishing a
+	// broken image and saying nothing leaves the author to work out why, and
+	// leaves a document that tried to read somewhere it should not looking
+	// like a typo.
+	if errors.Is(err, attachment.ErrOutsideProject) {
+		line, col := GetLineCol(source, node.Pos())
+
+		return ast.WalkStop, fmt.Errorf("line %d, col %d: %w", line, col, err)
+	}
 
 	// We were unable to resolve it locally, treat as URL
 	if err != nil {


### PR DESCRIPTION
A document names the files to upload, and on a repository that accepts pull
requests a document is something a contributor writes. Nothing checked where a
name led, so

    ![logo](../../../../home/runner/.aws/credentials)

read that file and published it as a page attachment, under a flattened name --
".._.._home_runner_.aws_credentials" -- that looks like any other. A deploy key,
a token file or a CI secret could be exfiltrated by anyone who could get a
Markdown file merged, or in many pipelines merely proposed.

Upward paths themselves are ordinary: "../images/logo.png" from a docs folder is
how a repository refers to shared assets, and README documents exactly that. So
the boundary is not the document's directory. A file is attached when it is
inside the directory mark is running in -- the repository, for a run at its root
-- or inside the document's own directory, which is what keeps a run given an
absolute path to a document elsewhere working.

Symlinks are resolved before the comparison. A link committed to the repository
reaches outside it as well as a path does, and the path itself looks innocent.
The roots are resolved too, or a repository reached through a symlinked path
would put every file in it outside itself.

Refused loudly rather than quietly. The image renderer treats an unresolvable
attachment as a URL, which would have published a broken image and left the
author to work out why -- and left a document that tried to read somewhere it
should not looking like a typo. This one names the file, the path it resolved
to, and what to do about it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
