### PR TITLE
fix(parser): a "$$" inside a code block does not close a fence

### DIFF
--- a/markdown/math_block_test.go
+++ b/markdown/math_block_test.go
@@ -194,3 +194,48 @@ func TestClosedMathFenceInABlockquoteIsStillFound(t *testing.T) {
 	assert.Contains(t, out, "<ac:image")
 	assert.Contains(t, out, "<blockquote>")
 }
+
+// TestMathFenceIsNotClosedByOneInsideACodeBlock: the lookahead for a closing
+// fence reads the source, so it read the code samples in it too. A document
+// showing what a display formula looks like closed a fence opened further up,
+// and the formula then swallowed everything between them -- the opening ```
+// included, which left the rest of the document inside a code block nobody had
+// opened. Silently, and with a zero exit code.
+func TestMathFenceIsNotClosedByOneInsideACodeBlock(t *testing.T) {
+	out := compileMath(t, "Intro.\n\n$$\na + b\n\nProse that must survive.\n\n```\n$$\n```\n\nTail.\n")
+
+	assert.NotContains(t, out, "<ac:image", "nothing closed the fence, so nothing was a formula")
+	assert.Contains(t, out, "Prose that must survive.")
+	assert.Contains(t, out, "Tail.")
+	assert.Contains(t, out, "<![CDATA[$$]]>", "and the sample is still a code sample")
+	require.NoError(t, CheckWellFormed(out))
+}
+
+// TestMathFenceIsNotClosedByOneInAnIndentedCodeBlock covers the other kind of
+// code block, which the parser knows about and a scan for "$$" does not.
+func TestMathFenceIsNotClosedByOneInAnIndentedCodeBlock(t *testing.T) {
+	out := compileMath(t, "Intro.\n\n$$\na + b\n\nProse that must survive.\n\n    $$\n\nTail.\n")
+
+	assert.NotContains(t, out, "<ac:image")
+	assert.Contains(t, out, "Prose that must survive.")
+	assert.Contains(t, out, "Tail.")
+}
+
+// TestMathFenceIsStillClosedByOneAfterACodeBlock is the other half: a sample
+// showing the syntax does not stop a real closer further down from working.
+func TestMathFenceIsStillClosedByOneAfterACodeBlock(t *testing.T) {
+	out := compileMath(t, "```\n$$\n```\n\n$$\nE = mc^2\n$$\n\nTail.\n")
+
+	assert.Contains(t, out, `ac:alt="E = mc^2"`, "the real fence still renders")
+	assert.Contains(t, out, "<![CDATA[$$]]>", "and the sample is still a sample")
+	assert.Contains(t, out, "<p>Tail.</p>")
+}
+
+// TestMathFenceInABlockquoteIsNotClosedFromInsideACodeBlock: the two rules meet
+// -- a closer inside a quotation still counts, one inside code still does not.
+func TestMathFenceInABlockquoteIsNotClosedFromInsideACodeBlock(t *testing.T) {
+	out := compileMath(t, "> $$\n> a + b\n\nProse.\n\n```\n> $$\n```\n")
+
+	assert.NotContains(t, out, "<ac:image")
+	assert.Contains(t, out, "Prose.")
+}

--- a/parser/mathblock.go
+++ b/parser/mathblock.go
@@ -3,6 +3,8 @@ package parser
 import (
 	"bytes"
 
+	"github.com/kovetskiy/mark/v16/metadata"
+
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/text"
@@ -136,36 +138,75 @@ func openingFence(line []byte, pos int) (fence, bool) {
 // written.
 //
 // Read from the source rather than through the reader, which is mid-parse and
-// not ours to move.
-func (f fence) closerAhead(source []byte, from int) bool {
+// not ours to move -- and checked against where the code is, because reading
+// the source means reading the code samples in it too. A document showing what
+// a display formula looks like
+//
+//	```
+//	$$
+//	```
+//
+// closed a fence opened further up, and the formula then swallowed everything
+// between them, the opening ``` included -- which left the rest of the document
+// inside a code block that nothing had opened on purpose. Silently, and with a
+// zero exit code.
+func (f fence) closerAhead(source []byte, from int, code []metadata.Region) bool {
 	if from < 0 || from >= len(source) {
 		return false
 	}
 
+	offset := from
 	for _, line := range bytes.Split(source[from:], []byte("\n")) {
-		if f.closesBlock(undoContainerPrefix(line)) {
+		// Asked at the content rather than at the start of the line. An
+		// indented code block's region begins after the indent that made it
+		// one, so a line measured from its first byte falls outside the very
+		// region that describes it.
+		content, skipped := undoContainerPrefix(line)
+
+		if !metadata.InCode(code, offset+skipped) && f.closesBlock(content) {
 			return true
 		}
+
+		offset += len(line) + 1 // the newline Split consumed
 	}
 
 	return false
 }
 
+// codeRegionsKey holds the document's code regions for the length of one parse.
+var codeRegionsKey = parser.NewContextKey()
+
+// codeRegions reports where the code is, working it out once per document.
+//
+// goldmark is asked rather than the bytes searched for backticks: tildes,
+// indented blocks, closing fences longer than their opener and nesting are all
+// easy to get subtly wrong, and the parser already knows.
+func codeRegions(reader text.Reader, pc parser.Context) []metadata.Region {
+	if cached, ok := pc.Get(codeRegionsKey).([]metadata.Region); ok {
+		return cached
+	}
+
+	regions := metadata.CodeRegions(reader.Source())
+	pc.Set(codeRegionsKey, regions)
+
+	return regions
+}
+
 // undoContainerPrefix strips what a container takes off a line before a block
-// parser is ever shown it.
+// parser is ever shown it, and reports how many bytes went.
 //
 // The lookahead reads the source, so a closing fence inside a blockquote still
 // carries its "> ". Erring towards finding a closer is the safe direction: a
 // fence that is found to close behaves exactly as it always has, and only one
 // that closes nowhere is read as text.
-func undoContainerPrefix(line []byte) []byte {
-	line = bytes.TrimLeft(line, " \t")
+func undoContainerPrefix(line []byte) ([]byte, int) {
+	rest := bytes.TrimLeft(line, " \t")
 
-	for len(line) > 0 && line[0] == '>' {
-		line = bytes.TrimLeft(line[1:], " \t")
+	for len(rest) > 0 && rest[0] == '>' {
+		rest = bytes.TrimLeft(rest[1:], " \t")
 	}
 
-	return line
+	return rest, len(line) - len(rest)
 }
 
 // closesBlock reports whether a line is the closing fence.
@@ -215,7 +256,7 @@ func (b *mathBlockParser) Open(parent ast.Node, reader text.Reader, pc parser.Co
 	}
 
 	// Nothing closes it, so it opens nothing.
-	if !opened.closerAhead(reader.Source(), segment.Stop) {
+	if !opened.closerAhead(reader.Source(), segment.Stop, codeRegions(reader, pc)) {
 		return nil, parser.NoChildren
 	}
 


### PR DESCRIPTION
Follow-up to #979, which bounded an unclosed display fence by looking ahead for its closer. The lookahead reads the source — so it reads the code samples in it too.

A document showing what a display formula looks like:

````markdown
$$
a + b

Prose that must survive.

```
$$
```

Tail.
````

closes the fence against the **sample**. The formula then swallows the prose and the opening ``` with it, which leaves the rest of the document inside a code block nobody opened:

```html
<ac:image ac:alt="a + b

Prose that must survive.

```">…</ac:image>
<ac:structured-macro ac:name="code">…Tail.
```

Silently, exit code 0. Worse than the swallowing #979 was added to prevent, since that at least tended to fail loudly on invalid TeX.

### The fix

goldmark is asked where the code is (`metadata.CodeRegions`) rather than the bytes searched for backticks — tildes, indented blocks, closing fences longer than their opener and nesting are all easy to get subtly wrong, and the parser already knows. It is worked out once per document and kept on the parse context, so a document with many fences does not re-parse itself for each one.

One thing that did not work first time: the offset is taken at the **line's content**, not its first byte. An indented code block's region begins after the indent that made it one, so a line measured from its start falls outside the very region that describes it — the fenced case passed while the indented case went on failing.

### Coverage

| Test | Without fix |
|---|---|
| `TestMathFenceIsNotClosedByOneInsideACodeBlock` | FAIL |
| `TestMathFenceIsNotClosedByOneInAnIndentedCodeBlock` | FAIL |
| `TestMathFenceIsStillClosedByOneAfterACodeBlock` | guardrail — a sample does not stop a real closer |
| `TestMathFenceInABlockquoteIsNotClosedFromInsideACodeBlock` | both rules at once |

Existing math tests all still pass, including `TestMathFenceInsideACodeBlockStaysCode` and the blockquote and list-item cases. Full suite green, `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)