### PR TITLE
fix(util): MARK_CONFIG applies to every flag, not the ones declared after it

### DIFF
--- a/util/flags.go
+++ b/util/flags.go
@@ -18,6 +18,26 @@ import (
 var filename string
 
 var Flags = []cli.Flag{
+	// First, and it has to stay first. Every other flag finds the
+	// configuration file through the pointer below, which is filled in as the
+	// flags are resolved -- in the order they are declared. Anything declared
+	// above this looks for its TOML value while that pointer is still empty and
+	// silently gets nothing.
+	//
+	// A path on the command line happened to survive being declared late. One
+	// in MARK_CONFIG did not, so "MARK_CONFIG=/etc/mark.toml mark" ignored
+	// files, username, password, target-url, base-url and log-level while
+	// honouring space, parents and features -- reported, if at all, as
+	// "confluence password should be specified using -p flag".
+	&cli.StringFlag{
+		Name:        "config",
+		Aliases:     []string{"c"},
+		Value:       ConfigFilePath(),
+		Usage:       "use the specified configuration file.",
+		TakesFile:   true,
+		Sources:     cli.NewValueSourceChain(cli.EnvVar("MARK_CONFIG")),
+		Destination: &filename,
+	},
 	&cli.StringFlag{
 		Name:      "files",
 		Aliases:   []string{"f"},
@@ -136,15 +156,6 @@ var Flags = []cli.Flag{
 		Usage:   "base URL for Confluence. Alternative option for base_url config field.",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_BASE_URL"),
 			altsrctoml.TOML("base-url", altsrc.NewStringPtrSourcer(&filename))),
-	},
-	&cli.StringFlag{
-		Name:        "config",
-		Aliases:     []string{"c"},
-		Value:       ConfigFilePath(),
-		Usage:       "use the specified configuration file.",
-		TakesFile:   true,
-		Sources:     cli.NewValueSourceChain(cli.EnvVar("MARK_CONFIG")),
-		Destination: &filename,
 	},
 	&cli.BoolFlag{
 		Name:    "ci",

--- a/util/flags_test.go
+++ b/util/flags_test.go
@@ -2,8 +2,12 @@ package util
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,4 +77,124 @@ func mustParse(t *testing.T, cmd *cli.Command, args ...string) *cli.Command {
 	require.NoError(t, cmd.Run(context.Background(), args))
 	require.NotNil(t, parsed)
 	return parsed
+}
+
+// The flag set is a package-level value and the TOML source behind it keeps the
+// file it first read, so a second cli.Command run in one process sees none of
+// it. Each case below therefore resolves its flags in a subprocess -- which is
+// also the only way mark itself ever resolves them.
+
+// TestConfigSubprocess is the worker for the cases below and does nothing
+// unless a parent names it.
+func TestConfigSubprocess(t *testing.T) {
+	wanted := os.Getenv("MARK_TEST_FLAGS")
+	if wanted == "" {
+		t.Skip("not a subprocess case")
+	}
+
+	args := []string{"mark"}
+	if extra := os.Getenv("MARK_TEST_ARGS"); extra != "" {
+		var extraArgs []string
+		require.NoError(t, json.Unmarshal([]byte(extra), &extraArgs))
+		args = append(args, extraArgs...)
+	}
+
+	parsed := mustParse(t, &cli.Command{Flags: Flags}, args...)
+
+	resolved := map[string]string{}
+	for _, name := range strings.Split(wanted, ",") {
+		resolved[name] = parsed.String(name)
+	}
+
+	encoded, err := json.Marshal(resolved)
+	require.NoError(t, err)
+
+	fmt.Printf("\nRESOLVED%sRESOLVED\n", encoded)
+}
+
+// resolveFlags runs TestConfigSubprocess in a fresh process and returns what
+// the named flags came out as.
+func resolveFlags(t *testing.T, environment map[string]string, names []string, args ...string) map[string]string {
+	t.Helper()
+
+	encodedArgs, err := json.Marshal(args)
+	require.NoError(t, err)
+
+	worker := exec.Command(os.Args[0], "-test.run=^TestConfigSubprocess$", "-test.v")
+	worker.Env = append(os.Environ(),
+		"MARK_TEST_FLAGS="+strings.Join(names, ","),
+		"MARK_TEST_ARGS="+string(encodedArgs),
+	)
+	for name, value := range environment {
+		worker.Env = append(worker.Env, name+"="+value)
+	}
+
+	output, err := worker.CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	_, after, found := strings.Cut(string(output), "RESOLVED")
+	require.True(t, found, "worker printed no result: %s", output)
+	encoded, _, found := strings.Cut(after, "RESOLVED")
+	require.True(t, found, "worker printed no result: %s", output)
+
+	var resolved map[string]string
+	require.NoError(t, json.Unmarshal([]byte(encoded), &resolved))
+
+	return resolved
+}
+
+func writeConfig(t *testing.T, dir, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+// TestConfigFromTheEnvironmentAppliesToEveryFlag: every other flag finds the
+// configuration file through a pointer to the "config" flag's destination,
+// which is filled in as the flags are resolved -- in the order they are
+// declared. "config" sat at index 17, so every flag declared before it looked
+// for its TOML value while that pointer was still empty.
+//
+// A path on the command line happened to survive that. One in MARK_CONFIG did
+// not, so "MARK_CONFIG=/etc/mark.toml mark" silently ignored files, username,
+// password, target-url, base-url and log-level while honouring space, parents
+// and features -- and the only sign of it was the misleading "confluence
+// password should be specified using -p flag".
+func TestConfigFromTheEnvironmentAppliesToEveryFlag(t *testing.T) {
+	path := writeConfig(t, t.TempDir(), "mark.toml",
+		"files = \"from-config.md\"\nusername = \"cfguser\"\n"+
+			"password = \"cfgpass\"\nspace = \"CFG\"\n")
+
+	resolved := resolveFlags(t,
+		map[string]string{"MARK_CONFIG": path},
+		[]string{"files", "username", "password", "space"},
+	)
+
+	// Declared after "config", and honoured even before the fix.
+	assert.Equal(t, "CFG", resolved["space"])
+
+	// Declared before it, and silently dropped.
+	assert.Equal(t, "from-config.md", resolved["files"])
+	assert.Equal(t, "cfguser", resolved["username"])
+	assert.Equal(t, "cfgpass", resolved["password"])
+}
+
+// TestConfigOnTheCommandLineStillWins: the environment must not overtake a path
+// the caller named explicitly.
+func TestConfigOnTheCommandLineStillWins(t *testing.T) {
+	dir := t.TempDir()
+	fromEnv := writeConfig(t, dir, "env.toml", "username = \"env\"\n")
+	fromFlag := writeConfig(t, dir, "flag.toml", "username = \"flag\"\n")
+
+	resolved := resolveFlags(t,
+		map[string]string{"MARK_CONFIG": fromEnv},
+		[]string{"username", "config"},
+		"--config", fromFlag,
+	)
+
+	assert.Equal(t, "flag", resolved["username"])
+	assert.Equal(t, fromFlag, resolved["config"])
 }


### PR DESCRIPTION
Every flag reads its TOML value through a pointer to the `config` flag's destination:

```go
var filename string   // util/flags.go:18
Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_FILES"), altsrctoml.TOML("files", altsrc.NewStringPtrSourcer(&filename)))
```

That pointer is filled in as the flags are resolved, **in declaration order** — and `config` was declared 18th. The seventeen flags above it looked for their values while it was still empty, and quietly got nothing.

A path given on the command line survived it. One given in the environment did not:

```
MARK_CONFIG=mark.toml mark   →  files="" username="" password="" space="CFG"
mark --config mark.toml      →  files="from-config.md" username="cfguser" …
```

So `MARK_CONFIG=/etc/mark.toml` ignored `files`, `username`, `password`, `target-url`, `base-url`, `log-level`, `version-message`, `color` and every boolean above it — while honouring `space`, `parents` and `features`. A configuration file half applied, with no indication which half.

What the user actually saw was `confluence password should be specified using -p flag`, about a password sitting in the file they had just named. This is the same diagnosis problem as #613, from a different cause.

### The fix

`config` is declared first, with a note that it has to stay there. Its own precedence is unchanged: a path on the command line still beats one in the environment.

### On the test harness

The cases run in a subprocess. The flag set is a package-level value and the TOML source behind it keeps the file it first read, so a **second** `cli.Command` run in one process sees none of it — the assertions would otherwise depend on which test happened to run first (verified: whichever ran second resolved every flag to `""`). One process per case is also the only way mark itself ever resolves a flag.

- `TestConfigFromTheEnvironmentAppliesToEveryFlag` — fails without the fix; asserts a flag declared *before* `config` and one declared after both pick the file up
- `TestConfigOnTheCommandLineStillWins` — guardrail for precedence

Full suite green, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)