### PR TITLE
fix(transformer): a directive quoted as an example is not a directive

### DIFF
--- a/markdown/directive_codespan_test.go
+++ b/markdown/directive_codespan_test.go
@@ -1,0 +1,106 @@
+package mark
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// compileBeside compiles a document written next to the given files, so that an
+// include has something real to find or miss.
+func compileBeside(t *testing.T, source string, files map[string]string) (string, error) {
+	t.Helper()
+
+	dir := t.TempDir()
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+	}
+
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	out, _, err := CompileMarkdown(
+		[]byte(source), std, filepath.Join(dir, "doc.md"), types.MarkConfig{},
+	)
+
+	return out, err
+}
+
+// TestIncludeInACodeSpanIsNotRun: the pass that expands includes before
+// goldmark sees the document skips code regions, spans included. The AST
+// transformer that picks up what it left had no equivalent check and matched a
+// paragraph at a time, so a sentence documenting the syntax pulled the file in
+// and dropped the code span it was quoted in.
+func TestIncludeInACodeSpanIsNotRun(t *testing.T) {
+	out, err := compileBeside(t,
+		"To include, write `<!-- Include: snippet.md -->` in your doc.\n",
+		map[string]string{"snippet.md": "SECRET FRAGMENT BODY"},
+	)
+	require.NoError(t, err)
+
+	assert.NotContains(t, out, "SECRET FRAGMENT BODY", "the file was not pulled in")
+	assert.Contains(t, out, "<code>", "and the span is still a span")
+	assert.Contains(t, out, "Include: snippet.md", "showing what the author wrote")
+	assert.Contains(t, out, "in your doc.")
+}
+
+// TestIncludeInACodeSpanNamingAMissingFileStillCompiles: worse than the wrong
+// output, an example naming a file that does not exist failed the whole compile
+// -- so writing about mark's own syntax broke the page doing it.
+func TestIncludeInACodeSpanNamingAMissingFileStillCompiles(t *testing.T) {
+	out, err := compileBeside(t,
+		"Write `<!-- Include: nope.md -->` to include a file.\n", nil,
+	)
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "Include: nope.md")
+}
+
+// TestMacroInACodeSpanIsNotDefined: a macro directive quoted as an example was
+// registered for real, and the paragraph around it deleted outright.
+func TestMacroInACodeSpanIsNotDefined(t *testing.T) {
+	out, err := compileBeside(t,
+		"Write `<!-- Macro: :hi:\nTemplate: #inline\ninline: \"BOOM\" -->` to define it.\n\n"+
+			"Then :hi: appears.\n", nil,
+	)
+	require.NoError(t, err)
+
+	// "BOOM" appears once, inside the example the author quoted -- and nowhere
+	// else, because :hi: below was never given a meaning.
+	assert.Equal(t, 1, strings.Count(out, "BOOM"))
+	assert.Contains(t, out, "Then :hi: appears.", "the macro was not applied")
+	assert.Contains(t, out, "to define it.", "and the paragraph around it survives")
+}
+
+// TestIncludeOutsideACodeSpanStillRuns is the other half. The directive is only
+// inert where it is quoted.
+func TestIncludeOutsideACodeSpanStillRuns(t *testing.T) {
+	out, err := compileBeside(t,
+		"Before.\n\n<!-- Include: snippet.md -->\n\nAfter.\n",
+		map[string]string{"snippet.md": "PULLED IN"},
+	)
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "PULLED IN")
+	assert.Contains(t, out, "Before.")
+	assert.Contains(t, out, "After.")
+}
+
+// TestIncludeInAFencedBlockIsStillNotRun: fenced blocks were never affected --
+// they hold no child nodes for the transformer to concatenate -- and stay that
+// way.
+func TestIncludeInAFencedBlockIsStillNotRun(t *testing.T) {
+	out, err := compileBeside(t,
+		"```\n<!-- Include: snippet.md -->\n```\n",
+		map[string]string{"snippet.md": "SECRET FRAGMENT BODY"},
+	)
+	require.NoError(t, err)
+
+	assert.NotContains(t, out, "SECRET FRAGMENT BODY")
+}

--- a/transformer/include.go
+++ b/transformer/include.go
@@ -65,7 +65,14 @@ func (t *IncludeTransformer) TransformWithModified(doc *ast.Document, reader tex
 			return ast.WalkContinue, nil
 		}
 
-		rawContent := ExtractNodeRawContent(node, reader.Source())
+		// A directive written as an example is not a directive. The span
+		// itself contributes nothing, and its children are skipped too or the
+		// walk simply finds the directive one level further down.
+		if node.Kind() == ast.KindCodeSpan {
+			return ast.WalkSkipChildren, nil
+		}
+
+		rawContent := ExtractDirectiveContent(node, reader.Source())
 
 		dir, _ := includes.ParseIncludeDirective(rawContent)
 		if dir != nil {
@@ -81,7 +88,7 @@ func (t *IncludeTransformer) TransformWithModified(doc *ast.Document, reader tex
 				var combined bytes.Buffer
 				combined.Write(rawContent)
 				for sibling := node.NextSibling(); sibling != nil; sibling = sibling.NextSibling() {
-					sibContent := ExtractNodeRawContent(sibling, reader.Source())
+					sibContent := ExtractDirectiveContent(sibling, reader.Source())
 					combined.Write(sibContent)
 					target.nodesToRemove = append(target.nodesToRemove, sibling)
 					visited[sibling] = true

--- a/transformer/macro.go
+++ b/transformer/macro.go
@@ -65,7 +65,14 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 			return ast.WalkContinue, nil
 		}
 
-		rawContent := ExtractNodeRawContent(node, reader.Source())
+		// A directive written as an example is not a directive. The span
+		// itself contributes nothing, and its children are skipped too or the
+		// walk simply finds the directive one level further down.
+		if node.Kind() == ast.KindCodeSpan {
+			return ast.WalkSkipChildren, nil
+		}
+
+		rawContent := ExtractDirectiveContent(node, reader.Source())
 
 		dir, _ := macro.ParseMacroDirective(rawContent)
 		if dir != nil {
@@ -81,7 +88,7 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 				var combined bytes.Buffer
 				combined.Write(rawContent)
 				for sibling := node.NextSibling(); sibling != nil; sibling = sibling.NextSibling() {
-					sibContent := ExtractNodeRawContent(sibling, reader.Source())
+					sibContent := ExtractDirectiveContent(sibling, reader.Source())
 					combined.Write(sibContent)
 					target.nodesToRemove = append(target.nodesToRemove, sibling)
 					visited[sibling] = true
@@ -138,13 +145,17 @@ func (t *MacroTransformer) TransformWithModified(doc *ast.Document, reader text.
 				return ast.WalkContinue, nil
 			}
 
+			if node.Kind() == ast.KindCodeSpan {
+				return ast.WalkSkipChildren, nil
+			}
+
 			switch node.(type) {
 			case *ast.Paragraph, *ast.Text:
 			default:
 				return ast.WalkContinue, nil
 			}
 
-			raw := ExtractNodeRawContent(node, reader.Source())
+			raw := ExtractDirectiveContent(node, reader.Source())
 			if len(raw) > 0 && m.Regexp.Match(raw) {
 				textNodesToReplace = append(textNodesToReplace, struct {
 					node    ast.Node

--- a/transformer/util.go
+++ b/transformer/util.go
@@ -74,6 +74,51 @@ func extractHTMLBlockBytes(t *ast.HTMLBlock, source []byte) []byte {
 	return res
 }
 
+// ExtractDirectiveContent is ExtractNodeRawContent with inline code left out.
+//
+// A directive is only a directive where it would run. The pass that expands
+// includes and macros before goldmark ever sees the document skips code
+// regions, and metadata.CodeRegions covers spans as well as fenced blocks -- but
+// the AST transformers that pick up what that pass left behind had no
+// equivalent, and they match a paragraph at a time. So
+//
+//	To include, write `<!-- Include: nav.md -->` in your doc.
+//
+// pulled nav.md into the page and dropped the code span with it, and naming a
+// file that does not exist failed the whole compile. Writing about mark's own
+// syntax broke the document doing it.
+//
+// Fenced blocks were never affected: they hold no child nodes, so there is
+// nothing here to concatenate.
+func ExtractDirectiveContent(node ast.Node, source []byte) []byte {
+	if node.Kind() == ast.KindCodeSpan {
+		return nil
+	}
+
+	// The leaf kinds carry their own bytes; only the recursive case has
+	// children a code span could be hiding among.
+	switch node.(type) {
+	case *ast.HTMLBlock, *ast.RawHTML, *ast.Text, *ast.String:
+		return ExtractNodeRawContent(node, source)
+	}
+
+	if !node.HasChildren() {
+		return ExtractNodeRawContent(node, source)
+	}
+
+	buf := getBuffer()
+	defer putBuffer(buf)
+
+	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
+		buf.Write(ExtractDirectiveContent(child, source))
+	}
+
+	out := make([]byte, buf.Len())
+	copy(out, buf.Bytes())
+
+	return out
+}
+
 func ExtractNodeRawContent(node ast.Node, source []byte) []byte {
 	switch t := node.(type) {
 	case *ast.HTMLBlock:


### PR DESCRIPTION
The pass that expands includes and macros before goldmark sees the document already skips code regions, and `metadata.CodeRegions` covers **spans** as well as fenced blocks. The AST transformers that pick up what that pass leaves behind had no equivalent check, and they match a paragraph at a time.

```markdown
To include, write `<!-- Include: snippet.md -->` in your doc.
```

published:

```html
<p>To include, write SECRET FRAGMENT BODYin your doc.</p>
```

The file pulled in, the code span gone. And naming a file that does not exist — as documentation naturally does — failed the **whole compile**:

```
unable to load template "nope.md"
```

So writing about mark's own syntax broke the document doing it. A macro directive quoted the same way was registered for real and the surrounding paragraph deleted outright, so the example vanished and the placeholder it defined started expanding further down the page.

### Two things were needed

**`ExtractDirectiveContent`** — the content a directive is looked for in now leaves inline code out, which covers a span sitting in the middle of a paragraph.

**Skipping the span's children** — without this the walk simply finds the directive one level down and rewrites an `*ast.Text` node *inside* the span. goldmark then panics rendering it:

```
interface conversion: ast.Node is *ast.Paragraph, not *ast.Text
  goldmark/renderer/html.(*Renderer).renderCodeSpan
```

which is a worse outcome than the bug. Both walks in `macro.go` and the one in `include.go` skip `ast.KindCodeSpan`.

Fenced blocks were never affected — they hold no child nodes for any of this to concatenate — and there is now a test so they stay that way.

### Coverage

Five tests; the three below fail without the fix:

| Test | Without fix |
|---|---|
| `TestIncludeInACodeSpanIsNotRun` | FAIL |
| `TestIncludeInACodeSpanNamingAMissingFileStillCompiles` | FAIL |
| `TestMacroInACodeSpanIsNotDefined` | FAIL |
| `TestIncludeOutsideACodeSpanStillRuns` | guardrail — a real directive still runs |
| `TestIncludeInAFencedBlockIsStillNotRun` | guardrail |

Full suite green, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)