### PR TITLE
fix(orphan): a folder is a child too, and trashing takes it along

### DIFF
--- a/confluence/api.go
+++ b/confluence/api.go
@@ -1899,6 +1899,75 @@ func (api *API) GetChildPages(parentID string) ([]PageInfo, error) {
 	return all, nil
 }
 
+// HasChildFolders reports whether a folder sits directly beneath a page.
+//
+// Folders are v2 entities and never appear in content/{id}/child/page, which
+// lists content of type page and nothing else. A page whose only children are
+// folders therefore looks childless there -- while trashing it takes the
+// folders, and every page inside them, along with it.
+//
+// A deployment that does not route the v2 children endpoint is a deployment
+// without folders, so a 404 is read as "none" rather than as a failure: there
+// is nothing there for the answer to be wrong about. Any other status is a real
+// failure and is reported, because a caller about to delete something should
+// not be told "no children" by a request that did not work.
+//
+// Stops at the first folder it sees. The answer is a yes or a no, and the rest
+// of the listing cannot change it.
+func (api *API) HasChildFolders(parentID string) (bool, error) {
+	const pageSize = 100
+
+	var cursor string
+	for {
+		result := struct {
+			Results []struct {
+				ID   string `json:"id"`
+				Type string `json:"type"`
+			} `json:"results"`
+
+			Links struct {
+				Next string `json:"next"`
+			} `json:"_links"`
+		}{}
+
+		query := map[string]string{"limit": fmt.Sprintf("%d", pageSize)}
+		if cursor != "" {
+			query["cursor"] = cursor
+		}
+
+		request, err := api.v2().Res(
+			"pages/"+parentID+"/direct-children", &result,
+		).Get(query)
+		if err != nil {
+			return false, fmt.Errorf("unable to list children of %s: %w", parentID, err)
+		}
+
+		// First page only: a 404 partway through is a real failure, and reading
+		// it as "none" would answer from a listing already known to be partial.
+		if request.Raw.StatusCode == http.StatusNotFound && cursor == "" {
+			return false, nil
+		}
+
+		if request.Raw.StatusCode != http.StatusOK {
+			return false, newErrorStatusNotOK(request)
+		}
+
+		for _, child := range result.Results {
+			if child.Type == "folder" {
+				return true, nil
+			}
+		}
+
+		next := nextCursor(result.Links.Next)
+		// A server that hands back the cursor it was given would otherwise keep
+		// this loop going for as long as it keeps answering.
+		if next == "" || next == cursor || len(result.Results) == 0 {
+			return false, nil
+		}
+		cursor = next
+	}
+}
+
 // MoveContentAfter places a page immediately after one of its siblings.
 //
 // Unlike the append form, the target here is a sibling rather than the new

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -660,6 +660,14 @@ func (s *Server) handleV2(w http.ResponseWriter, r *http.Request, path string) {
 			s.getFolder(w, folderID)
 			return
 		}
+		// /pages/{id}/direct-children -- children of every type, which is what
+		// separates it from the v1 child/page listing.
+		if rest, ok := strings.CutPrefix(path, "/pages/"); ok {
+			if pageID, sub, found := strings.Cut(rest, "/"); found && sub == "direct-children" {
+				s.directChildren(w, r, pageID)
+				return
+			}
+		}
 		// /spaces/{id}/properties and /spaces/{id}/properties/{propertyID}
 		if rest, ok := strings.CutPrefix(path, "/spaces/"); ok {
 			spaceID, sub, _ := strings.Cut(rest, "/")
@@ -1319,6 +1327,40 @@ func (s *Server) childPages(w http.ResponseWriter, r *http.Request, parentID str
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}
+
+// directChildren answers the v2 listing of a page's children of every type.
+// Only pages and folders exist in this fake; the type field is what a caller
+// telling them apart relies on.
+func (s *Server) directChildren(w http.ResponseWriter, r *http.Request, parentID string) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	results := []map[string]any{}
+	for _, id := range s.childOrder[parentID] {
+		if p, ok := s.pages[id]; ok && p.ParentID == parentID {
+			results = append(results, map[string]any{
+				"id": p.ID, "type": "page", "title": p.Title,
+			})
+		}
+	}
+	for _, f := range s.folders {
+		if f.ParentID == parentID {
+			results = append(results, map[string]any{
+				"id": f.ID, "type": "folder", "title": f.Title,
+			})
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"results": results,
+		"_links":  map[string]any{},
+	})
 }
 
 // ChildOrder returns the ids of a page's children, in order.

--- a/mark_orphan_test.go
+++ b/mark_orphan_test.go
@@ -377,3 +377,43 @@ func TestOnOrphanCompileOnlyActsOnNothing(t *testing.T) {
 
 	assert.False(t, server.Page(gone.ID).Trashed, "a compile must remove nothing")
 }
+
+// TestOnOrphanLeavesAPageWithChildFolders: the child listing that guards the
+// deletion is a listing of pages, and a folder is not one. mark puts folders
+// under pages itself, so a page whose children are all folders read as
+// childless -- and trashing it takes the folders, and every page inside them,
+// along with it.
+func TestOnOrphanLeavesAPageWithChildFolders(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	header := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n"
+	writeFile(t, dir, "keep.md", header+"<!-- Title: Keep -->\n\nKeep.\n")
+	writeFile(t, dir, "gone.md", header+"<!-- Title: Gone -->\n\nGone.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		TrackPages: true, OnOrphan: "delete", Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	gone, err := api.FindPage("DOCS", "Gone", "page")
+	require.NoError(t, err)
+	require.NotNil(t, gone)
+
+	// A folder beneath it, holding a page nobody in this repository wrote.
+	folder := server.AddFolder("DOCS", "Manuals", gone.ID, "page")
+	server.AddFolder("DOCS", "Nested", folder.ID, "folder")
+
+	require.NoError(t, os.Remove(filepath.Join(dir, "gone.md")))
+	require.NoError(t, Run(config))
+
+	page := server.Page(gone.ID)
+	require.NotNil(t, page)
+	assert.False(t, page.Trashed, "a page holding folders must be left alone")
+}

--- a/page/orphan.go
+++ b/page/orphan.go
@@ -173,6 +173,24 @@ func HandleOrphans(
 			continue
 		}
 
+		// The listing above is of pages, and a folder is not one. mark puts
+		// folders under pages itself, so a page whose children are all folders
+		// reads as childless there -- and trashing it takes the folders, and
+		// every page inside them, along with it.
+		folders, err := api.HasChildFolders(orphan.PageID)
+		if err != nil {
+			return handled, fmt.Errorf("unable to list children of %s: %w", orphan.PageID, err)
+		}
+
+		if folders {
+			log.Warn().Msgf(
+				"page %q has child folder(s) and is left alone: removing it would take them too",
+				orphan.Title,
+			)
+
+			continue
+		}
+
 		if dryRun {
 			log.Info().Msgf("page %q would be %sd", orphan.Title, action)
 			handled = append(handled, orphan.Path)


### PR DESCRIPTION
The guard in front of `--on-orphan delete` asks Confluence for a page's children and leaves the page alone if it has any — *"those may be pages nobody in this repository ever wrote"*. It asks `content/{id}/child/page`, which lists content of type `page` and nothing else.

Folders are v2 entities and never appear there. And mark puts folders **under pages** itself:

```go
folder, err = api.CreateFolder(spaceID, title, anchorPageID, "page")   // page/ancestry.go
```

So a page whose children are all folders reads as childless, passes the guard, and is trashed. Confluence trashes the folders with it and every page inside them — the exact outcome the guard exists to prevent, reached *through* the guard rather than around it.

### Reproduction

`docs/team.md` publishes "Team Docs"; other documents use `Parent: Team Docs` plus `Folder:` headers, so mark creates folders anchored to that page and publishes into them. Delete `docs/team.md`, run with `--on-orphan delete`, and the whole subtree goes.

### The fix

Asked now of `pages/{id}/direct-children`, which lists children of every type. It stops at the first folder it sees, since the answer is a yes or a no.

A deployment that does not route that endpoint is a deployment without folders, so a 404 **on the first page** is read as "none" rather than as a failure — there is nothing there for the answer to be wrong about. Any other status is reported, because a caller about to delete something should not be told "no children" by a request that did not work.

The fake server grows the same route, listing pages and folders together and distinguishing them by `type`.

### Coverage

`TestOnOrphanLeavesAPageWithChildFolders` — an orphan with a folder beneath it, itself holding a nested folder. Without the fix:

```
--- FAIL: TestOnOrphanLeavesAPageWithChildFolders
    Messages: a page holding folders must be left alone
```

Full suite green, `golangci-lint` clean.

> Worth a maintainer's eye on the `direct-children` route against a real Cloud tenant — I could verify it only against the fake server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)