### PR TITLE
fix(parser): a "$$" that closes nowhere is not a fence

### DIFF
--- a/markdown/math_block_test.go
+++ b/markdown/math_block_test.go
@@ -101,13 +101,19 @@ func TestMathFenceInsideACodeBlockStaysCode(t *testing.T) {
 }
 
 // TestUnclosedMathFenceDoesNotSwallowTheDocument: an opening fence with no
-// closer takes the rest of the document, which is what a fenced code block does
-// too. What matters is that it is one formula rather than a parse that runs
-// away.
+// closer is not a fence.
+//
+// This used to run to the end of the document on the grounds that a fenced code
+// block does the same, which CommonMark does say. The two are not comparable in
+// what it costs. A code block still publishes what it swallowed, and publishes
+// it legibly; a formula publishes a picture of it, or nothing at all -- prose
+// is not valid TeX, so the usual outcome is a failed page and an error naming
+// the formula rather than the line the fence was opened on.
 func TestUnclosedMathFenceDoesNotSwallowTheDocument(t *testing.T) {
 	out := compileMath(t, "$$\nE = mc^2\n\nstill inside\n")
 
-	assert.Equal(t, 1, strings.Count(out, "<ac:image"))
+	assert.Equal(t, 0, strings.Count(out, "<ac:image"), "nothing was a formula")
+	assert.Contains(t, out, "still inside", "and the rest of the document survives")
 }
 
 // TestBracketFenceIsABlock: "\[" on a line of its own opens a display formula
@@ -156,4 +162,35 @@ func TestLongerDollarFenceIsMatchedByItsOwnLength(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(out, "<ac:image"))
 	assert.NotContains(t, out, "<p>$</p>")
 	assert.NotContains(t, out, "</ac:image>$")
+}
+
+// TestUnclosedBracketFenceLeavesTheDocumentAlone is the same for the other
+// fence. "\[" with no "\]" is the CommonMark escape for a literal bracket.
+func TestUnclosedBracketFenceLeavesTheDocumentAlone(t *testing.T) {
+	out := compileMath(t, "Intro paragraph.\n\n\\[\na + b\n\n## A heading\n\nBody text that must survive.\n")
+
+	assert.Contains(t, out, "<p>Intro paragraph.</p>")
+	assert.Contains(t, out, "A heading")
+	assert.Contains(t, out, "Body text that must survive.")
+	assert.NotContains(t, out, "<ac:image")
+}
+
+// TestClosedMathFenceStillOpensABlock is the other half: a fence that does
+// close behaves exactly as it always has, wherever its closer happens to be.
+func TestClosedMathFenceStillOpensABlock(t *testing.T) {
+	out := compileMath(t, "Intro.\n\n$$\na + b\n$$\n\nProse after.\n")
+
+	assert.Contains(t, out, "<ac:image")
+	assert.Contains(t, out, "<p>Prose after.</p>")
+	assert.NotContains(t, out, "$$")
+}
+
+// TestClosedMathFenceInABlockquoteIsStillFound: the lookahead reads the source,
+// where a closing fence inside a quotation still carries its "> ". Missing it
+// would refuse a formula that closes perfectly well.
+func TestClosedMathFenceInABlockquoteIsStillFound(t *testing.T) {
+	out := compileMath(t, "> $$\n> \\begin{aligned}\n> a &= b\n>\n> c &= d\n> \\end{aligned}\n> $$\n")
+
+	assert.Contains(t, out, "<ac:image")
+	assert.Contains(t, out, "<blockquote>")
 }

--- a/parser/mathblock.go
+++ b/parser/mathblock.go
@@ -115,6 +115,59 @@ func openingFence(line []byte, pos int) (fence, bool) {
 	return fence{}, false
 }
 
+// closerAhead reports whether this fence is ever closed in what follows.
+//
+// A fence that is never closed used to run to the end of the document. Every
+// remaining paragraph became part of the formula, so the page was published as
+// one picture of the rest of the file -- or, more often, failed outright, since
+// prose is not valid TeX:
+//
+//	unable to render formula "a + b\n\n## A heading\n\nBody text...":
+//	You can't use macro parameter character # in math mode
+//
+// which names the formula rather than the line the fence was opened on, and
+// leaves the author reading an error about TeX to find a missing "$$".
+//
+// CommonMark lets an unclosed code fence run to the end of its container, and
+// goldmark's fenced code block does just that. A code block is still legible
+// that way and its content still reaches the page; a formula is neither, and
+// takes everything after it along. So a fence that closes nowhere is not
+// treated as a fence at all, and the "$$" stays in the text where it was
+// written.
+//
+// Read from the source rather than through the reader, which is mid-parse and
+// not ours to move.
+func (f fence) closerAhead(source []byte, from int) bool {
+	if from < 0 || from >= len(source) {
+		return false
+	}
+
+	for _, line := range bytes.Split(source[from:], []byte("\n")) {
+		if f.closesBlock(undoContainerPrefix(line)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// undoContainerPrefix strips what a container takes off a line before a block
+// parser is ever shown it.
+//
+// The lookahead reads the source, so a closing fence inside a blockquote still
+// carries its "> ". Erring towards finding a closer is the safe direction: a
+// fence that is found to close behaves exactly as it always has, and only one
+// that closes nowhere is read as text.
+func undoContainerPrefix(line []byte) []byte {
+	line = bytes.TrimLeft(line, " \t")
+
+	for len(line) > 0 && line[0] == '>' {
+		line = bytes.TrimLeft(line[1:], " \t")
+	}
+
+	return line
+}
+
 // closesBlock reports whether a line is the closing fence.
 func (f fence) closesBlock(line []byte) bool {
 	trimmed := bytes.TrimSpace(line)
@@ -158,6 +211,11 @@ func (b *mathBlockParser) Open(parent ast.Node, reader text.Reader, pc parser.Co
 
 	opened, ok := openingFence(line, pos)
 	if !ok {
+		return nil, parser.NoChildren
+	}
+
+	// Nothing closes it, so it opens nothing.
+	if !opened.closerAhead(reader.Source(), segment.Stop) {
 		return nil, parser.NoChildren
 	}
 


### PR DESCRIPTION
An unclosed display fence ran to the end of the document. Everything after it became one formula, so the page was published as a picture of the rest of the file — or, far more often, not published at all:

```markdown
$$
a + b

## A heading

Body text that must survive.
```

```
unable to render formula "a + b\n\n## A heading\n\nBody text that must survive.":
You can't use macro parameter character # in math mode
```

The error names the formula, not the line the fence was opened on, so the author is left reading about TeX macro parameters to work out that they are missing a `$$`. With content that happens to be valid TeX there is no error at all — the rest of the document simply becomes one image.

### This reverses a deliberate decision

`TestUnclosedMathFenceDoesNotSwallowTheDocument` documented the old behaviour as intended:

> an opening fence with no closer takes the rest of the document, which is what a fenced code block does too.

CommonMark does say that about code fences. But the two are not comparable in what it costs: a code block still publishes what it swallowed, and publishes it legibly. A formula publishes a picture of it or nothing at all, and takes every heading and paragraph after it along. The test is rewritten to record the new intent and why.

### The fix

`Open` looks ahead for a closer and declines to open a block when there is none, leaving `$$` as the text the author wrote.

The lookahead reads `reader.Source()` rather than moving the reader, which is mid-parse and not ours to touch, and strips the prefixes a container would have taken off — a closing fence inside a blockquote still carries its `> ` in the raw source. Erring towards *finding* a closer is the safe direction: a fence that is found to close behaves exactly as it always has, and only one that closes nowhere is read as text.

`\[` with no `\]` is handled the same way, and falls back to CommonMark's escape for a literal bracket.

### Coverage

- `TestUnclosedMathFenceDoesNotSwallowTheDocument` — rewritten; no image, rest of document survives
- `TestUnclosedBracketFenceLeavesTheDocumentAlone`
- `TestClosedMathFenceStillOpensABlock` — guardrail
- `TestClosedMathFenceInABlockquoteIsStillFound` — guardrail for the prefix-stripping lookahead

Existing block-form tests (blank lines, blockquote, list item, `$$$` length matching) all still pass. Full suite green, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)