### PR TITLE
fix(util): "-p -" with nothing on standard input is a missing password

### DIFF
--- a/util/auth.go
+++ b/util/auth.go
@@ -26,6 +26,21 @@ func GetCredentials(
 ) (*Credentials, error) {
 	var err error
 
+	// Ahead of the empty check and not after it. "-p -" does not carry a token,
+	// it says where the token is, so whether one was given at all is only known
+	// once standard input has been read. Checked first, the check passed on the
+	// "-" itself and a run with nothing piped in went on to authenticate with
+	// an empty password -- reported by Confluence as a 401, which reads as the
+	// wrong credential rather than as a missing one.
+	if password == "-" {
+		stdin, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read password from stdin: %w", err)
+		}
+
+		password = strings.TrimSpace(string(stdin))
+	}
+
 	if password == "" {
 		if !compileOnly {
 			return nil, errors.New(
@@ -34,15 +49,6 @@ func GetCredentials(
 			)
 		}
 		password = "none"
-	}
-
-	if password == "-" {
-		stdin, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			return nil, fmt.Errorf("unable to read password from stdin: %w", err)
-		}
-
-		password = strings.TrimSpace(string(stdin))
 	}
 
 	if compileOnly && targetURL == "" {

--- a/util/auth_test.go
+++ b/util/auth_test.go
@@ -108,6 +108,30 @@ func TestGetCredentialsPasswordFromStdin(t *testing.T) {
 	assert.Equal(t, "token-from-stdin", creds.Password)
 }
 
+// TestGetCredentialsRejectsAnEmptyPasswordOnStdin covers "-p -" with nothing
+// piped in, which is what a shell substitution that produced nothing looks like.
+//
+// The flag names where the token is rather than carrying one, so an empty
+// standard input means no token was given -- the same as passing none, and
+// worth the same error. Sent as an empty password instead, it comes back from
+// Confluence as a 401: the report for a credential that is wrong, not for one
+// that was never there.
+func TestGetCredentialsRejectsAnEmptyPasswordOnStdin(t *testing.T) {
+	read, write, err := os.Pipe()
+	require.NoError(t, err)
+	require.NoError(t, write.Close())
+
+	original := os.Stdin
+	os.Stdin = read
+
+	defer func() { os.Stdin = original }()
+
+	_, err = GetCredentials("user", "-", "", "https://confluence.example.com", false)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "-p")
+}
+
 // TestGetCredentialsRejectsAnUnparseableURL covers the target URL that is not
 // one at all, which is worth an error naming the value rather than a request to
 // an empty host.


### PR DESCRIPTION
Reading the token from standard input happens after the empty-password check, and `-p -` passes that check on the `-` itself. A run with nothing piped in — a shell substitution that came back empty, a heredoc that never opened — therefore authenticates with an empty password and gets a 401 back: the report for a credential that is wrong, not for one that was never there, which sends whoever gets it looking at their token rather than at the pipe that failed to carry it.

`-p -` does not carry a token, it says where the token is, so whether one was given at all is only known once standard input has been read. Doing that first means the run stops with the error it should have had.

```console
$ printf "" | mark -b https://confluence.example.com -p - --files doc.md
FATAL confluence password should be specified using -p flag or be stored in configuration file
```

A token on standard input still works as before, and `--compile-only` still falls back to its placeholder.

Covered by `TestGetCredentialsRejectsAnEmptyPasswordOnStdin`; `go test ./...`, `-race` and `golangci-lint` are clean.

Noted for #916: with the read moved up, the `resolvedFromCommand` flag that keeps a `--password-command` printing a bare `-` out of this branch is no longer needed there, and can go when that branch next rebases.