### PR TITLE
fix(transformer): repair the markup a transformer has already replaced

### DIFF
--- a/markdown/xml_wellformed_test.go
+++ b/markdown/xml_wellformed_test.go
@@ -90,3 +90,39 @@ func compileRawHTMLDoc(t *testing.T, src string, features ...string) string {
 
 	return out
 }
+
+// TestVoidElementsAreClosedInASplitDetails: a <details> broken by a blank line
+// takes the unbalanced path, which rewrites the fragment and hands the result
+// on as a Text node carrying replacement-content. The repair walked HTMLBlock
+// and RawHTML only, so those bytes went out exactly as the author wrote them --
+// and the identical markup without the blank line came out correct, which made
+// the difference look like anything but the blank line.
+func TestVoidElementsAreClosedInASplitDetails(t *testing.T) {
+	out := compileRawHTMLDoc(t,
+		"<details>\n<summary>Title</summary>\n<p>a<br>b</p>\n\nmarkdown paragraph\n\n</details>\n",
+	)
+
+	assert.Contains(t, out, "<br />")
+	assert.NotContains(t, out, "<br>")
+	require.NoError(t, CheckWellFormed(out))
+}
+
+// TestVoidElementsAreClosedInALayoutBlock: the layout transformer replaces the
+// whole HTML block the moment one line in it names a layout directive, and the
+// replacement reached the page unrepaired for the same reason.
+func TestVoidElementsAreClosedInALayoutBlock(t *testing.T) {
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	// One HTML block: it opens with a tag, so it runs to the blank line and
+	// takes the directive and the <br> together. That is what makes the layout
+	// transformer replace the node the repair would otherwise have walked.
+	out, _, err := CompileMarkdownWithTransformer([]byte(
+		"<div>\n<!-- ac:layout-cell -->\na<br>b\n<!-- ac:layout-cell end -->\n</div>\n",
+	), std, "test.md", types.MarkConfig{})
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "<br />")
+	assert.NotContains(t, out, "<br>")
+	require.NoError(t, CheckWellFormed(out))
+}

--- a/transformer/xml_wellformed.go
+++ b/transformer/xml_wellformed.go
@@ -45,6 +45,16 @@ func (t *XMLWellFormedTransformer) Transform(doc *ast.Document, reader text.Read
 		switch node.(type) {
 		case *ast.HTMLBlock, *ast.RawHTML:
 			nodes = append(nodes, node)
+
+		case *ast.Text:
+			// A transformer that ran earlier -- Details, Layout -- replaces the
+			// HTML block it rewrote with a Text node carrying the result, so by
+			// the time this one walks the tree those bytes are no longer in a
+			// node this switch would otherwise recognise. They are still the
+			// author's markup and still have to be well-formed.
+			if _, ok := node.Attribute(replacementContent); ok {
+				nodes = append(nodes, node)
+			}
 		}
 
 		return ast.WalkContinue, nil
@@ -53,6 +63,21 @@ func (t *XMLWellFormedTransformer) Transform(doc *ast.Document, reader text.Read
 	source := reader.Source()
 
 	for _, node := range nodes {
+		// Repaired in place: the bytes are held on the attribute rather than in
+		// the source, and the node is already what the renderer expects.
+		if existing, ok := node.Attribute(replacementContent); ok {
+			raw, ok := existing.([]byte)
+			if !ok {
+				continue
+			}
+
+			if fixed, changed := wellFormedHTML(raw); changed {
+				node.SetAttribute(replacementContent, fixed)
+			}
+
+			continue
+		}
+
 		parent := node.Parent()
 		if parent == nil {
 			continue
@@ -77,6 +102,10 @@ func (t *XMLWellFormedTransformer) Transform(doc *ast.Document, reader text.Read
 var (
 	cdataOpen  = []byte("<![CDATA[")
 	cdataClose = []byte("]]>")
+
+	// replacementContent is the attribute an earlier transformer leaves its
+	// rewritten markup on. See renderer/text.go, which writes it out as-is.
+	replacementContent = []byte("replacement-content")
 )
 
 // wellFormedHTML returns raw with void elements closed and comment bodies made


### PR DESCRIPTION
`XMLWellFormedTransformer` runs last (priority 120) and walks `HTMLBlock` and `RawHTML`. By then some of that markup is in neither: `Details` (110) and `Layout` (100) rewrite a block and hand the result on as an `ast.Text` node carrying `replacement-content`.

```go
textNode := ast.NewText()
textNode.SetAttribute([]byte("replacement-content"), item.newB)
```

So the repair walks straight past it, and the bytes reach Confluence exactly as the author wrote them.

```markdown
<details>
<summary>Title</summary>
<p>a<br>b</p>

markdown paragraph

</details>
```

publishes `<br>` unclosed, and the page fails the well-formedness gate in its entirety:

```
line 2: element <br> closed by </p>
```

The **identical markup without the blank line** comes out correct, because a balanced `<details>` takes a different path (`renderHTMLNodeTree`) that closes void elements on the way — so the difference looks like anything but the blank line. A layout directive anywhere in an HTML block does the same to the rest of that block.

### The fix

The walk also collects a `Text` node carrying `replacement-content` and repairs it **in place, on the attribute** — the bytes are no longer in the source, and the node is already what `renderer/text.go` expects.

Fixing it at the repair rather than in each transformer means anything else that replaces a node this way is covered by the same change, instead of having to remember to close its own tags.

### Coverage

Two compile-level tests, both failing without the fix:

- `TestVoidElementsAreClosedInASplitDetails`
- `TestVoidElementsAreClosedInALayoutBlock` — the `<br>` sits in the same HTML block as the directive, which is what makes the transformer replace the node

Both assert `CheckWellFormed` passes. Full suite green, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)