### PR TITLE
fix(transformer): a CDATA section survives becoming an expand macro

### DIFF
--- a/markdown/details_test.go
+++ b/markdown/details_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kovetskiy/mark/v16/stdlib"
 	"github.com/kovetskiy/mark/v16/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConvertDetailsToExpand(t *testing.T) {
@@ -222,4 +223,50 @@ func TestDetailsInFencedCodeBlockIsLiteral(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, actual, "<details>")
 	assert.NotContains(t, actual, `ac:name="expand"`)
+}
+
+// TestCDATAInsideDetailsSurvivesUnaltered: converting a <details> parses the
+// fragment as HTML, and html.Parse has no notion of CDATA. It reads
+// "<![CDATA[" as a bogus comment ending at the first ">", and everything after
+// that as markup -- so a sample containing ">" was cut in two: the tail
+// re-parsed and rewritten, the section left unterminated.
+//
+// A code sample is the one thing that must reach the page as written, and this
+// rewrote it and then failed the publish for it.
+func TestCDATAInsideDetailsSurvivesUnaltered(t *testing.T) {
+	lib, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	sample := "<![CDATA[if a > b then <br> done]]>"
+	input := "<details>\n<summary>Code</summary>\n" +
+		`<ac:structured-macro ac:name="code"><ac:plain-text-body>` + sample +
+		"</ac:plain-text-body></ac:structured-macro>\n</details>\n"
+
+	actual, _, err := CompileMarkdown([]byte(input), lib, "testdata/test.md", types.MarkConfig{})
+	require.NoError(t, err)
+
+	assert.Contains(t, actual, sample, "the sample reaches the page as written")
+	assert.NotContains(t, actual, "<br />", "and nothing inside it was rewritten")
+	assert.NotContains(t, actual, "]]&gt;", "and the section is not left unterminated")
+
+	assert.Contains(t, actual, `ac:name="expand"`, "the details still became a macro")
+	require.NoError(t, CheckWellFormed(actual))
+}
+
+// TestCDATAWithoutAngleBracketStillWorks is the case that happened to survive
+// before, kept so the fix is not mistaken for the whole of the behaviour.
+func TestCDATAWithoutAngleBracketStillWorks(t *testing.T) {
+	lib, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	sample := "<![CDATA[plain sample]]>"
+	input := "<details>\n<summary>Code</summary>\n" +
+		`<ac:structured-macro ac:name="code"><ac:plain-text-body>` + sample +
+		"</ac:plain-text-body></ac:structured-macro>\n</details>\n"
+
+	actual, _, err := CompileMarkdown([]byte(input), lib, "testdata/test.md", types.MarkConfig{})
+	require.NoError(t, err)
+
+	assert.Contains(t, actual, sample)
+	require.NoError(t, CheckWellFormed(actual))
 }

--- a/transformer/details.go
+++ b/transformer/details.go
@@ -2,6 +2,7 @@ package transformer
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 
 	"github.com/yuin/goldmark/ast"
@@ -126,7 +127,104 @@ func (t *DetailsTransformer) Transform(doc *ast.Document, reader text.Reader, pc
 
 // transformDetailsAt converts the <details> tags in one AST node's raw content,
 // advancing *depth by the fragment's net nesting change.
+//
+// CDATA sections are lifted out first and put back at the end. html.Parse has
+// no notion of CDATA: it reads "<![CDATA[" as a bogus comment ending at the
+// first ">", and everything after that as ordinary markup. So a code sample
+// containing ">" was cut in two -- the tail re-parsed and rewritten, the
+// section left unterminated -- which is the one thing CDATA is there to
+// prevent, and it failed the page outright with "unexpected EOF in CDATA
+// section".
 func (t *DetailsTransformer) transformDetailsAt(rawContent []byte, depth *int) ([]byte, bool) {
+	protected, sections := protectCDATA(rawContent)
+
+	out, changed := t.transformDetailsMarkup(protected, depth)
+	if !changed {
+		return rawContent, false
+	}
+
+	return restoreCDATA(out, sections), true
+}
+
+// cdataToken is what a CDATA section is stood in by while the markup around it
+// is parsed. Letters and digits only, so that neither html.Parse nor the
+// renderer's escaping can alter it.
+const cdataToken = "MARKCDATASECTION"
+
+// protectCDATA replaces every CDATA section with a token and returns the
+// sections in the order they were found.
+func protectCDATA(raw []byte) ([]byte, [][]byte) {
+	if !bytes.Contains(raw, cdataOpen) {
+		return raw, nil
+	}
+
+	// A token the document is not already using, so that restoring cannot put a
+	// section somewhere the author wrote the token themselves.
+	token := cdataToken
+	for bytes.Contains(raw, []byte(token)) {
+		token += "X"
+	}
+
+	var (
+		buf      bytes.Buffer
+		sections [][]byte
+		rest     = raw
+	)
+
+	for len(rest) > 0 {
+		start := bytes.Index(rest, cdataOpen)
+		if start == -1 {
+			buf.Write(rest)
+
+			break
+		}
+
+		buf.Write(rest[:start])
+
+		end := bytes.Index(rest[start:], cdataClose)
+		if end == -1 {
+			// Unterminated. Everything left is inside the section as far as
+			// anything downstream can tell, so it is carried out whole.
+			sections = append(sections, rest[start:])
+			fmt.Fprintf(&buf, "%s%d%s", token, len(sections)-1, token)
+
+			break
+		}
+
+		stop := start + end + len(cdataClose)
+		sections = append(sections, rest[start:stop])
+		fmt.Fprintf(&buf, "%s%d%s", token, len(sections)-1, token)
+
+		rest = rest[stop:]
+	}
+
+	if len(sections) == 0 {
+		return raw, nil
+	}
+
+	// The token is handed back with the sections so that restoring uses the one
+	// substituting actually chose.
+	return buf.Bytes(), append([][]byte{[]byte(token)}, sections...)
+}
+
+// restoreCDATA puts the sections back where their tokens stand.
+func restoreCDATA(rendered []byte, sections [][]byte) []byte {
+	if len(sections) == 0 {
+		return rendered
+	}
+
+	token := string(sections[0])
+	for i, section := range sections[1:] {
+		rendered = bytes.ReplaceAll(
+			rendered, fmt.Appendf(nil, "%s%d%s", token, i, token), section,
+		)
+	}
+
+	return rendered
+}
+
+// transformDetailsMarkup does the work on content holding no CDATA section.
+func (t *DetailsTransformer) transformDetailsMarkup(rawContent []byte, depth *int) ([]byte, bool) {
 	lower := bytes.ToLower(rawContent)
 	hasOpen := bytes.Contains(lower, []byte("<details"))
 	hasClose := bytes.Contains(lower, []byte("</details"))


### PR DESCRIPTION
Converting a `<details>` parses the fragment with `html.Parse`, which has no notion of CDATA. It reads `<![CDATA[` as a bogus comment ending at the **first `>`**, and everything after that as ordinary markup.

```markdown
<details>
<summary>Code</summary>
<ac:structured-macro ac:name="code"><ac:plain-text-body><![CDATA[if a > b then <br> done]]></ac:plain-text-body></ac:structured-macro>
</details>
```

published:

```
<![CDATA[if a > b then <br /> done]]&gt;
```

The sample is quietly rewritten (`<br>` → `<br />`) and the section is never closed, so the page fails with `unexpected EOF in CDATA section`. A code sample is the one thing that has to reach the page exactly as written — this rewrote it and then refused to publish it.

This is the same hazard `xml_wellformed.go:87` is written to avoid; `details.go` had no equivalent guard.

### The fix

Sections are lifted out before the markup is parsed and put back after it is rendered, standing in the meantime as a token of letters and digits that neither `html.Parse` nor the renderer's escaping can alter. The token is lengthened until the document is not already using it, so restoring cannot place a section where an author happened to write the token themselves.

The renderer's existing CDATA branch is what made the shorter case work — it only ever saw sections with no `>` in them, since those are the ones `html.Parse` reports whole.

### Coverage

- `TestCDATAInsideDetailsSurvivesUnaltered` — fails without the fix; asserts the sample is byte-identical, nothing inside was rewritten, the section is terminated, the `<details>` still became an `expand` macro, and `CheckWellFormed` passes
- `TestCDATAWithoutAngleBracketStillWorks` — the case that already worked, kept so the fix is not mistaken for the whole of the behaviour

Full suite green, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)