### PR TITLE
fix(mark): a compile publishes nothing, so it may not delete either

### DIFF
--- a/mark.go
+++ b/mark.go
@@ -108,6 +108,15 @@ func (c Config) output() io.Writer {
 	return io.Discard
 }
 
+// readOnly reports whether this run may leave Confluence untouched. A compile
+// prints the body it would have sent and stops; a dry run reports what it would
+// have done. Neither publishes anything, so neither may delete, archive or
+// reorder either -- a guard that asks only about --dry-run is one --compile-only
+// walks straight past.
+func (c Config) readOnly() bool {
+	return c.DryRun || c.CompileOnly
+}
+
 // Run processes all files matching Config.Files and publishes them to
 // Confluence, and is RunContext with a context that is never cancelled.
 func Run(config Config) error {
@@ -227,10 +236,11 @@ func run(ctx context.Context, config Config) error {
 	// their say-so.
 	var tracker *manifest.Store
 	if config.TrackPages {
-		// A dry run resolves exactly as a real one does -- otherwise its preview
-		// is fiction -- and resolving records what it finds. The store it gets
-		// cannot write, which is a guard that holds however it is used.
-		if config.DryRun {
+		// A run that publishes nothing resolves exactly as a real one does --
+		// otherwise its preview is fiction -- and resolving records what it
+		// finds. The store it gets cannot write, which is a guard that holds
+		// however it is used.
+		if config.readOnly() {
 			tracker = manifest.NewReadOnlyStore(api)
 		} else {
 			tracker = manifest.NewStore(api)
@@ -393,7 +403,7 @@ func run(ctx context.Context, config Config) error {
 		// Not attempted when a file failed: the pages that did not publish are
 		// missing from the sequence, and ordering the rest against each other
 		// would arrange them as though the absent ones were gone for good.
-		if err := page.OrderChildren(api, config.DryRun, ordered); err != nil {
+		if err := page.OrderChildren(api, config.readOnly(), ordered); err != nil {
 			return fmt.Errorf("unable to order pages: %w", err)
 		}
 	}
@@ -2023,13 +2033,13 @@ func handleOrphans(
 				continue
 			}
 
-			handled, err = page.HandleOrphans(api, action, candidates, config.DryRun)
+			handled, err = page.HandleOrphans(api, action, candidates, config.readOnly())
 			if err != nil {
 				return err
 			}
 		}
 
-		if config.DryRun {
+		if config.readOnly() {
 			continue
 		}
 

--- a/mark_orphan_test.go
+++ b/mark_orphan_test.go
@@ -335,3 +335,45 @@ func TestOrphanUnderWithoutScopeIsUnchanged(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, known, "reported once and then forgotten, as before")
 }
+
+// TestOnOrphanCompileOnlyActsOnNothing: --compile-only prints the body it would
+// have sent and stops, so it may not delete either. Only --dry-run got the
+// read-only manifest, so a compile took the writable one and then returned
+// before publishing -- which made every tracked page an orphan.
+//
+// The guard that keeps a space from being emptied counts what the run saw, and
+// a document that has opted out of synchronising is looked up purely to mark it
+// seen. One such document is therefore enough to carry the run past the guard
+// and on to trashing a page whose source file is still sitting on disk.
+func TestOnOrphanCompileOnlyActsOnNothing(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	header := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n"
+	writeFile(t, dir, "keep.md", header+"<!-- Title: Keep -->\n\nKeep.\n")
+	writeFile(t, dir, "gone.md", header+"<!-- Title: Gone -->\n\nGone.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		TrackPages: true, OnOrphan: "delete", Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	gone, err := api.FindPage("DOCS", "Gone", "page")
+	require.NoError(t, err)
+	require.NotNil(t, gone)
+
+	// keep.md stays exactly where it is and merely stops synchronising.
+	writeFile(t, dir, "keep.md", header+"<!-- Title: Keep -->\n<!-- Synchronized: false -->\n\nKeep.\n")
+	require.NoError(t, os.Remove(filepath.Join(dir, "gone.md")))
+
+	config.CompileOnly = true
+	require.NoError(t, Run(config))
+
+	assert.False(t, server.Page(gone.ID).Trashed, "a compile must remove nothing")
+}


### PR DESCRIPTION
`--compile-only` prints the body it would have sent and stops — but it was given a **writable** manifest, since only `--dry-run` got the read-only one. Because it returns before publishing, every tracked page in the run becomes an orphan:

```
mark --compile-only --track-pages --on-orphan delete -f '**/*.md'
  → DELETE /rest/api/content/1004
```

The page trashed there has its source file sitting on disk the whole time. The manifest is rewritten to match.

### Why the safety net doesn't catch it

`handleOrphans` refuses to act when a space published nothing this run, on the reasoning that a failed checkout and a wholesale deletion look alike. That guard counts the paths the run *saw* — and a document that has opted out of synchronising is looked up purely to mark it seen:

```go
// Looked up purely to mark the path as seen.
if _, _, err := tracker.Lookup(meta.Space, file); err != nil {
```

So a single `<!-- Synchronized: false -->` anywhere in the tree carries the run past the guard.

### The fix

Both flags now answer one question, `Config.readOnly`, asked wherever a run must leave Confluence alone:

| Site | Before | After |
|---|---|---|
| manifest store | writable unless `--dry-run` | read-only for both |
| `HandleOrphans` | acts unless `--dry-run` | describes only, for both |
| forgetting handled entries | skipped on `--dry-run` | skipped for both |
| `OrderChildren` | reorders unless `--dry-run` | reorders for neither |

Ordering was the same bug with a quieter outcome — a compile rearranged pages it was only supposed to be rendering.

`--dry-run` was already right about all four and is unchanged. What changes is that `--compile-only` is right about them too, which is what it always read as.

### Coverage

`TestOnOrphanCompileOnlyActsOnNothing` — publishes two documents, stops one synchronising, removes the other's source, then compiles. Without the fix:

```
--- FAIL: TestOnOrphanCompileOnlyActsOnNothing
    Error: Should be false
    Messages: a compile must remove nothing
```

Full suite green, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)