### PR TITLE
fix(page): a lookup that failed is not a page or folder that is gone

### DIFF
--- a/page/ancestry.go
+++ b/page/ancestry.go
@@ -226,10 +226,23 @@ func EnsureFolderAncestry(
 			if ok {
 				folder, err = api.GetFolderByID(id)
 				if err != nil {
-					// Recorded but gone. Fall through and create it again.
+					// Not "gone": GetFolderByID answers a 404 with (nil, nil),
+					// so an error here is a 401, a 403 or a 5xx that outlived
+					// every retry -- most often a scoped token without folder
+					// read. Taking that for absence created a second folder
+					// with the same title and split the hierarchy this lookup
+					// exists to hold together, and the run that did it looked
+					// like it had worked.
+					return nil, fmt.Errorf(
+						"unable to check whether folder %q was renamed: %w", title, err,
+					)
+				}
+
+				if folder == nil {
+					// Recorded, and really not there any more. Fall through and
+					// create it again.
 					log.Warn().Msgf("folder %q was recorded as %s, which no longer exists", title, id)
-					folder = nil
-				} else if folder != nil {
+				} else {
 					log.Info().Msgf(
 						"folder %q was renamed to %q; using it rather than creating another",
 						title, folder.Title,

--- a/page/lookup_failure_test.go
+++ b/page/lookup_failure_test.go
@@ -1,0 +1,147 @@
+package page
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInScopeTreatsADeletedPageAsGone: a tracked page deleted by hand in
+// Confluence is out of scope for acting on, not a reason to end the run.
+//
+// GetPageByIDExpanded answers a 404 with an error and never with (nil, nil), so
+// the nil check this used to rely on was unreachable and the error went
+// straight up. The same repository publishes fine without --orphan-under, which
+// made the flag itself look broken.
+func TestInScopeTreatsADeletedPageAsGone(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	inScope, err := InScope(api, "2000", Orphan{
+		Path: "gone.md", PageID: "9999", Title: "Gone",
+	})
+
+	require.NoError(t, err, "a page that is already gone is not a failed run")
+	assert.False(t, inScope)
+}
+
+// TestInScopeReportsARealFailure is the other half. A 403 says nothing about
+// where the page sits, and answering "not in scope" would quietly leave every
+// orphan alone while looking like a clean run.
+func TestInScopeReportsARealFailure(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	page := server.AddPage("DOCS", "Doc", "page", home.ID)
+
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if strings.Contains(r.URL.Path, "/content/"+page.ID) {
+			return http.StatusForbidden, `{"message":"no"}`, true
+		}
+
+		return 0, "", false
+	})
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	_, err := InScope(api, home.ID, Orphan{
+		Path: "doc.md", PageID: page.ID, Title: "Doc",
+	})
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, confluence.ErrNotFound)
+	assert.Contains(t, err.Error(), page.ID)
+}
+
+// stubFolderTracker is a FolderTracker holding a fixed mapping.
+type stubFolderTracker struct {
+	folders  map[string]string
+	recorded map[string]string
+}
+
+func (s *stubFolderTracker) LookupFolder(_, path string) (string, bool, error) {
+	id, ok := s.folders[path]
+
+	return id, ok, nil
+}
+
+func (s *stubFolderTracker) RecordFolder(_, path, id string) error {
+	s.recorded[path] = id
+
+	return nil
+}
+
+// TestFolderAncestryReportsAFailedRead: a folder recorded for this position is
+// read back when nothing carries its title any more, because it may simply have
+// been renamed. GetFolderByID answers a 404 with (nil, nil), so an error there
+// is a 401, a 403 or a 5xx that outlived every retry -- and it was logged as
+// "no longer exists" and swallowed.
+//
+// The run then created a second folder with the same title, recorded it over
+// the first, and published into it: the hierarchy split in two, by a run that
+// looked like it had worked.
+func TestFolderAncestryReportsAFailedRead(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	anchor := server.AddPage("DOCS", "Anchor", "page", home.ID)
+
+	const recorded = "4242"
+
+	anchorID := anchor.ID
+	folders := []string{"Manuals-failed-read"}
+
+	tracker := &stubFolderTracker{
+		folders:  map[string]string{folderPathKey(&anchorID, folders, 0): recorded},
+		recorded: map[string]string{},
+	}
+
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if strings.Contains(r.URL.Path, "/folders/"+recorded) {
+			return http.StatusForbidden, `{"message":"no"}`, true
+		}
+
+		return 0, "", false
+	})
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	_, err := EnsureFolderAncestry(false, api, "DOCS", folders, &anchorID, tracker)
+
+	require.Error(t, err, "a folder that could not be read is not a folder that is gone")
+	assert.Contains(t, err.Error(), "Manuals-failed-read")
+	assert.Empty(t, server.Folders(), "and no second folder was created")
+	assert.Empty(t, tracker.recorded, "nor recorded over the first")
+}
+
+// TestFolderAncestryRecreatesAFolderThatIsReallyGone is the other half: a
+// recorded folder that Confluence answers 404 for really has been deleted, and
+// creating it again is the right thing to do.
+func TestFolderAncestryRecreatesAFolderThatIsReallyGone(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	anchor := server.AddPage("DOCS", "Anchor", "page", home.ID)
+
+	anchorID := anchor.ID
+	folders := []string{"Manuals-really-gone"}
+
+	tracker := &stubFolderTracker{
+		// An id the fake has never heard of, which it answers 404 for.
+		folders:  map[string]string{folderPathKey(&anchorID, folders, 0): "9999"},
+		recorded: map[string]string{},
+	}
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	parent, err := EnsureFolderAncestry(false, api, "DOCS", folders, &anchorID, tracker)
+
+	require.NoError(t, err)
+	require.NotNil(t, parent)
+	assert.Equal(t, "Manuals-really-gone", parent.Title)
+	assert.Len(t, server.Folders(), 1)
+}

--- a/page/orphan.go
+++ b/page/orphan.go
@@ -1,6 +1,7 @@
 package page
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -113,12 +114,23 @@ func InScope(api *confluence.API, scopeID string, orphan Orphan) (bool, error) {
 
 	page, err := api.GetPageByIDExpanded(orphan.PageID, "ancestors")
 	if err != nil {
+		// Already gone from Confluence -- deleted by hand between runs, most
+		// likely. Out of scope for acting on, and the caller forgets it either
+		// way.
+		//
+		// Asked of the error rather than of a nil page: this call answers a 404
+		// with an error and never with (nil, nil), so the nil check below was
+		// unreachable and --orphan-under failed the whole run over a page
+		// somebody had already deleted. The same repository publishes fine
+		// without the flag, which made the flag itself look broken.
+		if errors.Is(err, confluence.ErrNotFound) {
+			return false, nil
+		}
+
 		return false, fmt.Errorf("unable to read page %s: %w", orphan.PageID, err)
 	}
 
 	if page == nil {
-		// Already gone from Confluence. Out of scope for acting on, and the
-		// caller forgets it either way.
 		return false, nil
 	}
 


### PR DESCRIPTION
Two places read a failed request as an absence, and acted on it.

### A folder that could not be read was recreated

When nothing carries a recorded folder's title any more, the folder recorded for that position is read back — it may simply have been renamed. But:

```go
folder, err = api.GetFolderByID(id)
if err != nil {
    // Recorded but gone. Fall through and create it again.
    log.Warn().Msgf("folder %q was recorded as %s, which no longer exists", title, id)
    folder = nil
}
```

`GetFolderByID` answers a **404 with `(nil, nil)`**, so a non-nil error there is a 401, a 403 or a 5xx that outlived every retry — a scoped token without folder read being the usual one. It was logged as "no longer exists", swallowed, and the run went on to create a second folder with the same title, record it over the first, and publish into it.

The hierarchy the tracker exists to hold together splits in two, and the run that did it looks like it worked.

The error is reported now. A folder Confluence really answers 404 for is still recreated — the case the branch was written for, now reached by the condition that actually means it.

### An orphan whose page was already deleted ended the run

```go
page, err := api.GetPageByIDExpanded(orphan.PageID, "ancestors")
if err != nil {
    return false, fmt.Errorf("unable to read page %s: %w", orphan.PageID, err)
}
if page == nil {
    // Already gone from Confluence.
    return false, nil
}
```

`GetPageByIDExpanded` answers a 404 with an error and never with `(nil, nil)`, so that second branch was unreachable. Delete a tracked page by hand, remove its source file, and `--orphan-under` fails the whole run: nothing publishes, and the manifest entry can never be cleaned up. The same repository publishes fine *without* the flag, which makes the flag itself look broken.

Asked of the error now, through the `ErrNotFound` that already exists for the purpose — *"so callers that need to act on 'this is gone' specifically can ask with errors.Is instead of matching on the message"*. A 403 is still reported: it says nothing about where the page sits, and answering "not in scope" would leave every orphan alone while looking like a clean run.

### Coverage

| Test | Without fix |
|---|---|
| `TestFolderAncestryReportsAFailedRead` | FAIL — asserts no second folder is created and nothing is recorded over the first |
| `TestFolderAncestryRecreatesAFolderThatIsReallyGone` | guardrail — a real 404 still recreates |
| `TestInScopeTreatsADeletedPageAsGone` | FAIL |
| `TestInScopeReportsARealFailure` | guardrail — a 403 is still an error |

Both failure cases are driven through the fake server's `SetFail` hook. Full suite green, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)