### PR TITLE
fix(attachment): compare the file and the project in the same terms

### DIFF
--- a/attachment/attachment.go
+++ b/attachment/attachment.go
@@ -242,46 +242,69 @@ var ErrOutsideProject = errors.New("attachment is outside the project")
 // is not the document's directory. It is that directory or the one mark was run
 // in, which for a run at the root of a repository is the repository.
 //
-// Symlinks are resolved before the comparison, since a link committed to the
-// repository is as good as a path for reaching outside it. A link that cannot
-// be resolved is left to the open below to report.
+// Both sides are resolved before the comparison, since a link committed to the
+// repository is as good as a path for reaching outside it -- and since the
+// roots have to be resolved too, or a repository reached through a symlinked
+// path would put every file in it outside itself.
 func checkAttachmentPath(base, name string) error {
-	path := filepath.Join(base, name)
+	path := resolveDeepest(filepath.Join(base, name))
 
-	roots := []string{base}
+	roots := []string{resolveDeepest(base)}
 	if cwd, err := os.Getwd(); err == nil {
-		roots = append(roots, cwd)
+		roots = append(roots, resolveDeepest(cwd))
 	}
 
-	candidates := []string{path}
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
-		candidates = append(candidates, resolved)
+	if withinAny(path, roots) {
+		return nil
 	}
 
-	for _, candidate := range candidates {
-		if withinAny(candidate, roots) {
-			continue
-		}
-
-		// Reported as an absolute path: "docs/../../id_rsa" cleans down to
-		// "../id_rsa", which says less about where the file actually is than
-		// the reader needs in order to judge it.
-		shown := candidate
-		if absolute, err := filepath.Abs(candidate); err == nil {
-			shown = absolute
-		}
-
-		return fmt.Errorf(
-			"%w: %q resolves to %s, which is outside both %q and the directory mark is "+
-				"running in; publish from a directory that contains it",
-			ErrOutsideProject, name, shown, base,
-		)
-	}
-
-	return nil
+	// Reported as the resolved absolute path: "docs/../../id_rsa" cleans down
+	// to "../id_rsa", which says less about where the file actually is than the
+	// reader needs in order to judge it.
+	return fmt.Errorf(
+		"%w: %q resolves to %s, which is outside both %q and the directory mark is "+
+			"running in; publish from a directory that contains it",
+		ErrOutsideProject, name, path, base,
+	)
 }
 
-// withinAny reports whether a path is inside any of the roots.
+// resolveDeepest resolves the longest leading part of a path that exists and
+// re-appends whatever is left.
+//
+// Both sides of the comparison have to be in the same terms or a directory is
+// found not to contain the file sitting in it: with mark run in
+// "/mnt/data/work" and the document named through a link as
+// "~/work/docs/x.md", "/home/me/work/docs/logo.png" is not relative to
+// "/mnt/data/work", however plainly it sits beside its own document. Symlinked
+// checkouts, bind-mounted CI workspaces and every path under macOS's /tmp
+// arrive this way.
+//
+// The deepest part rather than the whole path, because the file itself need not
+// exist: a name that is merely misspelled should be refused by the open, which
+// says so, rather than by the boundary, which would say something else.
+func resolveDeepest(path string) string {
+	path = filepath.Clean(path)
+
+	rest := ""
+	for {
+		if resolved, err := filepath.EvalSymlinks(path); err == nil {
+			return filepath.Join(resolved, rest)
+		}
+
+		parent := filepath.Dir(path)
+		if parent == path {
+			// The root itself did not resolve; nothing is left to walk up to.
+			return filepath.Join(path, rest)
+		}
+
+		rest = filepath.Join(filepath.Base(path), rest)
+		path = parent
+	}
+}
+
+// withinAny reports whether a path is inside any of the roots. It compares the
+// paths as it is given them; resolving one side but not the other is the bug
+// resolveDeepest exists to prevent.
 func withinAny(path string, roots []string) bool {
 	absolute, err := filepath.Abs(path)
 	if err != nil {
@@ -292,12 +315,6 @@ func withinAny(path string, roots []string) bool {
 		absoluteRoot, err := filepath.Abs(root)
 		if err != nil {
 			continue
-		}
-
-		// EvalSymlinks on the root as well, or a repository reached through a
-		// symlinked path would put every file in it outside itself.
-		if resolved, err := filepath.EvalSymlinks(absoluteRoot); err == nil {
-			absoluteRoot = resolved
 		}
 
 		relative, err := filepath.Rel(absoluteRoot, absolute)

--- a/attachment/traversal_test.go
+++ b/attachment/traversal_test.go
@@ -16,6 +16,15 @@ func project(t *testing.T) (root, docs string) {
 	t.Helper()
 
 	root = t.TempDir()
+
+	// t.TempDir may hand back a path through a symlink (/tmp on macOS).
+	// Resolved first, so that every path built below is in the same terms --
+	// resolving root afterwards left docs spelled the other way, which is why
+	// these tests passed on Linux while the boundary was broken.
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
+
 	docs = filepath.Join(root, "docs")
 	require.NoError(t, os.MkdirAll(docs, 0o755))
 
@@ -24,12 +33,6 @@ func project(t *testing.T) (root, docs string) {
 
 	require.NoError(t, os.Chdir(root))
 	t.Cleanup(func() { _ = os.Chdir(before) })
-
-	// t.TempDir may hand back a path through a symlink (/tmp on macOS), and the
-	// boundary is compared after resolving them.
-	if resolved, err := filepath.EvalSymlinks(root); err == nil {
-		root = resolved
-	}
 
 	return root, docs
 }
@@ -96,4 +99,77 @@ func TestAttachmentBesideTheDocumentStillWorks(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, attachments, 1)
+}
+
+// TestProjectReachedThroughASymlinkStillWorks: mark is run in the repository,
+// but the document was named through a link to it -- "-f ~/work/docs/*.md" with
+// ~/work a symlink, a bind-mounted CI workspace, or any path under macOS's /tmp.
+// The file sits beside its own document; that the path used to reach it is
+// spelled differently is not the document's doing.
+func TestProjectReachedThroughASymlinkStillWorks(t *testing.T) {
+	root, docs := project(t)
+
+	require.NoError(t, os.WriteFile(filepath.Join(docs, "logo.png"), []byte("PNG"), 0o644))
+
+	link := filepath.Join(t.TempDir(), "work")
+	require.NoError(t, os.Symlink(root, link))
+
+	attachments, err := ResolveLocalAttachments(
+		vfs.LocalOS, filepath.Join(link, "docs"), []string{"logo.png"},
+	)
+
+	require.NoError(t, err)
+	assert.Len(t, attachments, 1)
+}
+
+// TestUpwardPathThroughASymlinkStillWorks: the shared-assets shape README
+// documents, reached through a link. "../images" is a sibling of the document
+// directory, so it is only inside the project once both sides are resolved.
+func TestUpwardPathThroughASymlinkStillWorks(t *testing.T) {
+	root, _ := project(t)
+
+	images := filepath.Join(root, "images")
+	require.NoError(t, os.MkdirAll(images, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(images, "logo.png"), []byte("PNG"), 0o644))
+
+	link := filepath.Join(t.TempDir(), "work")
+	require.NoError(t, os.Symlink(root, link))
+
+	attachments, err := ResolveLocalAttachments(
+		vfs.LocalOS, filepath.Join(link, "docs"), []string{"../images/logo.png"},
+	)
+
+	require.NoError(t, err)
+	assert.Len(t, attachments, 1)
+}
+
+// TestOutsideTheProjectIsStillRefusedThroughASymlink: resolving both sides is
+// what makes the boundary work, not what loosens it.
+func TestOutsideTheProjectIsStillRefusedThroughASymlink(t *testing.T) {
+	root, _ := project(t)
+
+	secret := filepath.Join(filepath.Dir(root), "id_rsa")
+	require.NoError(t, os.WriteFile(secret, []byte("PRIVATE KEY"), 0o600))
+
+	link := filepath.Join(t.TempDir(), "work")
+	require.NoError(t, os.Symlink(root, link))
+
+	_, err := ResolveLocalAttachments(
+		vfs.LocalOS, filepath.Join(link, "docs"), []string{"../../id_rsa"},
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrOutsideProject)
+}
+
+// TestMissingFileIsReportedByTheOpen: a misspelled name is refused by the open,
+// which names the file, rather than by the boundary, which would send the
+// author looking for a traversal they did not write.
+func TestMissingFileIsReportedByTheOpen(t *testing.T) {
+	_, docs := project(t)
+
+	_, err := ResolveLocalAttachments(vfs.LocalOS, docs, []string{"logo.png"})
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrOutsideProject)
 }


### PR DESCRIPTION
A repository reached through a symlink had every one of its attachments refused, with a message that named a directory plainly containing the file it was refusing:

```
"logo.png" resolves to /home/me/work/docs/logo.png, which is outside
both "/home/me/work/docs" and the directory mark is running in
```

`checkAttachmentPath` resolved the roots with `EvalSymlinks` but not the path compared against them, and every candidate had to pass. Wherever the document was named through a link, the written path could never be relative to the resolved root. `renderer/image.go` turns `ErrOutsideProject` into a hard stop, so a document referring to the file beside it failed the whole publish.

This is the ordinary case, not an exotic one:

- mark run in `/mnt/data/work` with the document given as `~/work/docs/x.md`
- a bind-mounted CI workspace
- on macOS, every path under `/tmp` and `TMPDIR`, which lead through `/private`

### The fix

Both sides are resolved before comparison, by `resolveDeepest` — the longest leading part of a path that exists, with the rest re-appended. The deepest part rather than the whole path because the file itself need not exist: a misspelled name should be refused by the open, which names it, rather than by the boundary, which would send the author looking for a traversal they never wrote.

Resolving both sides is what makes the boundary work rather than what loosens it. A symlink committed to the repository and pointing out of it resolves to where it leads and is still refused, as is `../../id_rsa`.

### Why the tests missed it

The helper built the document directory from the unresolved `t.TempDir()` and resolved only the repository root afterwards, leaving the two spelled differently — the very mismatch under test. It resolves first now, so the boundary is exercised rather than the difference between two spellings of one directory. CI runs on Linux, where `/tmp` is real, which is why this passed.

### Coverage

Four cases added; the two "still works" ones fail without the fix:

| Test | Without fix |
|---|---|
| `TestProjectReachedThroughASymlinkStillWorks` | FAIL |
| `TestUpwardPathThroughASymlinkStillWorks` | FAIL |
| `TestOutsideTheProjectIsStillRefusedThroughASymlink` | pass (guardrail) |
| `TestMissingFileIsReportedByTheOpen` | pass (guardrail) |

Full suite green, `golangci-lint` clean.

Follows up #972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)