### PR TITLE
fix(renderer): a definition list inside another closes its own rows

### DIFF
--- a/renderer/definitionlist.go
+++ b/renderer/definitionlist.go
@@ -24,10 +24,23 @@ import (
 type ConfluenceDefinitionListRenderer struct {
 	html.Config
 
-	// inRow and inCell track how much of the current row has been written.
-	// A row spans several nodes -- one term, then any number of descriptions --
-	// so the closing tags belong to whatever node comes next rather than to the
-	// node that opened them.
+	// open holds one frame per definition list currently being written, and
+	// only the innermost is ever written to.
+	//
+	// A definition may itself contain a definition list, and the two lists'
+	// rows have nothing to do with each other: with a single pair of flags the
+	// inner list reset them on the way in and closed the outer list's row on
+	// the way out, leaving a <td> and a <tr> that nothing ever closed. One
+	// nested list anywhere in a document made the whole page fail the
+	// well-formedness check and never reach Confluence.
+	open []listRow
+}
+
+// listRow tracks how much of the current row has been written. A row spans
+// several nodes -- one term, then any number of descriptions -- so the closing
+// tags belong to whatever node comes next rather than to the node that opened
+// them.
+type listRow struct {
 	inRow  bool
 	inCell bool
 }
@@ -46,8 +59,7 @@ func (r *ConfluenceDefinitionListRenderer) RegisterFuncs(reg renderer.NodeRender
 
 func (r *ConfluenceDefinitionListRenderer) renderList(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
-		r.inRow = false
-		r.inCell = false
+		r.open = append(r.open, listRow{})
 
 		_, _ = w.WriteString("<table>\n<tbody>\n")
 
@@ -55,9 +67,21 @@ func (r *ConfluenceDefinitionListRenderer) renderList(w util.BufWriter, source [
 	}
 
 	r.closeRow(w)
+	if len(r.open) > 0 {
+		r.open = r.open[:len(r.open)-1]
+	}
 	_, _ = w.WriteString("</tbody>\n</table>\n")
 
 	return ast.WalkContinue, nil
+}
+
+// current returns the list being written, or nil outside one.
+func (r *ConfluenceDefinitionListRenderer) current() *listRow {
+	if len(r.open) == 0 {
+		return nil
+	}
+
+	return &r.open[len(r.open)-1]
 }
 
 func (r *ConfluenceDefinitionListRenderer) renderTerm(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
@@ -66,7 +90,9 @@ func (r *ConfluenceDefinitionListRenderer) renderTerm(w util.BufWriter, source [
 		r.closeRow(w)
 
 		_, _ = w.WriteString("<tr>\n<th>")
-		r.inRow = true
+		if row := r.current(); row != nil {
+			row.inRow = true
+		}
 
 		return ast.WalkContinue, nil
 	}
@@ -81,18 +107,23 @@ func (r *ConfluenceDefinitionListRenderer) renderDescription(w util.BufWriter, s
 		return ast.WalkContinue, nil
 	}
 
+	row := r.current()
+	if row == nil {
+		return ast.WalkContinue, nil
+	}
+
 	// A definition written before any term -- which the syntax allows -- still
 	// needs a row to sit in.
-	if !r.inRow {
+	if !row.inRow {
 		_, _ = w.WriteString("<tr>\n<th></th>\n")
-		r.inRow = true
+		row.inRow = true
 	}
 
 	// Several definitions of one term share its cell rather than each claiming
 	// a row of their own, which would leave rows with no term to head them.
-	if !r.inCell {
+	if !row.inCell {
 		_, _ = w.WriteString("<td>")
-		r.inCell = true
+		row.inCell = true
 
 		return ast.WalkContinue, nil
 	}
@@ -110,17 +141,18 @@ func (r *ConfluenceDefinitionListRenderer) renderDescription(w util.BufWriter, s
 // closeRow finishes whatever row is open, giving a term with no definition an
 // empty cell so that every row has both columns.
 func (r *ConfluenceDefinitionListRenderer) closeRow(w util.BufWriter) {
-	if !r.inRow {
+	row := r.current()
+	if row == nil || !row.inRow {
 		return
 	}
 
-	if r.inCell {
+	if row.inCell {
 		_, _ = w.WriteString("</td>\n")
-		r.inCell = false
+		row.inCell = false
 	} else {
 		_, _ = w.WriteString("<td></td>\n")
 	}
 
 	_, _ = w.WriteString("</tr>\n")
-	r.inRow = false
+	row.inRow = false
 }

--- a/renderer/definitionlist_test.go
+++ b/renderer/definitionlist_test.go
@@ -79,3 +79,45 @@ func TestDefinitionListKeepsInlineMarkup(t *testing.T) {
 	assert.Contains(t, actual, "<strong>Bold</strong>")
 	assert.Contains(t, actual, "<code>code</code>")
 }
+
+// TestNestedDefinitionListClosesBothRows: a definition may hold a definition
+// list of its own, and the two lists' rows have nothing to do with each other.
+// With one pair of flags shared between them the inner list reset the outer
+// list's row on the way in and closed it on the way out, leaving a <td> and a
+// <tr> that nothing closed -- and one such list anywhere in a document made the
+// whole page fail the well-formedness check rather than only that list.
+func TestNestedDefinitionListClosesBothRows(t *testing.T) {
+	actual := renderDefinitionList(t,
+		"Term A\n:   Def A\n\n    Inner\n    :   InnerDef\n\nTerm B\n:   Def B\n",
+	)
+	assertWellFormed(t, actual)
+
+	assert.Equal(t, 2, strings.Count(actual, "<table>"), "one table per list")
+	assert.Equal(t, 2, strings.Count(actual, "</table>"))
+
+	// Three rows across the two tables, every one of them closed.
+	assert.Equal(t, 3, strings.Count(actual, "<tr>"))
+	assert.Equal(t, 3, strings.Count(actual, "</tr>"))
+	assert.Equal(t, 3, strings.Count(actual, "</td>"))
+
+	assert.Contains(t, actual, "<th>Inner</th>")
+	assert.Contains(t, actual, "<th>Term B</th>")
+}
+
+// TestNestedDefinitionListLeavesTheOuterCellOpen: the inner table belongs
+// inside the outer definition's cell, not beside it.
+func TestNestedDefinitionListLeavesTheOuterCellOpen(t *testing.T) {
+	actual := renderDefinitionList(t,
+		"Outer\n:   Before\n\n    Inner\n    :   InnerDef\n",
+	)
+	assertWellFormed(t, actual)
+
+	outer := strings.Index(actual, "<td>Before")
+	inner := strings.Index(actual, "<th>Inner</th>")
+	closes := strings.LastIndex(actual, "</td>")
+
+	require.NotEqual(t, -1, outer)
+	require.NotEqual(t, -1, inner)
+	assert.Less(t, outer, inner, "the inner list sits inside the outer cell")
+	assert.Less(t, inner, closes, "the outer cell closes after it")
+}


### PR DESCRIPTION
`inRow`/`inCell` were single fields shared by every definition list in a document. A definition may hold a definition list of its own, so the inner list reset them on entry and closed the *outer* list's row on exit — leaving a `<td>` and a `<tr>` that nothing ever closed.

```markdown
Term A
:   Def A

    Inner
    :   InnerDef

Term B
:   Def B
```

```html
<td>Def A
<table>… inner list …</table>
<tr>              ← the outer </td> and </tr> never written
<th>Term B</th>
```

### Why it costs the whole page

A body is checked for well-formedness before it is sent, because Confluence rejects markup it cannot parse *in its entirety*:

```
line 18: element <td> closed by </tbody>
```

So one nested definition list anywhere in a document fails the entire publish — for a construct that reads as ordinary Markdown and gives no hint which part of the page was to blame.

### The fix

The flags become a stack, one frame per list currently open, and only the innermost is written to. The outer list's row survives the inner list untouched and closes where it always meant to: after the table nested in its cell.

### Coverage

Two tests, both failing without the fix:

- `TestNestedDefinitionListClosesBothRows` — two tables, three rows, every one closed, and the result passes `assertWellFormed`
- `TestNestedDefinitionListLeavesTheOuterCellOpen` — the inner table sits *inside* the outer cell rather than beside it

`definitionlist_test.go` previously had no nesting case, which is why this shipped. Full suite green, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)