### PR TITLE
feat(report): annotate a warned-about link against the file it is in

### DIFF
--- a/README.md
+++ b/README.md
@@ -1177,6 +1177,18 @@ Pages still publish exactly as they would have. It is a separate flag from
 the run at the end: use `--check-links-warn-only` to not fail at all, and
 `--continue-on-error` to attempt every file before failing.
 
+With `--output-format github` each warning is annotated against the file and the
+line-less document it came from, so it appears in the pull request rather than
+only in the build log:
+
+```console
+::notice file=docs/doc.md::published "Doc" to https://confluence.example.com/display/DOCS/1003
+::warning file=docs/doc.md::link "guide" does not resolve: it is a directory, not a document
+```
+
+Without the flag the same link fails the run and is annotated as an `::error`
+instead.
+
 ### Upload and included inline images
 
 ```markdown

--- a/mark.go
+++ b/mark.go
@@ -976,7 +976,11 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		return nil, nil, fmt.Errorf("unable to compile markdown: %w", err)
 	}
 
-	if err := reportBrokenLinks(resolver.Broken(), file, config.CheckLinksWarnOnly); err != nil {
+	// Kept for the report as well as the log. Reaching this line with any of
+	// them means the run was told to warn rather than fail, since otherwise
+	// reportBrokenLinks has already ended it.
+	brokenLinks := resolver.Broken()
+	if err := reportBrokenLinks(brokenLinks, file, config.CheckLinksWarnOnly); err != nil {
 		return nil, nil, err
 	}
 
@@ -1087,6 +1091,7 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		File: file, Status: status,
 		Space: spaceOf(meta), Title: target.Title,
 		PageID: target.ID, URL: api.BaseURL + target.Links.Full,
+		Warnings: brokenLinks,
 	})
 
 	if shouldUpdatePage {

--- a/mark_checklinks_test.go
+++ b/mark_checklinks_test.go
@@ -1,6 +1,7 @@
 package mark
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -259,4 +260,64 @@ func TestCheckLinksWarnOnlyRequiresCheckLinks(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--check-links")
+}
+
+// TestCheckLinksWarnOnlyIsAnnotated covers what --check-links-warn-only is for
+// in CI: told about a link that does not resolve, without the run failing.
+//
+// The warning has to reach the report and not only the log. A line in the build
+// output is one nobody scrolls to; an annotation appears against the file in the
+// pull request, which is where somebody is already looking.
+func TestCheckLinksWarnOnlyIsAnnotated(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "guide"), 0o755))
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Title: Doc -->\n\nSee [guide](guide).\n")
+
+	var out bytes.Buffer
+
+	err := Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files:              filepath.Join(dir, "doc.md"),
+		CheckLinks:         []string{"internal"},
+		CheckLinksWarnOnly: true,
+		OutputFormat:       "github",
+		Output:             &out,
+	})
+	require.NoError(t, err, "warn-only must not fail the run")
+
+	assert.Contains(t, out.String(), "::notice", "the document still published")
+	assert.Contains(t, out.String(), "::warning", "and the link is still worth saying")
+	assert.Contains(t, out.String(), "it is a directory, not a document")
+}
+
+// TestCheckLinksFailureIsAnnotatedAsAnError is the other half, and the reason
+// the two are told apart: without warn-only the run fails, and the annotation
+// says so rather than being a warning beside a page that never published.
+func TestCheckLinksFailureIsAnnotatedAsAnError(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Title: Doc -->\n\nSee [other](./missing.md).\n")
+
+	var out bytes.Buffer
+
+	err := Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files:        filepath.Join(dir, "doc.md"),
+		CheckLinks:   []string{"internal"},
+		OutputFormat: "github",
+		Output:       &out,
+	})
+	require.Error(t, err)
+
+	assert.Contains(t, out.String(), "::error")
+	assert.NotContains(t, out.String(), "::warning")
 }

--- a/report/report.go
+++ b/report/report.go
@@ -65,6 +65,15 @@ type Page struct {
 	// Reason says why a page was skipped or how it failed, in the words a
 	// person would want to read.
 	Reason string `json:"reason,omitempty"`
+
+	// Warnings are what was wrong with a document that was published anyway --
+	// a link that does not resolve, when the run was told to warn about those
+	// rather than fail on them.
+	//
+	// Kept apart from Reason because they do not say what became of the page:
+	// a document can carry them and still have published perfectly well, which
+	// is the whole reason for warning instead of failing.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // Orphan is a tracked page whose document is gone, and what was done about it.
@@ -199,6 +208,16 @@ func (r *Report) writeGitHub(w io.Writer) error {
 		case StatusPublished:
 			if err := command(w, "notice", page.File,
 				fmt.Sprintf("published %q to %s", page.Title, page.URL)); err != nil {
+				return err
+			}
+		}
+
+		// Whatever became of the document. A warning is worth showing against
+		// a page that published and against one that was left unchanged, which
+		// has no line of its own at all -- the point of it is to be seen in the
+		// diff by somebody who is not reading the build log.
+		for _, warning := range page.Warnings {
+			if err := command(w, "warning", page.File, warning); err != nil {
 				return err
 			}
 		}

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -61,6 +61,74 @@ func TestGitHubAnnotatesTheFile(t *testing.T) {
 	assert.Equal(t, "::warning file=docs/c.md::the document is not synchronized", lines[2])
 }
 
+// TestGitHubAnnotatesAWarningAgainstAPageThatPublished covers a document that
+// was published with something wrong in it, which is what --check-links-warn-only
+// asks for: told about a link that does not resolve, without the run failing.
+//
+// The warning has to be an annotation of its own. Written only to the log it is
+// a line in the build output that nobody scrolls to, which is the opposite of
+// what asking to be warned was for.
+func TestGitHubAnnotatesAWarningAgainstAPageThatPublished(t *testing.T) {
+	r := New()
+	r.AddPage(Page{
+		File: "docs/a.md", Status: StatusPublished, Title: "A", URL: "https://example/x/1",
+		Warnings: []string{`link "guide" does not resolve: it is a directory, not a document`},
+	})
+
+	var out strings.Builder
+	require.NoError(t, r.Write(&out, FormatGitHub))
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.Len(t, lines, 2)
+	assert.Equal(t, `::notice file=docs/a.md::published "A" to https://example/x/1`, lines[0])
+	assert.Equal(t,
+		`::warning file=docs/a.md::link "guide" does not resolve: it is a directory, not a document`,
+		lines[1])
+}
+
+// TestGitHubAnnotatesAWarningOnAPageWithNoLineOfItsOwn is the case that would
+// otherwise disappear entirely: a document nothing was written for, because it
+// had not changed, still carrying a link that does not resolve.
+func TestGitHubAnnotatesAWarningOnAPageWithNoLineOfItsOwn(t *testing.T) {
+	r := New()
+	r.AddPage(Page{
+		File: "docs/a.md", Status: StatusUnchanged, Title: "A",
+		Warnings: []string{"link \"guide\" does not resolve: there is no such file"},
+	})
+
+	var out strings.Builder
+	require.NoError(t, r.Write(&out, FormatGitHub))
+
+	got := strings.TrimSpace(out.String())
+	assert.Equal(t,
+		`::warning file=docs/a.md::link "guide" does not resolve: there is no such file`, got)
+}
+
+// TestJSONCarriesWarnings covers the other machine-readable format, so that
+// what a run warned about can be read without parsing the log.
+func TestJSONCarriesWarnings(t *testing.T) {
+	r := New()
+	r.AddPage(Page{File: "docs/a.md", Status: StatusPublished, Warnings: []string{"a warning"}})
+
+	var out strings.Builder
+	require.NoError(t, r.Write(&out, FormatJSON))
+
+	assert.Contains(t, out.String(), `"warnings"`)
+	assert.Contains(t, out.String(), `"a warning"`)
+}
+
+// TestGitHubSaysNothingExtraWithoutWarnings is the boundary: the field is
+// absent for almost every document, and must add nothing when it is.
+func TestGitHubSaysNothingExtraWithoutWarnings(t *testing.T) {
+	r := New()
+	r.AddPage(Page{File: "docs/a.md", Status: StatusUnchanged, Title: "A"})
+
+	var out strings.Builder
+	require.NoError(t, r.Write(&out, FormatGitHub))
+
+	assert.Empty(t, strings.TrimSpace(out.String()))
+}
+
 // TestGitHubEscapes covers the characters that would otherwise end a command
 // early or start another one.
 func TestGitHubEscapes(t *testing.T) {


### PR DESCRIPTION
With `--check-links --check-links-warn-only --output-format github`, a link that does not resolve produced no annotation at all — the message went only to the log, where GitHub shows it as a line of build output rather than against the file in the pull request.

## Before

```console
# without warn-only: the run fails, and the annotation is useful
::error file=docs/doc.md::1 link does not resolve:%0A  link "guide" does not resolve: it is a directory, not a document

# with warn-only: the link is nowhere in the annotations
::notice file=docs/doc.md::published "Doc" to https://confluence.example.com/display/DOCS/1003
```

## After

```console
::notice file=docs/doc.md::published "Doc" to https://confluence.example.com/display/DOCS/1003
::warning file=docs/doc.md::link "guide" does not resolve: it is a directory, not a document
```

So the combination that is most useful in CI — visible in the diff, does not fail the build — is now available. It was the one combination you could not get.

## Why it did not work

Annotations are written from a document’s *status* (`failed` → `::error`, `skipped` → `::warning`, `published` → `::notice`). A warned-about link deliberately leaves the status alone, because the document really did publish — so `reportBrokenLinks` logged and returned `nil`, and the report never heard about it.

## The change

`report.Page` gains a `Warnings []string`, carried beside the outcome rather than in place of it (`Reason` says what *became* of a page; these do not). `processFile` passes the broken links it already collected. Reaching that point with any of them means the run was told to warn rather than fail, since otherwise `reportBrokenLinks` has already ended it.

In the GitHub format they are commands of their own, emitted whatever the status — including `unchanged`, which has no line of its own, and where a link that does not resolve is no less worth seeing. The JSON format carries them under `"warnings"`. The `url` format is untouched.

26 lines of implementation; the rest is tests and documentation.

## Tests

- `report`: a warning against a published page, against an unchanged page with no line of its own, in JSON, and the boundary — a page with no warnings adds nothing.
- end-to-end: `--check-links-warn-only` publishes and emits both `::notice` and `::warning`; without it the same link is an `::error` and no warning.

`go build ./...`, the full `go test ./...`, `golangci-lint run ./...` and `markdownlint` are clean.