### PR TITLE
fix: refuse a mermaid scale set beside an SVG in Config

### DIFF
--- a/mark.go
+++ b/mark.go
@@ -200,6 +200,21 @@ func run(ctx context.Context, config Config) error {
 		)
 	}
 
+	// A scale is refused here only where it would have done something. The
+	// command line refuses any scale set beside an SVG, because IsSet tells a
+	// value somebody chose from the default every run carries -- a Config field
+	// cannot say that, and the CLI fills this one in with 1.0 whether or not
+	// anybody asked for it. Zero is the field nobody set and one scales
+	// nothing, so neither is worth failing a run over; a 2 carried over from a
+	// PNG setup is a scaling that silently would not happen.
+	if config.MermaidOutput == "svg" && config.MermaidScale != 0 && config.MermaidScale != 1 {
+		return fmt.Errorf(
+			"MermaidScale %v does not apply to MermaidOutput \"svg\": "+
+				"an SVG is the same drawing at every size",
+			config.MermaidScale,
+		)
+	}
+
 	if config.CheckLinksWarnOnly && len(config.CheckLinks) == 0 {
 		return fmt.Errorf(
 			"--check-links-warn-only requires --check-links: " +

--- a/mark_mermaid_test.go
+++ b/mark_mermaid_test.go
@@ -66,3 +66,32 @@ func TestMermaidBundleNeedsAnSVGToGoIn(t *testing.T) {
 func TestMermaidDefaultsPublishAsBefore(t *testing.T) {
 	require.NoError(t, Run(mermaidFixture(t)))
 }
+
+// TestMermaidScaleIsRefusedWhereItWouldHaveScaled covers a scale carried over
+// from a PNG setup. Nothing multiplies the pixels of an SVG, so the run would
+// publish diagrams at a size nobody asked for -- the original size -- and say
+// nothing about the setting it passed over.
+func TestMermaidScaleIsRefusedWhereItWouldHaveScaled(t *testing.T) {
+	config := mermaidFixture(t)
+	config.MermaidOutput = "svg"
+	config.MermaidScale = 2
+
+	err := Run(config)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "MermaidScale")
+}
+
+// TestMermaidScaleThatScalesNothingIsLeftAlone is the boundary, and the reason
+// the check is not the command line's. A Config field cannot say whether
+// anybody set it, and the CLI fills this one in with 1.0 on every run: refusing
+// that would refuse every SVG run mark makes of its own.
+func TestMermaidScaleThatScalesNothingIsLeftAlone(t *testing.T) {
+	for _, scale := range []float64{0, 1} {
+		config := mermaidFixture(t)
+		config.MermaidOutput = "svg"
+		config.MermaidScale = scale
+
+		assert.NoError(t, Run(config), "a scale of %v scales nothing", scale)
+	}
+}


### PR DESCRIPTION
Follow-up to #769, from the last Copilot review on it — the finding arrived after the PR was merged.

`run()` validates `MermaidOutput` and `MermaidBundle` for callers that arrive through the public `Config` rather than through a flag, but says nothing about `MermaidScale`. A caller moving a PNG setup to SVG keeps a scale that nothing multiplies: diagrams are published at their own size, and the setting that was passed over is never mentioned.

## Why it is not the same check the CLI makes

`CheckFlags` refuses *any* `--mermaid-scale` set beside `--mermaid-output=svg`, because `IsSet` tells a value somebody chose from the default that every run carries. A `Config` field cannot say that, and `util/cli.go` fills this one in with the flag default of `1.0` whether or not anybody asked for it — so refusing every non-zero scale here would refuse every SVG run mark makes of its own.

So the check refuses a scale only where it would have done something:

- `0` is the field a caller never set.
- `1` scales nothing.
- anything else is a scaling that would silently not happen, and is refused.

The CLI stays the stricter of the two, which is right: it knows whether the value was chosen.

## Tests

- `TestMermaidScaleIsRefusedWhereItWouldHaveScaled` — `MermaidOutput: "svg"` with `MermaidScale: 2` fails.
- `TestMermaidScaleThatScalesNothingIsLeftAlone` — `0` and `1` do not, which is what keeps mark's own SVG runs working.

`go build ./...`, the mermaid tests and `golangci-lint` are clean; verified against a built binary that `--mermaid-output=svg` still publishes and that `--mermaid-output=svg --mermaid-scale 2` is still refused by the CLI.