### PR TITLE
fix: say what the run actually did, and check what it was told before it acts

### DIFF
--- a/mark.go
+++ b/mark.go
@@ -133,7 +133,7 @@ func Run(config Config) error {
 //
 // Whatever the run did before it stopped stands, including the page manifest,
 // which is saved on the way out as it is for any other ending.
-func RunContext(ctx context.Context, config Config) error {
+func RunContext(ctx context.Context, config Config) (err error) {
 	// The browser is shared for the life of the process and is started lazily
 	// by the first diagram or formula. A library caller has no other way to
 	// know it exists, so a run that started one shuts it down; the CLI's own
@@ -303,6 +303,24 @@ func run(ctx context.Context, config Config) error {
 	// What the run did, for whatever is reading the output rather than the log.
 	results := report.New()
 
+	// Written on the way out, whatever the way out is. It used to be written at
+	// the end of a successful run only, so --output-format json produced zero
+	// bytes whenever the run failed after publishing -- an unresolved link, a
+	// failed ordering pass, an orphan that could not be handled -- which is
+	// exactly when an account of what was published is worth having. A failed
+	// write still fails the run, but only when nothing worse already has.
+	defer func() {
+		if writeErr := results.Write(config.output(), outputFormat); writeErr != nil {
+			if err == nil {
+				err = fmt.Errorf("unable to write the run report: %w", writeErr)
+
+				return
+			}
+
+			log.Error().Err(writeErr).Msg("unable to write the run report")
+		}
+	}()
+
 	// Pages that asked for a position among their siblings, collected as they
 	// publish and applied once at the end -- the order of one page only means
 	// anything alongside the others.
@@ -331,20 +349,36 @@ func run(ctx context.Context, config Config) error {
 				continue
 			}
 
-			if writeErr := results.Write(config.output(), outputFormat); writeErr != nil {
-				log.Error().Err(writeErr).Msg("unable to write the run report")
-			}
-
 			return err
 		}
 
 		if target != nil {
-			log.Info().Msgf("page successfully updated: %s", api.BaseURL+target.Links.Full)
+			url := api.BaseURL + target.Links.Full
+
+			// What the report says rather than "there is a page here". A page
+			// held back by --no-overwrite is one this run deliberately did not
+			// write, and announcing it as updated contradicted the warning
+			// printed a line earlier -- "leaving it alone" followed
+			// immediately by "page successfully updated".
+			status := results.StatusOf(file)
+
+			switch status {
+			case report.StatusSkipped:
+				// Already said where the decision was made, with the reason.
+
+			case report.StatusUnchanged:
+				log.Info().Msgf("page is already up to date: %s", url)
+
+			default:
+				log.Info().Msgf("page successfully updated: %s", url)
+			}
 
 			// The other formats describe the whole run at the end, where a
-			// page published twice can be reported once.
-			if outputFormat == report.FormatURL {
-				if _, err := fmt.Fprintln(config.output(), api.BaseURL+target.Links.Full); err != nil {
+			// page published twice can be reported once. A page left alone is
+			// not one this run put there, so it is not named among the URLs of
+			// the pages it did.
+			if outputFormat == report.FormatURL && status != report.StatusSkipped {
+				if _, err := fmt.Fprintln(config.output(), url); err != nil {
 					return err
 				}
 			}
@@ -426,10 +460,6 @@ func run(ctx context.Context, config Config) error {
 			"%s:\n  %s",
 			pluraliseLinks(len(missingPages)), strings.Join(missingPages, "\n  "),
 		)
-	}
-
-	if err := results.Write(config.output(), outputFormat); err != nil {
-		return fmt.Errorf("unable to write the run report: %w", err)
 	}
 
 	if hasErrors {

--- a/mark_reporting_test.go
+++ b/mark_reporting_test.go
@@ -1,0 +1,120 @@
+package mark
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/kovetskiy/mark/v16/report"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNoOverwriteDoesNotPrintTheURLOfAPageItLeftAlone: the drift branch returns
+// the page, and the caller took a page coming back as proof one had been
+// written -- so a run said "leaving it alone" and then, on the very next line,
+// "page successfully updated", and printed the URL among the pages it had
+// published.
+func TestNoOverwriteDoesNotPrintTheURLOfAPageItLeftAlone(t *testing.T) {
+	server, id, config := noOverwriteFixture(t)
+
+	// Somebody edits the page in Confluence, which is what --no-overwrite is
+	// there to notice.
+	server.EditPage(id, "<p>By hand.</p>")
+
+	var out bytes.Buffer
+	config.OutputFormat = report.FormatURL
+	config.Output = &out
+
+	require.NoError(t, Run(config))
+
+	assert.Empty(t, strings.TrimSpace(out.String()),
+		"a page this run deliberately did not write is not one of the pages it wrote")
+}
+
+// TestNoOverwriteStillReportsTheSkip: silence in the URL list is not silence in
+// the report, which is where the reason belongs.
+func TestNoOverwriteStillReportsTheSkip(t *testing.T) {
+	server, id, config := noOverwriteFixture(t)
+
+	server.EditPage(id, "<p>By hand.</p>")
+
+	var out bytes.Buffer
+	config.OutputFormat = report.FormatJSON
+	config.Output = &out
+
+	require.NoError(t, Run(config))
+
+	var parsed report.Report
+	require.NoError(t, json.Unmarshal(out.Bytes(), &parsed))
+	require.Len(t, parsed.Pages, 1)
+
+	assert.Equal(t, report.StatusSkipped, parsed.Pages[0].Status)
+	assert.Contains(t, parsed.Pages[0].Reason, "edited in Confluence")
+}
+
+// TestReportIsWrittenWhenTheRunFails: the report used to be written only after
+// every check had passed, so --output-format json produced nothing at all when
+// a run published its pages and then failed on an unresolved link -- which is
+// exactly when an account of what was published is worth having.
+func TestReportIsWrittenWhenTheRunFails(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Doc -->\n\nSee [it](ac:Nowhere).\n")
+
+	var out bytes.Buffer
+
+	err := Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files:        filepath.Join(dir, "doc.md"),
+		Features:     []string{"mention"},
+		CheckLinks:   []string{"confluence"},
+		OutputFormat: report.FormatJSON,
+		Output:       &out,
+	})
+
+	require.Error(t, err, "the unresolved link still fails the run")
+
+	var parsed report.Report
+	require.NoError(t, json.Unmarshal(out.Bytes(), &parsed), "and the report is still written")
+	require.Len(t, parsed.Pages, 1)
+	assert.Equal(t, report.StatusPublished, parsed.Pages[0].Status,
+		"the page did publish, whatever became of the link")
+}
+
+// TestUnresolvedLinkNamesTheDocument: the resolver was given the directory the
+// document sits in as the source of its messages, so with several documents in
+// one folder the message named the folder and left the reader to work out which
+// file it meant.
+func TestUnresolvedLinkNamesTheDocument(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	dir := t.TempDir()
+	header := "<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n"
+	writeFile(t, dir, "innocent.md", header+"<!-- Title: Innocent -->\n\nNothing wrong here.\n")
+	writeFile(t, dir, "guilty.md", header+"<!-- Title: Guilty -->\n\nSee [it](ac:Nowhere).\n")
+
+	err := Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files:      filepath.Join(dir, "*.md"),
+		Features:   []string{"mention"},
+		CheckLinks: []string{"confluence"},
+		Output:     io.Discard,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "guilty.md", "the message names the file to open")
+	assert.NotContains(t, err.Error(), "innocent.md")
+}

--- a/page/link.go
+++ b/page/link.go
@@ -216,7 +216,16 @@ func (r *LinkResolver) checkConfluenceLink(target, text string) error {
 
 	// Noted rather than looked up: the page may not have been published yet,
 	// and whether it ever is can only be known once the run is over.
-	r.Checker.NotePage(r.SpaceForLinks, title, r.Base)
+	//
+	// Reported against the document rather than r.Base, which is the directory
+	// the document sits in: with several documents in one directory the message
+	// named a folder and left the reader to find which file it meant.
+	source := r.SourceFile
+	if source == "" {
+		source = r.Base
+	}
+
+	r.Checker.NotePage(r.SpaceForLinks, title, source)
 
 	return nil
 }

--- a/report/report.go
+++ b/report/report.go
@@ -112,6 +112,25 @@ func (r *Report) AddPage(page Page) {
 	r.Pages = append(r.Pages, page)
 }
 
+// StatusOf reports what the run last recorded for a document, or "" if it
+// recorded nothing about it.
+func (r *Report) StatusOf(file string) string {
+	if r == nil {
+		return ""
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for i := range r.Pages {
+		if r.Pages[i].File == file {
+			return r.Pages[i].Status
+		}
+	}
+
+	return ""
+}
+
 // AddOrphan records a tracked page whose document has gone.
 func (r *Report) AddOrphan(orphan Orphan) {
 	if r == nil {

--- a/util/cli.go
+++ b/util/cli.go
@@ -88,7 +88,7 @@ func RunMark(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 
-	parents := strings.Split(cmd.String("parents"), cmd.String("parents-delimiter"))
+	parents := splitParents(cmd.String("parents"), cmd.String("parents-delimiter"))
 
 	config := mark.Config{
 		BaseURL:               creds.BaseURL,
@@ -171,4 +171,24 @@ func SetLogLevel(cmd *cli.Command) error {
 	}
 
 	return nil
+}
+
+// splitParents reads the --parents value, dropping empty fields.
+//
+// A delimiter is a separator, not a parent. "/A/B" split to ["", "A", "B"] and
+// the guard downstream checks only element zero, so a leading delimiter
+// silently discarded the whole list and published the page under whatever
+// ancestry the document itself named. "A//B" and "A/B/" went the other way and
+// put a parent with no title into the chain, which ancestry resolution then
+// looks up and, finding nothing, creates.
+func splitParents(value, delimiter string) []string {
+	var parents []string
+
+	for _, parent := range strings.Split(value, delimiter) {
+		if parent != "" {
+			parents = append(parents, parent)
+		}
+	}
+
+	return parents
 }

--- a/util/flags.go
+++ b/util/flags.go
@@ -416,6 +416,19 @@ func CheckFlags(context context.Context, command *cli.Command) (context.Context,
 		}
 	}
 
+	imageAlign := strings.TrimSpace(command.String("image-align"))
+	if imageAlign != "" {
+		switch strings.ToLower(imageAlign) {
+		case "left", "center", "right":
+			// ok
+		default:
+			return context, fmt.Errorf(
+				"invalid value for --image-align: %q (expected: left, center, or right)",
+				imageAlign,
+			)
+		}
+	}
+
 	mathFormat := strings.TrimSpace(command.String("math-format"))
 	if mathFormat != "" {
 		switch mathFormat {

--- a/util/flags_test.go
+++ b/util/flags_test.go
@@ -241,3 +241,53 @@ func mustParseArgs(t *testing.T, cmd *cli.Command, args ...string) (context.Cont
 
 	return context.Background(), mustParse(t, cmd, args...)
 }
+
+// TestSplitParentsDropsEmptyFields: a delimiter is a separator, not a parent.
+// "/A/B" split to ["", "A", "B"], and the guard that consumes this checks only
+// element zero -- so a leading delimiter silently discarded the whole list and
+// the page published under whatever ancestry the document itself named. "A//B"
+// and "A/B/" went the other way and put a parent with no title into the chain,
+// which ancestry resolution looks up and, finding nothing, creates.
+func TestSplitParentsDropsEmptyFields(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		written  string
+		expected []string
+	}{
+		{"plain", "A/B", []string{"A", "B"}},
+		{"leading", "/A/B", []string{"A", "B"}},
+		{"trailing", "A/B/", []string{"A", "B"}},
+		{"doubled", "A//B", []string{"A", "B"}},
+		{"only delimiters", "//", nil},
+		{"empty", "", nil},
+		{"single", "A", []string{"A"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, splitParents(test.written, "/"))
+		})
+	}
+}
+
+// TestImageAlignIsCheckedBeforeAnythingIsCreated: --content-appearance and
+// --math-format are both checked here, and --image-align was not -- it was
+// validated inside the publish, after CreatePage and after attachments had
+// gone up. A misspelling therefore left an empty page in Confluence and then
+// failed the run.
+func TestImageAlignIsCheckedBeforeAnythingIsCreated(t *testing.T) {
+	cmd := &cli.Command{Flags: Flags}
+	_, err := CheckFlags(mustParseArgs(t, cmd, "mark", "--image-align", "centre"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "centre")
+	assert.Contains(t, err.Error(), "center")
+}
+
+func TestImageAlignAcceptsWhatItDocuments(t *testing.T) {
+	for _, align := range []string{"left", "center", "right", "CENTER", " right "} {
+		t.Run(align, func(t *testing.T) {
+			cmd := &cli.Command{Flags: Flags}
+			_, err := CheckFlags(mustParseArgs(t, cmd, "mark", "--image-align", align))
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Five independent fixes, all of the same shape: a run misreporting itself, or acting before checking. Each is a few lines and each has a test that fails without it.

### F18 — a page held back by `--no-overwrite` was announced as published

The drift branch returns the page so it still counts as seen, and the caller read *a page came back* as proof one had been written:

```
WARN  page "Doc" was edited in Confluence since mark published it; leaving it alone
INFO  page successfully updated: .../1004
```

`--output-format url` also named it among the pages the run had published. The caller asks the report now, which knew all along — a skipped page is not announced, an unchanged one says so, and only a page this run wrote is listed among the URLs of the pages it wrote.

### F21 — the report was written only after every check had passed

A run that published its pages and *then* failed — an unresolved link, a failed ordering pass, an orphan it could not handle — wrote **zero bytes** of `--output-format json`. That is exactly when an account of what was published is worth having.

Written on the way out now, whatever the way out is, and still only once. A failed write still fails the run, but only when nothing worse already has.

### F22 — an unresolved `ac:` link named a directory

```
/tmp/…/001: link "ac:Nowhere" does not resolve: there is no page "Nowhere" in space "DOCS"
```

`filepath.Dir(file)` was passed as the message source, so a folder with several documents in it named the folder. `r.SourceFile` held the answer and was already used correctly for deferrals.

### F19 — `--parents` treated a delimiter as a parent

```
/A/B   -> ["" "A" "B"]   prepended: false     ← the whole list silently discarded
A//B   -> ["A" "" "B"]   prepended: true      ← an empty-titled parent in the chain
A/B/   -> ["A" "B" ""]   prepended: true
```

The guard downstream checks only element zero. A leading delimiter published the page under whatever ancestry the document itself named; a doubled or trailing one put a parent with no title into the chain, which ancestry resolution looks up and, finding nothing, **creates**.

### F20 — `--image-align` was validated after the page was created

`getImageAlign` runs after `CreatePage` and after attachments upload, so `--image-align centre` left an empty page in Confluence and then failed. Checked in `CheckFlags` now, where `--content-appearance` and `--math-format` have always been. (The compile-only path already checked first, which made the real run the outlier.)

### Coverage

| Test | Without fix |
|---|---|
| `TestNoOverwriteDoesNotPrintTheURLOfAPageItLeftAlone` | FAIL |
| `TestNoOverwriteStillReportsTheSkip` | guardrail — the reason still reaches the report |
| `TestReportIsWrittenWhenTheRunFails` | FAIL |
| `TestUnresolvedLinkNamesTheDocument` | FAIL |
| `TestSplitParentsDropsEmptyFields` | new helper; old expression's output shown above |
| `TestImageAlignIsCheckedBeforeAnythingIsCreated` | FAIL |
| `TestImageAlignAcceptsWhatItDocuments` | guardrail |

Full suite green, `golangci-lint` clean.

Happy to split this into five if you would rather review them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)