### PR TITLE
fix: refuse a feature name nothing will read, and let front matter set Order

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ labels:
   - <label 1>
   - <label 2>
 image-align: <left|center|right>
+order: <whole number>
 ---
 
 <page contents>

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -228,6 +228,33 @@ func toBool(val any) (bool, bool) {
 	}
 }
 
+// toInt reads a front matter number.
+//
+// YAML decodes a whole number as int, but a value written in a document nested
+// inside another structure can arrive as int64 or float64, and one that was
+// quoted arrives as a string. All of them are the number the author wrote.
+func toInt(val any) (int, bool) {
+	switch v := val.(type) {
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	case float64:
+		// Only a whole number: 1.5 is not a position among siblings.
+		if v != float64(int(v)) {
+			return 0, false
+		}
+
+		return int(v), true
+	case string:
+		parsed, err := strconv.Atoi(strings.TrimSpace(v))
+
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
 // toStringMap reads a front matter mapping, keeping the values as written.
 //
 // A YAML mapping decodes to map[string]any, but a document nested inside
@@ -342,6 +369,14 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 				setContentAppearance(meta, toString(v))
 			case "imagealign":
 				meta.ImageAlign = strings.ToLower(toString(v))
+			case "order":
+				order, ok := toInt(v)
+				if !ok {
+					return nil, nil, fmt.Errorf(
+						"order must be a whole number, got %v", v,
+					)
+				}
+				meta.Order = &order
 			case "synchronized":
 				value, ok := toBool(v)
 				if !ok {

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -501,3 +501,53 @@ func TestParseHeaderCommentStillParsesValidHeaders(t *testing.T) {
 	assert.Equal(t, "a", key)
 	assert.Empty(t, value)
 }
+
+// TestExtractMetaYAMLFrontMatterOrder: Meta.Order exists and the HTML-comment
+// path has always read it, but the front matter switch had no case for it -- so
+// a document written that way could not position itself among its siblings at
+// all, and said nothing about why.
+func TestExtractMetaYAMLFrontMatterOrder(t *testing.T) {
+	markdown := "---\nspace: DOCS\ntitle: Test Page\norder: 3\n---\n# Content\n"
+
+	meta, _, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", true)
+	require.NoError(t, err)
+	require.NotNil(t, meta.Order)
+	assert.Equal(t, 3, *meta.Order)
+}
+
+// TestExtractMetaYAMLFrontMatterOrderAccepts covers the shapes a YAML number
+// arrives in: bare, quoted, and negative for a page that sorts first.
+func TestExtractMetaYAMLFrontMatterOrderAccepts(t *testing.T) {
+	for _, test := range []struct {
+		written  string
+		expected int
+	}{
+		{"3", 3},
+		{`"4"`, 4},
+		{"-1", -1},
+		{"0", 0},
+	} {
+		t.Run(test.written, func(t *testing.T) {
+			markdown := "---\nspace: DOCS\norder: " + test.written + "\n---\nBody\n"
+
+			meta, _, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", true)
+			require.NoError(t, err)
+			require.NotNil(t, meta.Order)
+			assert.Equal(t, test.expected, *meta.Order)
+		})
+	}
+}
+
+// TestExtractMetaYAMLFrontMatterOrderRejectsNonNumbers: a position among
+// siblings is a whole number, and saying so beats ordering by nothing.
+func TestExtractMetaYAMLFrontMatterOrderRejectsNonNumbers(t *testing.T) {
+	for _, written := range []string{"first", "1.5", "[1]"} {
+		t.Run(written, func(t *testing.T) {
+			markdown := "---\nspace: DOCS\norder: " + written + "\n---\nBody\n"
+
+			_, _, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", true)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "order")
+		})
+	}
+}

--- a/util/flags.go
+++ b/util/flags.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -16,6 +17,30 @@ import (
 )
 
 var filename string
+
+// KnownFeatures are the values --features accepts. Every one of them is read
+// with a plain slices.Contains at the point it takes effect, so a name that is
+// not on this list is indistinguishable from one deliberately left off: the
+// feature is simply never switched on, and nothing is said about it.
+//
+// The usage text is built from this list, so the two cannot drift.
+var KnownFeatures = []string{
+	"d2",
+	"date",
+	"emoji",
+	"frontmatter",
+	"inline-link-card",
+	"math",
+	"mention",
+	"mermaid",
+	"mkdocsadmonitions",
+	"plantuml",
+}
+
+// defaultFeatures are what --features replaces when it is given at all, which
+// is worth saying in the usage: enabling one feature silently turns the others
+// off.
+var defaultFeatures = []string{"mermaid", "mention"}
 
 var Flags = []cli.Flag{
 	// First, and it has to stay first. Every other flag finds the
@@ -293,9 +318,11 @@ var Flags = []cli.Flag{
 	},
 
 	&cli.StringSliceFlag{
-		Name:    "features",
-		Value:   []string{"mermaid", "mention"},
-		Usage:   "Enables optional features. Current features: d2, date, emoji, frontmatter, inline-link-card, math, mention, mermaid, mkdocsadmonitions, plantuml",
+		Name:  "features",
+		Value: []string{"mermaid", "mention"},
+		Usage: "Enables optional features, replacing the defaults (" +
+			strings.Join(defaultFeatures, ", ") + ") rather than adding to them. " +
+			"Current features: " + strings.Join(KnownFeatures, ", "),
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_FEATURES"), altsrctoml.TOML("features", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.BoolFlag{
@@ -372,6 +399,19 @@ func CheckFlags(context context.Context, command *cli.Command) (context.Context,
 			return context, fmt.Errorf(
 				"invalid value for --content-appearance: %q (expected: full-width, fixed, or default)",
 				contentAppearance,
+			)
+		}
+	}
+
+	for _, feature := range command.StringSlice("features") {
+		// Compared as written rather than trimmed, because that is how it is
+		// read where it takes effect: --features "math, mermaid" hands the
+		// second one over with its leading space still on, and it would go
+		// unrecognised there just as surely.
+		if !slices.Contains(KnownFeatures, feature) {
+			return context, fmt.Errorf(
+				"invalid value for --features: %q (expected any of: %s)",
+				feature, strings.Join(KnownFeatures, ", "),
 			)
 		}
 	}

--- a/util/flags_test.go
+++ b/util/flags_test.go
@@ -198,3 +198,46 @@ func TestConfigOnTheCommandLineStillWins(t *testing.T) {
 	assert.Equal(t, "flag", resolved["username"])
 	assert.Equal(t, fromFlag, resolved["config"])
 }
+
+// TestFeaturesRejectsAnUnknownName: every feature is read with a plain
+// slices.Contains where it takes effect, so a misspelling was indistinguishable
+// from a feature deliberately left off -- "--features=mermaidd" published the
+// page with mermaid quietly not running, and said nothing.
+func TestFeaturesRejectsAnUnknownName(t *testing.T) {
+	cmd := &cli.Command{Flags: Flags}
+	_, err := CheckFlags(mustParseArgs(t, cmd, "mark", "--features", "mermaidd"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mermaidd", "the message names the value")
+	assert.Contains(t, err.Error(), "mermaid", "and what was expected instead")
+}
+
+// TestFeaturesRejectsAnUntrimmedName: --features "math, mermaid" hands the
+// second one over with its leading space still attached, and it goes
+// unrecognised where it is read. Saying so beats switching it off in silence.
+func TestFeaturesRejectsAnUntrimmedName(t *testing.T) {
+	cmd := &cli.Command{Flags: Flags}
+	_, err := CheckFlags(mustParseArgs(t, cmd, "mark", "--features", "math, mermaid"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "features")
+}
+
+// TestFeaturesAcceptsEveryKnownName guards the list against drifting from the
+// names the code actually looks for.
+func TestFeaturesAcceptsEveryKnownName(t *testing.T) {
+	for _, feature := range KnownFeatures {
+		t.Run(feature, func(t *testing.T) {
+			cmd := &cli.Command{Flags: Flags}
+			_, err := CheckFlags(mustParseArgs(t, cmd, "mark", "--features", feature))
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// mustParseArgs is mustParse with the context CheckFlags wants alongside.
+func mustParseArgs(t *testing.T, cmd *cli.Command, args ...string) (context.Context, *cli.Command) {
+	t.Helper()
+
+	return context.Background(), mustParse(t, cmd, args...)
+}


### PR DESCRIPTION
Two ways of telling mark something it then ignored without a word.

### `--features` was validated nowhere

`--content-appearance` and `--math-format` are checked against the values they accept in `CheckFlags`; `--on-orphan` and `--output-format` check their own. `--features` was checked nowhere, and every feature is read with a plain `slices.Contains` where it takes effect:

```go
slices.Contains(c.MarkConfig.Features, "mermaid")
```

So `--features=mermaidd` is indistinguishable from deliberately leaving mermaid off. The page publishes with the feature quietly not running, and the run says nothing.

The names are one list now (`KnownFeatures`), checked once and used to build the usage text so the two cannot drift. A `TestFeaturesAcceptsEveryKnownName` subtest per name guards the list against the code it describes.

A value is compared **as written** rather than trimmed, because that is how it is read where it takes effect — `--features "math, mermaid"` hands the second one over with its leading space still attached, and it goes unrecognised there just as surely.

The usage line now also says that `--features` *replaces* the defaults rather than adding to them:

```
--features string [ --features string ]  Enables optional features, replacing the defaults
   (mermaid, mention) rather than adding to them. Current features: d2, date, emoji,
   frontmatter, inline-link-card, math, mention, mermaid, mkdocsadmonitions, plantuml
```

Turning on one feature turns `mention` off. That is documented, but easy to meet the hard way.

### Front matter could not set `Order`

`Meta.Order` exists and the HTML-comment path has always read it (`metadata.go:497`). The front-matter switch had cases for fourteen keys and none for `order`, so a document written that way could not position itself among its siblings at all.

A number that was quoted, or that arrives from a nested structure as `int64` or `float64`, is the number the author wrote. `1.5` is not a position among siblings and is refused, naming the key.

Added to the README's front-matter block.

### Coverage

Both halves fail without the fix. Full suite green, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)