### PR TITLE
fix(chrome): notice a dead browser, bound its startup, and refuse a capture that would kill it

### DIFF
--- a/chrome/render.go
+++ b/chrome/render.go
@@ -12,8 +12,30 @@ import (
 )
 
 // renderTimeout bounds one screenshot. Starting the browser is not part of it:
-// that wait is WSURLReadTimeout above.
+// that wait is startupTimeout below.
 const renderTimeout = 120 * time.Second
+
+// startupTimeout bounds getting a browser ready to be asked for a picture.
+//
+// WSURLReadTimeout covers only the wait for Chrome to print the DevTools URL on
+// its stderr. Everything after that -- the websocket handshake,
+// Target.createTarget, Target.attachToTarget -- had no bound at all, so a
+// browser that announced itself and then wedged left mark waiting with no
+// output and no error. A contended CI box and a stalled GPU-process init both
+// produce exactly that.
+//
+// Longer than the URL wait it contains, since it is the whole of startup.
+const startupTimeout = 90 * time.Second
+
+// maxRasterSide is the largest side, in pixels after scaling, that a capture may
+// ask for. Chrome will not draw a texture wider than this and the failure it
+// gives for trying says nothing useful.
+const maxRasterSide = 16384
+
+// maxRasterPixels is the largest area, in pixels after scaling, that a capture
+// may ask for. Roughly a quarter of a gigabyte of bitmap, which is far above any
+// real diagram and far below what it takes to end the browser.
+const maxRasterPixels = 64 << 20
 
 var (
 	browserCtx    context.Context
@@ -31,7 +53,18 @@ func Context() (context.Context, error) {
 	defer browserMutex.Unlock()
 
 	if browserCtx != nil {
-		return browserCtx, nil
+		if browserCtx.Err() == nil {
+			return browserCtx, nil
+		}
+
+		// chromedp cancels this exact context when it loses the connection to
+		// the browser, so a context that is done means Chrome has died. It was
+		// handed out regardless, on a nil check alone, and every render after
+		// that failed with a bare "context canceled" -- which names neither the
+		// browser nor the crash, and never came right, because nothing started
+		// another one. Discarded and replaced instead, which is what the
+		// mermaid engine has always done for itself.
+		discard()
 	}
 
 	opts := append(chromedp.DefaultExecAllocatorOptions[:], AllocatorOptions()...)
@@ -39,10 +72,30 @@ func Context() (context.Context, error) {
 	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), opts...)
 	ctx, cancel := chromedp.NewContext(allocCtx)
 
-	if err := chromedp.Run(ctx); err != nil {
+	// Bounded, but not by giving the browser a context that expires: the
+	// browser has to outlive its own startup.
+	started := make(chan error, 1)
+	go func() { started <- chromedp.Run(ctx) }()
+
+	select {
+	case err := <-started:
+		if err != nil {
+			cancel()
+			allocCancel()
+
+			return nil, err
+		}
+
+	case <-time.After(startupTimeout):
 		cancel()
 		allocCancel()
-		return nil, err
+
+		return nil, fmt.Errorf(
+			"the browser did not finish starting within %s; "+
+				"it announced itself and then stopped responding, "+
+				"which usually means the machine is too loaded or too small to run it",
+			startupTimeout,
+		)
 	}
 
 	browserCtx = ctx
@@ -54,17 +107,22 @@ func Context() (context.Context, error) {
 	return browserCtx, nil
 }
 
+// discard shuts the current browser down. The caller holds browserMutex.
+func discard() {
+	if browserCancel != nil {
+		browserCancel()
+		browserCtx = nil
+		browserCancel = nil
+	}
+}
+
 // Cleanup shuts the browser down. A run that never rendered anything has none
 // to shut down, and calling this twice is harmless.
 func Cleanup() {
 	browserMutex.Lock()
 	defer browserMutex.Unlock()
 
-	if browserCancel != nil {
-		browserCancel()
-		browserCtx = nil
-		browserCancel = nil
-	}
+	discard()
 }
 
 // PNGFromSVG rasterises an SVG by loading it in the browser and screenshotting
@@ -86,14 +144,14 @@ func PNGFromSVG(svg []byte, selector string, scale float64) (png []byte, width, 
 	runCtx, cancel := context.WithTimeout(ctx, renderTimeout)
 	defer cancel()
 
-	var (
-		result []byte
-		model  *dom.BoxModel
-	)
+	// Measured before it is captured. A diagram's dimensions come from the
+	// document and are then multiplied by the scale, so four lines of d2 can
+	// ask for a capture of well over a gigapixel -- several gigabytes of bitmap
+	// -- which ends the browser, and with it every later diagram in the run.
+	var model *dom.BoxModel
 
 	err = chromedp.Run(runCtx,
 		chromedp.Navigate(fmt.Sprintf("data:image/svg+xml;base64,%s", base64.StdEncoding.EncodeToString(svg))),
-		chromedp.ScreenshotScale(selector, scale, &result, chromedp.ByJSPath),
 		chromedp.Dimensions(selector, &model, chromedp.ByJSPath),
 	)
 	if err != nil {
@@ -101,8 +159,55 @@ func PNGFromSVG(svg []byte, selector string, scale float64) (png []byte, width, 
 		// usual cause is that it died, and every later render would fail the
 		// same way until something restarted it.
 		Cleanup()
+
+		return nil, 0, 0, err
+	}
+
+	// Not a browser fault, so the browser is kept: the next diagram in the
+	// document has done nothing wrong.
+	if err := checkRasterBounds(model.Width, model.Height, scale); err != nil {
+		return nil, 0, 0, err
+	}
+
+	var result []byte
+
+	if err := chromedp.Run(runCtx,
+		chromedp.ScreenshotScale(selector, scale, &result, chromedp.ByJSPath),
+	); err != nil {
+		Cleanup()
+
 		return nil, 0, 0, err
 	}
 
 	return result, model.Width, model.Height, nil
+}
+
+// checkRasterBounds refuses a capture too large for the browser to survive
+// being asked for.
+//
+// Reported against what was asked for rather than what came back, because
+// nothing comes back: the browser is gone, and so is every diagram after it.
+func checkRasterBounds(width, height int64, scale float64) error {
+	scaledWidth := float64(width) * scale
+	scaledHeight := float64(height) * scale
+
+	if scaledWidth > maxRasterSide || scaledHeight > maxRasterSide {
+		return fmt.Errorf(
+			"the diagram is %.0fx%.0f pixels at scale %g, and no side may exceed %d; "+
+				"make the diagram smaller or lower the scale",
+			scaledWidth, scaledHeight, scale, maxRasterSide,
+		)
+	}
+
+	if scaledWidth*scaledHeight > maxRasterPixels {
+		return fmt.Errorf(
+			"the diagram is %.0fx%.0f pixels at scale %g, which is %.0f million pixels "+
+				"and more than the %.0f million a page may hold; "+
+				"make the diagram smaller or lower the scale",
+			scaledWidth, scaledHeight, scale,
+			scaledWidth*scaledHeight/1e6, float64(maxRasterPixels)/1e6,
+		)
+	}
+
+	return nil
 }

--- a/chrome/render_test.go
+++ b/chrome/render_test.go
@@ -1,0 +1,114 @@
+package chrome
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRasterBoundsRefuseAnOversizedDiagram: a diagram's dimensions come from the
+// document and are then multiplied by the scale, so four lines of d2
+//
+//	big: {shape: rectangle; width: 40000; height: 40000}
+//
+// compile to a 9 KB SVG asking for a capture of about 1.6 gigapixels -- several
+// gigabytes of bitmap. The browser does not survive being asked, and taking it
+// down takes every later diagram in the run with it.
+func TestRasterBoundsRefuseAnOversizedDiagram(t *testing.T) {
+	err := checkRasterBounds(40012, 40012, 1.0)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "40012x40012", "the message names the size asked for")
+	assert.Contains(t, err.Error(), "scale")
+}
+
+// TestRasterBoundsCountTheScale: the scale is what turns a diagram that would
+// have fitted into one that does not, so it belongs in the arithmetic and in
+// the message.
+func TestRasterBoundsCountTheScale(t *testing.T) {
+	// Comfortable on its own.
+	require.NoError(t, checkRasterBounds(4000, 4000, 1.0))
+
+	// The same diagram at four times the scale is sixteen times the pixels.
+	err := checkRasterBounds(4000, 4000, 4.0)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "16000x16000")
+	assert.Contains(t, err.Error(), "scale 4")
+}
+
+// TestRasterBoundsRefuseALongThinDiagram: area is not the only limit. Chrome
+// will not draw a texture wider than maxRasterSide however few pixels it holds,
+// and what it says for trying is no help.
+func TestRasterBoundsRefuseALongThinDiagram(t *testing.T) {
+	err := checkRasterBounds(20000, 10, 1.0)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no side may exceed")
+}
+
+// TestRasterBoundsAllowRealDiagrams: the bound exists to stop a runaway, not to
+// second-guess anybody's architecture diagram.
+func TestRasterBoundsAllowRealDiagrams(t *testing.T) {
+	for _, size := range []struct {
+		name          string
+		width, height int64
+		scale         float64
+	}{
+		{"a formula", 320, 64, 2.0},
+		{"a sequence diagram", 1200, 2400, 1.0},
+		{"a large architecture diagram", 4096, 4096, 1.0},
+		{"a wide timeline at double scale", 6000, 1200, 2.0},
+	} {
+		t.Run(size.name, func(t *testing.T) {
+			assert.NoError(t, checkRasterBounds(size.width, size.height, size.scale))
+		})
+	}
+}
+
+// TestContextReplacesADeadBrowser: chromedp cancels the very context it handed
+// back when it loses its connection to the browser, so once Chrome dies the
+// singleton is a context that is already done. It was handed out anyway, on a
+// nil check alone, and every render for the rest of the run failed with a bare
+//
+//	context canceled
+//
+// naming neither the browser nor the crash -- and it never came right, because
+// nothing ever started another one.
+func TestContextReplacesADeadBrowser(t *testing.T) {
+	t.Cleanup(Cleanup)
+
+	first, err := Context()
+	require.NoError(t, err)
+	require.NoError(t, first.Err())
+
+	// What losing the browser looks like from in here: the context is
+	// cancelled, and nothing tidies the singleton up, because whatever died did
+	// not go through Cleanup.
+	browserMutex.Lock()
+	browserCancel()
+	browserMutex.Unlock()
+
+	require.Error(t, first.Err(), "the shared context is done")
+
+	second, err := Context()
+	require.NoError(t, err)
+
+	assert.NoError(t, second.Err(), "a live browser rather than the dead one")
+	assert.NotSame(t, first, second)
+}
+
+// TestContextReturnsTheSameLiveBrowser is the other half: a browser that is
+// still working is still shared, and is not relaunched per diagram.
+func TestContextReturnsTheSameLiveBrowser(t *testing.T) {
+	t.Cleanup(Cleanup)
+
+	first, err := Context()
+	require.NoError(t, err)
+
+	second, err := Context()
+	require.NoError(t, err)
+
+	assert.Same(t, first, second)
+}


### PR DESCRIPTION
Three ways one diagram takes the rest of the run down with it. They compound, so they are fixed together.

### A dead browser was handed out for the rest of the run

```go
if browserCtx != nil {
    return browserCtx, nil     // only that it exists, never that it works
}
```

chromedp cancels **that exact context** when it loses its connection to the browser. So once Chrome died, every later render failed with:

```
context canceled
```

naming neither the browser nor the crash — and it never came right, because nothing started another one. `Cleanup()` is only reached when a render *returns* an error, so a browser that dies between two diagrams is never tidied up.

Now checked with `browserCtx.Err()` and replaced when done, which is what `mermaid.go` has always done for itself (`renderAttempts = 2` plus `discardEngine`).

### Startup had no bound past the DevTools URL

`WSURLReadTimeout` covers only the wait for Chrome to print one line on stderr. The websocket handshake, `Target.createTarget` and `Target.attachToTarget` that follow it had no bound at all — so a browser that announced itself and then wedged left mark waiting with no output and no error. A contended CI box and a stalled GPU-process init both produce exactly that.

Bounded by waiting on the run in a goroutine rather than by handing the browser a context that expires — the browser has to outlive its own startup.

### Nothing bounded what was being asked for

Dimensions come from the document and are then multiplied by the scale:

```d2
big: {shape: rectangle; width: 40000; height: 40000}
```

Four lines compile to a 9 KB SVG asking for roughly **1.6 gigapixels** — several gigabytes of bitmap. The element is measured before it is captured now, and a capture past either bound (`16384` per side, 64 Mpx of area) is refused, naming the size, the scale and what to do about it.

The browser is **kept** for that one: an oversized diagram is the document's fault, and the next diagram has done nothing wrong.

### Coverage

- `TestContextReplacesADeadBrowser` — cancels the shared context the way a crash does, then asserts the next caller gets a live browser. Verified failing with only the deadness check reverted: *"Expected and actual point to the same object"*.
- `TestContextReturnsTheSameLiveBrowser` — guardrail; a working browser is still shared, not relaunched per diagram
- `TestRasterBounds…` — the 40000² case, the scale multiplier, a long thin diagram, and four real diagram sizes that must keep working

Full suite green, `golangci-lint` clean.

> Context: the reporter's working tree had 13 chromium core files, 5 of them the browser process. The first two fixes are what turn that from "the rest of the run fails" into "the next diagram retries".

🤖 Generated with [Claude Code](https://claude.com/claude-code)