### PR TITLE
fix(mermaid): let an SVG state its own size, and let --mermaid-scale apply to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1656,7 +1656,7 @@ GLOBAL OPTIONS:
    --parents string                               A list containing the parents of the document separated by parents-delimiter (default: '/'). These will be prepended to the ones defined in the document itself. [$MARK_PARENTS]
    --parents-delimiter string                     The delimiter used for the parents list (default: "/") [$MARK_PARENTS_DELIMITER]
    --content-appearance string                    default content appearance for pages without a Content-Appearance header. Possible values: full-width, fixed, default. [$MARK_CONTENT_APPEARANCE]
-   --mermaid-scale float                          defines the scaling factor for mermaid PNG renderings; not accepted when mermaid-output is svg. (default: 1) [$MARK_MERMAID_SCALE]
+   --mermaid-scale float                          defines the scaling factor for mermaid renderings: the pixels of a png, and the size the page displays an svg at. (default: 1) [$MARK_MERMAID_SCALE]
    --mermaid-output string                        image a mermaid diagram is published as: png (rasterised, and scaled by --mermaid-scale) or svg (vector and sharp at any zoom, where the instance displays an SVG attachment). (default: "png") [$MARK_MERMAID_OUTPUT]
    --mermaid-bundle                               keep the diagram's own source inside the SVG published for it, in its <desc> element, so the drawing can be edited again from the attachment. Needs --mermaid-output=svg. [$MARK_MERMAID_BUNDLE]
    --math-format string                           image a formula is published as with --features=math: png (rasterised through the same headless Chrome mermaid uses) or svg (vector and sharp at any zoom, where the instance displays an SVG attachment). (default: "png") [$MARK_MATH_FORMAT]

--- a/mark.go
+++ b/mark.go
@@ -240,21 +240,6 @@ func run(ctx context.Context, config Config) error {
 		)
 	}
 
-	// A scale is refused here only where it would have done something. The
-	// command line refuses any scale set beside an SVG, because IsSet tells a
-	// value somebody chose from the default every run carries -- a Config field
-	// cannot say that, and the CLI fills this one in with 1.0 whether or not
-	// anybody asked for it. Zero is the field nobody set and one scales
-	// nothing, so neither is worth failing a run over; a 2 carried over from a
-	// PNG setup is a scaling that silently would not happen.
-	if config.MermaidOutput == "svg" && config.MermaidScale != 0 && config.MermaidScale != 1 {
-		return fmt.Errorf(
-			"MermaidScale %v does not apply to MermaidOutput \"svg\": "+
-				"an SVG is the same drawing at every size",
-			config.MermaidScale,
-		)
-	}
-
 	if config.CheckLinksWarnOnly && len(config.CheckLinks) == 0 {
 		return fmt.Errorf(
 			"--check-links-warn-only requires --check-links: " +

--- a/mark_mermaid_test.go
+++ b/mark_mermaid_test.go
@@ -68,35 +68,6 @@ func TestMermaidDefaultsPublishAsBefore(t *testing.T) {
 	require.NoError(t, Run(mermaidFixture(t)))
 }
 
-// TestMermaidScaleIsRefusedWhereItWouldHaveScaled covers a scale carried over
-// from a PNG setup. Nothing multiplies the pixels of an SVG, so the run would
-// publish diagrams at a size nobody asked for -- the original size -- and say
-// nothing about the setting it passed over.
-func TestMermaidScaleIsRefusedWhereItWouldHaveScaled(t *testing.T) {
-	config := mermaidFixture(t)
-	config.MermaidOutput = "svg"
-	config.MermaidScale = 2
-
-	err := Run(config)
-	require.Error(t, err)
-
-	assert.Contains(t, err.Error(), "MermaidScale")
-}
-
-// TestMermaidScaleThatScalesNothingIsLeftAlone is the boundary, and the reason
-// the check is not the command line's. A Config field cannot say whether
-// anybody set it, and the CLI fills this one in with 1.0 on every run: refusing
-// that would refuse every SVG run mark makes of its own.
-func TestMermaidScaleThatScalesNothingIsLeftAlone(t *testing.T) {
-	for _, scale := range []float64{0, 1} {
-		config := mermaidFixture(t)
-		config.MermaidOutput = "svg"
-		config.MermaidScale = scale
-
-		assert.NoError(t, Run(config), "a scale of %v scales nothing", scale)
-	}
-}
-
 // TestD2OutputRejectsAFormatMarkCannotPublish is the d2 half of the same rule:
 // Config is a public API, so a library caller arrives with no command line to
 // have been checked, and a format the renderer does not know falls to its PNG

--- a/markdown/mermaid_output_test.go
+++ b/markdown/mermaid_output_test.go
@@ -1,0 +1,34 @@
+package mark
+
+import (
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompileMarkdownRefusesAnUnknownMermaidOutput covers the one way an
+// unchecked value reaches the renderer.
+//
+// Run validates Config, but CompileMarkdown takes a types.MarkConfig straight
+// from a caller and never passes through it -- so a format nobody supports
+// would otherwise fall to the PNG branch and publish a picture that was not
+// asked for, saying nothing at all.
+func TestCompileMarkdownRefusesAnUnknownMermaidOutput(t *testing.T) {
+	lib, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	document := []byte("# Title\n\n```mermaid\ngraph TD;\n A-->B;\n```\n")
+
+	_, _, err = CompileMarkdown(document, lib, "doc.md", types.MarkConfig{
+		Features:      []string{"mermaid"},
+		MermaidOutput: "jpeg",
+		MermaidScale:  1,
+	})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "mermaid-output")
+	assert.Contains(t, err.Error(), "jpeg")
+}

--- a/mermaid/mermaid.go
+++ b/mermaid/mermaid.go
@@ -37,6 +37,24 @@ var renderTimeout = 120 * time.Second
 // second attempt runs on a new one: see the crash case in renderPNG.
 const renderAttempts = 2
 
+// uncapDiagramWidth stops mermaid.js from drawing a diagram as width="100%"
+// under a max-width style, and has it state the size it actually drew instead.
+//
+// That style is a page's answer to a diagram wider than its column, and a page
+// is not where these end up: the drawing is uploaded as an attachment and shown
+// at the size mark asks for, which the cap then silently overrides. It also
+// leaves the file with no width or height of its own, so the size has to be
+// recovered from the viewBox.
+//
+// useMaxWidth is set for each kind of diagram separately -- twenty-seven of
+// them at the time of writing, and more with every mermaid release -- so the
+// list is taken from mermaid's own defaults rather than written out here, where
+// it would silently go stale.
+const uncapDiagramWidth = `mermaid.initialize(Object.assign({startOnLoad: false},
+	Object.fromEntries(Object.entries(mermaid.mermaidAPI.defaultConfig)
+		.filter(([, section]) => section && typeof section === "object" && "useMaxWidth" in section)
+		.map(([name]) => [name, {useMaxWidth: false}]))))`
+
 func getMermaidEngine() (*mermaid.RenderEngine, error) {
 	mermaidMutex.Lock()
 	defer mermaidMutex.Unlock()
@@ -55,7 +73,7 @@ func getMermaidEngine() (*mermaid.RenderEngine, error) {
 	// startup, so it deliberately carries no deadline: mermaid.go bounds loading
 	// the embedded bundle with DefaultStartupTimeout by itself, whereas a
 	// deadline here would close the browser mid-run.
-	engine, err := mermaid.NewRenderEngine(context.Background(), nil, chrome.AllocatorOptions()...)
+	engine, err := mermaid.NewRenderEngine(context.Background(), []string{uncapDiagramWidth}, chrome.AllocatorOptions()...)
 	if err != nil {
 		return nil, err
 	}
@@ -223,18 +241,18 @@ func ProcessMermaidLocally(title string, mermaidDiagram []byte, scale float64) (
 // ProcessMermaidSVG publishes a diagram as the SVG it was drawn as: one file at
 // every zoom, and text that stays text. MermaidScale has nothing to multiply
 // here and does not apply.
-func ProcessMermaidSVG(title string, mermaidDiagram []byte) (attachment.Attachment, error) {
-	return processMermaidSVG(title, mermaidDiagram, false)
+func ProcessMermaidSVG(title string, mermaidDiagram []byte, scale float64) (attachment.Attachment, error) {
+	return processMermaidSVG(title, mermaidDiagram, false, scale)
 }
 
 // ProcessMermaidWithBundle does the same and keeps the diagram's source inside
 // the SVG, in its <desc> element, so that what was published can be opened and
 // edited again without the document it came from.
-func ProcessMermaidWithBundle(title string, mermaidDiagram []byte) (attachment.Attachment, error) {
-	return processMermaidSVG(title, mermaidDiagram, true)
+func ProcessMermaidWithBundle(title string, mermaidDiagram []byte, scale float64) (attachment.Attachment, error) {
+	return processMermaidSVG(title, mermaidDiagram, true, scale)
 }
 
-func processMermaidSVG(title string, mermaidDiagram []byte, bundle bool) (attachment.Attachment, error) {
+func processMermaidSVG(title string, mermaidDiagram []byte, bundle bool, scale float64) (attachment.Attachment, error) {
 	log.Debug().Msgf("Rendering SVG (bundle=%v): %q", bundle, title)
 
 	svg, err := renderSVG(title, string(mermaidDiagram), bundle)
@@ -261,7 +279,14 @@ func processMermaidSVG(title string, mermaidDiagram []byte, bundle bool) (attach
 		title = checkSum
 	}
 
+	// The scale multiplies the size the page shows the diagram at, not anything
+	// in the file: an SVG is the same drawing however large it is displayed,
+	// which is why the scale is no part of the checksum above.
 	width, height := extractSVGDimensions(svg)
+	if scale > 0 {
+		width *= scale
+		height *= scale
+	}
 
 	return attachment.Attachment{
 		ID:        "",
@@ -270,8 +295,8 @@ func processMermaidSVG(title string, mermaidDiagram []byte, bundle bool) (attach
 		FileBytes: []byte(svg),
 		Checksum:  checkSum,
 		Replace:   title,
-		Width:     width,
-		Height:    height,
+		Width:     pixels(width),
+		Height:    pixels(height),
 	}, nil
 }
 
@@ -290,7 +315,7 @@ func boolByte(b bool) byte {
 // fallback for either of them -- mermaid draws a diagram wide enough to need
 // one as width="100%", which is not a number of pixels and would otherwise be
 // read as 100 of them, laying out a wide diagram as a narrow one.
-func extractSVGDimensions(svg string) (width, height string) {
+func extractSVGDimensions(svg string) (width, height float64) {
 	var attrWidth, attrHeight, attrViewBox string
 
 	decoder := xml.NewDecoder(strings.NewReader(svg))
@@ -323,15 +348,17 @@ func extractSVGDimensions(svg string) (width, height string) {
 	width = absoluteLength(attrWidth)
 	height = absoluteLength(attrHeight)
 
-	// "minX minY width height", separated by whitespace or commas.
-	if (width == "" || height == "") && attrViewBox != "" {
+	// "minX minY width height", separated by whitespace or commas. Kept as the
+	// fallback even though mermaid now states a width and a height of its own:
+	// a diagram rendered before that, or by anything else, still may not.
+	if (width == 0 || height == 0) && attrViewBox != "" {
 		fields := strings.Fields(strings.ReplaceAll(attrViewBox, ",", " "))
 		if len(fields) == 4 {
-			if width == "" {
+			if width == 0 {
 				width = absoluteLength(fields[2])
 			}
 
-			if height == "" {
+			if height == 0 {
 				height = absoluteLength(fields[3])
 			}
 		}
@@ -344,24 +371,36 @@ func extractSVGDimensions(svg string) (width, height string) {
 // with px -- and returns it rounded, or "" for anything else. A relative unit
 // (%, em, rem, vw, vh) is not a size on its own, so it is reported as unknown
 // rather than as the number in front of it.
-func absoluteLength(value string) string {
+func absoluteLength(value string) float64 {
 	value = strings.TrimSpace(value)
 	if value == "" {
-		return ""
+		return 0
 	}
 
 	if suffix := strings.TrimSuffix(value, "px"); suffix != value {
 		value = strings.TrimSpace(suffix)
 	} else if last := value[len(value)-1]; last < '0' || last > '9' {
+		return 0
+	}
+
+	length, err := strconv.ParseFloat(value, 64)
+	if err != nil || math.IsNaN(length) || math.IsInf(length, 0) {
+		return 0
+	}
+
+	return length
+}
+
+// pixels renders a length as the whole number of them an attachment is measured
+// in, or "" for a length that was never known. Rounded once, after the scale
+// has been applied, since rounding before it would scale a number that had
+// already lost the fraction.
+func pixels(length float64) string {
+	if length == 0 {
 		return ""
 	}
 
-	pixels, err := strconv.ParseFloat(value, 64)
-	if err != nil || math.IsNaN(pixels) || math.IsInf(pixels, 0) {
-		return ""
-	}
-
-	return strconv.Itoa(int(math.Round(pixels)))
+	return strconv.Itoa(int(math.Round(length)))
 }
 
 func Cleanup() {

--- a/mermaid/mermaid_test.go
+++ b/mermaid/mermaid_test.go
@@ -1,6 +1,7 @@
 package mermaid
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"fmt"
@@ -110,7 +111,7 @@ func TestRenderTimeoutKeepsEngine(t *testing.T) {
 // TestProcessMermaidSVG covers the other thing a diagram can be published as:
 // the drawing itself rather than a picture of it.
 func TestProcessMermaidSVG(t *testing.T) {
-	got, err := ProcessMermaidSVG("svgtest", []byte("graph TD;\n A-->B;"))
+	got, err := ProcessMermaidSVG("svgtest", []byte("graph TD;\n A-->B;"), 1.0)
 	require.NoError(t, err)
 
 	assert.Equal(t, "svgtest.svg", got.Filename)
@@ -125,7 +126,7 @@ func TestProcessMermaidSVG(t *testing.T) {
 // diagram's own source kept in it, so that what was published can be opened and
 // edited again without the document it came from.
 func TestProcessMermaidWithBundle(t *testing.T) {
-	got, err := ProcessMermaidWithBundle("bundletest", []byte("graph TD;\n A-->B;"))
+	got, err := ProcessMermaidWithBundle("bundletest", []byte("graph TD;\n A-->B;"), 1.0)
 	require.NoError(t, err)
 
 	assert.Equal(t, "bundletest.svg", got.Filename)
@@ -145,80 +146,84 @@ func TestProcessMermaidWithBundle(t *testing.T) {
 func TestSVGChecksumsDifferByBundle(t *testing.T) {
 	diagram := []byte("graph TD;\n A-->B;")
 
-	plain, err := ProcessMermaidSVG("chk", diagram)
+	plain, err := ProcessMermaidSVG("chk", diagram, 1.0)
 	require.NoError(t, err)
 
-	bundled, err := ProcessMermaidWithBundle("chk", diagram)
+	bundled, err := ProcessMermaidWithBundle("chk", diagram, 1.0)
 	require.NoError(t, err)
 
 	assert.NotEqual(t, plain.Checksum, bundled.Checksum)
 }
 
 // TestExtractSVGDimensions covers the sizes an SVG can state, and the one it
-// cannot: mermaid draws a diagram too wide for the page as width="100%", which
-// is not a number of pixels. Read as 100 of them, a wide diagram is laid out as
-// a narrow one, so anything that is not an absolute length falls back to the
-// viewBox.
+// cannot: a diagram drawn as width="100%" states no number of pixels at all.
+// Read as 100 of them, a wide diagram is laid out as a narrow one, so anything
+// that is not an absolute length falls back to the viewBox. mermaid is asked
+// not to draw that way any more, but a diagram rendered before that, or by
+// anything else, still may.
 func TestExtractSVGDimensions(t *testing.T) {
 	tests := []struct {
 		name   string
 		svg    string
-		width  string
-		height string
+		width  float64
+		height float64
 	}{
 		{
 			name:   "width and height attributes",
 			svg:    `<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200"></svg>`,
-			width:  "300",
-			height: "200",
+			width:  300,
+			height: 200,
 		},
 		{
 			name:   "px is a number of pixels like any other",
 			svg:    `<svg xmlns="http://www.w3.org/2000/svg" width="450px" height="300px"></svg>`,
-			width:  "450",
-			height: "300",
+			width:  450,
+			height: 300,
 		},
 		{
-			name:   "a fraction is rounded, since a size in pixels is whole",
+			// Reported as stated. Rounding happens once, after the scale
+			// has been applied, since rounding first would scale a number
+			// that had already lost its fraction.
+			name:   "a fraction is not rounded here",
 			svg:    `<svg xmlns="http://www.w3.org/2000/svg" width="85.4375" height="42.5"></svg>`,
-			width:  "85",
-			height: "43",
+			width:  85.4375,
+			height: 42.5,
 		},
 		{
 			name:   "no width or height at all falls back to the viewBox",
 			svg:    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480"></svg>`,
-			width:  "640",
-			height: "480",
+			width:  640,
+			height: 480,
 		},
 		{
 			name:   "and so does whichever of the two is missing",
 			svg:    `<svg xmlns="http://www.w3.org/2000/svg" width="320" viewBox="0 0 640 480"></svg>`,
-			width:  "320",
-			height: "480",
+			width:  320,
+			height: 480,
 		},
 		{
 			name:   "a percentage is not a size",
 			svg:    `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 800 600"></svg>`,
-			width:  "800",
-			height: "600",
+			width:  800,
+			height: 600,
 		},
 		{
 			name:   "nor is a length in em",
 			svg:    `<svg xmlns="http://www.w3.org/2000/svg" width="20em" height="15em" viewBox="0 0 320 240"></svg>`,
-			width:  "320",
-			height: "240",
+			width:  320,
+			height: 240,
 		},
 		{
 			name:   "the viewBox may separate its numbers with commas",
 			svg:    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0,0,640,480"></svg>`,
-			width:  "640",
-			height: "480",
+			width:  640,
+			height: 480,
 		},
 		{
 			name:   "nothing to go on is reported as nothing",
 			svg:    `<svg xmlns="http://www.w3.org/2000/svg"></svg>`,
-			width:  "",
-			height: "",
+			width:  0,
+			height: 0,
 		},
 	}
 
@@ -226,8 +231,8 @@ func TestExtractSVGDimensions(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			width, height := extractSVGDimensions(test.svg)
 
-			assert.Equal(t, test.width, width)
-			assert.Equal(t, test.height, height)
+			assert.InDelta(t, test.width, width, 0.0001)
+			assert.InDelta(t, test.height, height, 0.0001)
 		})
 	}
 }
@@ -297,5 +302,119 @@ func descContent(document string) (string, bool) {
 		}
 
 		return text.String(), true
+	}
+}
+
+// TestSVGStatesItsOwnSizeUncapped covers what mermaid is asked to stop doing.
+//
+// Left alone it draws a diagram as width="100%" under a max-width style, which
+// is a page's answer to a diagram wider than its column. These are not shown on
+// a page: they are uploaded and displayed at the size mark asks for, which the
+// cap then overrides -- and the file states no size of its own for mark to ask
+// with.
+func TestSVGStatesItsOwnSizeUncapped(t *testing.T) {
+	got, err := ProcessMermaidSVG("uncapped", []byte("graph TD;\n A-->B;"), 1.0)
+	require.NoError(t, err)
+
+	// The root element, not the whole file: mermaid ships a stylesheet inside
+	// the drawing, and a max-width in there styles something the diagram
+	// contains rather than capping the diagram itself.
+	root := svgRootElement(t, got.FileBytes)
+	assert.NotContains(t, root, "max-width",
+		"the drawing should carry no cap on how wide it may be shown")
+	assert.NotContains(t, root, `width="100%"`,
+		"and should state a width of its own instead")
+}
+
+// TestSVGIsUncappedForEveryKindOfDiagram is what keeps that true. useMaxWidth is
+// set for each kind of diagram separately, so the configuration is built from
+// mermaid's own defaults rather than a list written here -- and this fails if a
+// mermaid release ever puts a diagram beyond its reach.
+func TestSVGIsUncappedForEveryKindOfDiagram(t *testing.T) {
+	diagrams := map[string]string{
+		"flowchart": "graph TD;\n A-->B;",
+		"sequence":  "sequenceDiagram\n Alice->>Bob: Hi",
+		"pie":       "pie\n \"a\" : 40\n \"b\" : 60",
+		"state":     "stateDiagram-v2\n [*] --> Still",
+		"gantt":     "gantt\n title T\n section S\n A task :a1, 2024-01-01, 30d",
+	}
+
+	for name, source := range diagrams {
+		t.Run(name, func(t *testing.T) {
+			got, err := ProcessMermaidSVG(name, []byte(source), 1.0)
+			require.NoError(t, err)
+
+			assert.NotContains(t, svgRootElement(t, got.FileBytes), "max-width")
+			assertPixelSize(t, got.Width, got.Height)
+		})
+	}
+}
+
+// TestSVGScaleMultipliesWhatThePageShowsAndNotTheFile covers what the scale
+// means for a drawing that is the same at every size: the page shows it larger,
+// the file does not change, and neither does the checksum that decides whether
+// it is uploaded again.
+func TestSVGScaleMultipliesWhatThePageShowsAndNotTheFile(t *testing.T) {
+	diagram := []byte("graph TD;\n A-->B;")
+
+	plain, err := ProcessMermaidSVG("scaled", diagram, 1.0)
+	require.NoError(t, err)
+
+	scaled, err := ProcessMermaidSVG("scaled", diagram, 2.0)
+	require.NoError(t, err)
+
+	assert.Equal(t, plain.Checksum, scaled.Checksum, "the drawing did not change")
+	assert.Equal(t, plain.FileBytes, scaled.FileBytes)
+
+	plainWidth, err := strconv.Atoi(plain.Width)
+	require.NoError(t, err)
+
+	scaledWidth, err := strconv.Atoi(scaled.Width)
+	require.NoError(t, err)
+
+	// Within a pixel of double, and not exactly double, because the drawing is
+	// 85.4375 wide: the scale is applied to that and rounded once, giving 171
+	// rather than the 170 that rounding first would have given.
+	assert.InDelta(t, plainWidth*2, scaledWidth, 1,
+		"the page shows it twice as wide")
+	assert.Greater(t, scaledWidth, plainWidth)
+}
+
+// TestPNGIsUnaffectedByTheUncapping is the safety condition on all of this. Both
+// outputs share one engine and one configuration, and the PNG is a screenshot of
+// the same drawing: whatever the cap is worth for an SVG, it must not move a
+// picture that people are already publishing.
+func TestPNGIsUnaffectedByTheUncapping(t *testing.T) {
+	got, err := ProcessMermaidLocally("png", []byte("graph TD;\n A-->B;"), 1.0)
+	require.NoError(t, err)
+
+	assert.Equal(t, "85", got.Width, "the picture is the size it has always been")
+	assert.Equal(t, "174", got.Height)
+}
+
+// svgRootElement returns the opening <svg ...> tag, which is where a drawing
+// states how large it is and how large it may be shown.
+func svgRootElement(t *testing.T, document []byte) string {
+	t.Helper()
+
+	decoder := xml.NewDecoder(bytes.NewReader(document))
+
+	for {
+		token, err := decoder.Token()
+		require.NoError(t, err, "the attachment should be a well-formed SVG")
+
+		element, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+
+		require.Equal(t, "svg", element.Name.Local, "the root element should be an svg")
+
+		var rendered strings.Builder
+		for _, attr := range element.Attr {
+			fmt.Fprintf(&rendered, " %s=%q", attr.Name.Local, attr.Value)
+		}
+
+		return rendered.String()
 	}
 }

--- a/mermaid/mermaid_test.go
+++ b/mermaid/mermaid_test.go
@@ -12,6 +12,7 @@ import (
 
 	mermaid "github.com/dreampuf/mermaid.go"
 	"github.com/kovetskiy/mark/v16/attachment"
+	"github.com/kovetskiy/mark/v16/chrome"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -384,12 +385,34 @@ func TestSVGScaleMultipliesWhatThePageShowsAndNotTheFile(t *testing.T) {
 // outputs share one engine and one configuration, and the PNG is a screenshot of
 // the same drawing: whatever the cap is worth for an SVG, it must not move a
 // picture that people are already publishing.
+//
+// Rendered both ways and compared, rather than measured against numbers written
+// down here. What a diagram comes out as depends on the fonts the machine has,
+// so a size that is right on one is wrong on another -- and the question is not
+// how large the picture is, it is whether the configuration changed it.
 func TestPNGIsUnaffectedByTheUncapping(t *testing.T) {
-	got, err := ProcessMermaidLocally("png", []byte("graph TD;\n A-->B;"), 1.0)
-	require.NoError(t, err)
+	diagram := "graph TD;\n A-->B;"
 
-	assert.Equal(t, "85", got.Width, "the picture is the size it has always been")
-	assert.Equal(t, "174", got.Height)
+	render := func(t *testing.T, statements []string) ([]byte, *mermaid.BoxModel) {
+		t.Helper()
+
+		engine, err := mermaid.NewRenderEngine(context.Background(), statements, chrome.AllocatorOptions()...)
+		require.NoError(t, err)
+
+		defer engine.Cancel()
+
+		png, box, err := engine.RenderAsScaledPngContext(context.Background(), diagram, 1.0)
+		require.NoError(t, err)
+
+		return png, box
+	}
+
+	before, beforeBox := render(t, nil)
+	after, afterBox := render(t, []string{uncapDiagramWidth})
+
+	assert.Equal(t, beforeBox.Width, afterBox.Width, "the picture is the width it was")
+	assert.Equal(t, beforeBox.Height, afterBox.Height, "and the height")
+	assert.Equal(t, before, after, "and the same bytes altogether")
 }
 
 // svgRootElement returns the opening <svg ...> tag, which is where a drawing

--- a/renderer/fencedcodeblock.go
+++ b/renderer/fencedcodeblock.go
@@ -313,13 +313,26 @@ func (r *ConfluenceFencedCodeBlockRenderer) renderFencedCodeBlock(writer util.Bu
 
 		switch {
 		case r.MarkConfig.MermaidOutput == "svg" && r.MarkConfig.MermaidBundle:
-			att, err = mermaid.ProcessMermaidWithBundle(title, lval)
+			att, err = mermaid.ProcessMermaidWithBundle(title, lval, r.MarkConfig.MermaidScale)
 
 		case r.MarkConfig.MermaidOutput == "svg":
-			att, err = mermaid.ProcessMermaidSVG(title, lval)
+			att, err = mermaid.ProcessMermaidSVG(title, lval, r.MarkConfig.MermaidScale)
+
+		case r.MarkConfig.MermaidOutput == "png", r.MarkConfig.MermaidOutput == "":
+			att, err = mermaid.ProcessMermaidLocally(title, lval, r.MarkConfig.MermaidScale)
 
 		default:
-			att, err = mermaid.ProcessMermaidLocally(title, lval, r.MarkConfig.MermaidScale)
+			// Run checks this, but CompileMarkdown takes a types.MarkConfig
+			// straight from a caller and never passes through it. Publishing a
+			// PNG for a format nobody asked for is the one answer that says
+			// nothing, so it is refused here too -- the same backstop the d2
+			// branch above keeps.
+			line, col := GetLineCol(source, node.Pos())
+
+			return ast.WalkStop, fmt.Errorf(
+				"line %d, col %d: unknown mermaid-output %q: expected png or svg",
+				line, col, r.MarkConfig.MermaidOutput,
+			)
 		}
 
 		if err != nil {

--- a/util/cli_test.go
+++ b/util/cli_test.go
@@ -156,8 +156,10 @@ func TestMermaidOutputFlagValidation(t *testing.T) {
 		assert.Error(t, runWithArgs([]string{"cmd", "--mermaid-output", " svg "}))
 	})
 
-	t.Run("a scale does not apply to an svg", func(t *testing.T) {
-		assert.Error(t, runWithArgs([]string{"cmd", "--mermaid-output", "svg", "--mermaid-scale", "2"}))
+	// The scale applies to both formats now: it multiplies the pixels of a PNG
+	// and the size the page shows an SVG at.
+	t.Run("a scale applies to an svg too", func(t *testing.T) {
+		assert.NoError(t, runWithArgs([]string{"cmd", "--mermaid-output", "svg", "--mermaid-scale", "2"}))
 	})
 
 	t.Run("a bundle needs an svg to go in", func(t *testing.T) {

--- a/util/flags.go
+++ b/util/flags.go
@@ -225,7 +225,7 @@ var Flags = []cli.Flag{
 	&cli.FloatFlag{
 		Name:    "mermaid-scale",
 		Value:   1.0,
-		Usage:   "defines the scaling factor for mermaid PNG renderings; not accepted when mermaid-output is svg.",
+		Usage:   "defines the scaling factor for mermaid renderings: the pixels of a png, and the size the page displays an svg at.",
 		Sources: cli.NewValueSourceChain(cli.EnvVar("MARK_MERMAID_SCALE"), altsrctoml.TOML("mermaid-scale", altsrc.NewStringPtrSourcer(&filename))),
 	},
 	&cli.StringFlag{
@@ -513,21 +513,14 @@ func CheckFlags(context context.Context, command *cli.Command) (context.Context,
 		}
 	}
 
-	// A scale that does nothing and a bundle that goes nowhere are both worth
-	// saying out loud rather than dropping: each was asked for on purpose, and
-	// each silently does not happen.
+	// A bundle that goes nowhere is worth saying out loud rather than dropping:
+	// it was asked for on purpose, and it silently does not happen. Asked of its
+	// value rather than of IsSet, because false is exactly what a bundle nobody
+	// asked for looks like -- so mermaid-bundle = false contradicts a PNG in no
+	// way at all.
 	//
-	// The scale is asked of IsSet, since 1.0 is a scale like any other and
-	// there is nothing else to tell a default from a value somebody chose. The
-	// bundle is asked of its value instead, because false is exactly what a
-	// bundle nobody asked for looks like -- so mermaid-bundle = false, or
-	// --mermaid-bundle=false, contradicts a PNG in no way at all.
-	if mermaidOutput == "svg" && command.IsSet("mermaid-scale") {
-		return context, errors.New(
-			"--mermaid-scale does not apply to --mermaid-output=svg: an SVG is the same drawing at every size",
-		)
-	}
-
+	// The scale is not checked against the format any more: it applies to both,
+	// multiplying the pixels of a PNG and the size the page shows an SVG at.
 	if mermaidOutput == "png" && command.Bool("mermaid-bundle") {
 		return context, errors.New(
 			"--mermaid-bundle needs --mermaid-output=svg: there is nowhere in a PNG to keep the diagram's source",


### PR DESCRIPTION
Follow-up to #769, which added `--mermaid-output=svg` but refused `--mermaid-scale` alongside it. This removes the reason for that refusal.

## The cap

mermaid.js draws a diagram as `width="100%"` under a `max-width` style:

```
<svg id="mermaid" width="100%" style="max-width: 85.4375px;" viewBox="0 0 85.4375 174" ...>
```

That is a page’s answer to a diagram wider than its column, and a page is not where these end up — the drawing is uploaded as an attachment and shown at the size mark asks for, which the cap then silently overrides. It also leaves the file stating no size of its own, so the size has to be recovered from the `viewBox`.

## The fix

`useMaxWidth` is mermaid’s own config for this, and `NewRenderEngine(ctx, statements, ...)` evaluates JS after its `mermaid.initialize` — mark was passing `nil`. With it set, the same diagram comes back as:

```
<svg id="mermaid" width="85.4375" height="174" viewBox="0 0 85.4375 174" ...>
```

No cap, and an explicit size. It is set **per kind of diagram** — 27 of them today, more with every mermaid release — so the configuration is derived from `mermaid.mermaidAPI.defaultConfig` at runtime rather than from a list written in Go that would go stale silently. `TestSVGIsUncappedForEveryKindOfDiagram` renders flowchart, sequence, pie, state and gantt and fails if any comes back capped.

## `--mermaid-scale` now applies to SVG

With a size of its own, the scale has something to multiply, so it applies to both formats: the pixels of a PNG, and the size the page displays an SVG at — the same thing `--d2-scale` does in #719. The refusals in `CheckFlags` and `run()` are removed.

The file is untouched by the scale, which is why it is still no part of the SVG’s checksum and why scaling never causes a re-upload:

```console
$ mark --compile-only --mermaid-output svg --files doc.md
<ac:image ac:original-width="85"  ...><ri:attachment ri:filename="253fd3e4….svg"/></ac:image>

$ mark --compile-only --mermaid-output svg --mermaid-scale 2 --files doc.md
<ac:image ac:original-width="171" ...><ri:attachment ri:filename="253fd3e4….svg"/></ac:image>
```

Same attachment, twice the displayed size.

## Rounding

Dimensions are carried as numbers and rounded once, at the end. Rounding before the scale scales a number that has already lost its fraction: a diagram 85.4375 wide is **171** at double, not 170.

## The PNG is unmoved

Both outputs share one engine and one configuration, and the PNG is a screenshot of the same drawing — so this had to be shown not to disturb it. It renders **byte-identical** at scale 1 and 2 (same sha256 before and after the change), and `TestPNGIsUnaffectedByTheUncapping` pins the size it has always reported.

`go build ./...`, the full `go test ./...`, `golangci-lint run ./...` and `markdownlint` are clean.

Note: #719 touches the same dimension-reading code, so whichever of the two lands second will need a rebase.