### PR TITLE
test(page): pin what a link to a directory does

### DIFF
--- a/page/link_test.go
+++ b/page/link_test.go
@@ -46,6 +46,78 @@ func TestLinkResolverIgnoresDirectories(t *testing.T) {
 	assert.Empty(t, resolved)
 }
 
+// TestLinkResolverLeavesRootedTargetsAlone covers a link written from the root:
+// [/example](/example).
+//
+// A rooted path is not a path in this repository. It is either somewhere on the
+// site the pages are published to, or one an attachment has already claimed,
+// and neither is mark's to follow -- so the link is left exactly as written
+// without anything on disk being consulted at all.
+//
+// Which is why a directory is no different from a file here, and both are no
+// different from nothing: the resolver never looks. Written down because the
+// obvious reading of "resolve a link" is that it goes and finds something.
+func TestLinkResolverLeavesRootedTargetsAlone(t *testing.T) {
+	base := t.TempDir()
+
+	// Everything a rooted target could name, sitting in the base directory so
+	// that a resolver which did look would find it and do something.
+	require.NoError(t, os.Mkdir(filepath.Join(base, "example"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(base, "page.md"),
+		[]byte("<!-- Space: DOCS -->\n<!-- Title: Page -->\n\nBody.\n"), 0o600))
+
+	resolver := &LinkResolver{API: &confluence.API{}, Base: base}
+
+	for _, target := range []string{
+		"/example",
+		"/example/",
+		"/page.md",
+		"/nothing-here",
+		"/example#a-heading",
+	} {
+		resolved, err := resolver.Resolve(target, "")
+		assert.NoError(t, err, "target %q", target)
+		assert.Empty(t, resolved, "target %q should have been left as written", target)
+	}
+}
+
+// TestFindLinkTargetSaysWhichKindOfNothingItFound covers the two ways a
+// relative link can fail to name a document, which are worth telling apart:
+// --check-links reports the reason, and "there is no such file" would send
+// somebody looking for a typo in a path that is perfectly correct.
+func TestFindLinkTargetSaysWhichKindOfNothingItFound(t *testing.T) {
+	base := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(base, "example"), 0o755))
+
+	_, why := findLinkTarget([]string{base}, "example")
+	require.NotNil(t, why)
+	assert.Contains(t, why.reason, "directory")
+
+	_, why = findLinkTarget([]string{base}, "no-such-thing")
+	require.NotNil(t, why)
+	assert.Contains(t, why.reason, "no such file")
+}
+
+// TestFindLinkTargetPrefersAFileInALaterSearchDirectory covers a directory that
+// shares its name with a document somewhere else on the search path.
+//
+// A directory is not an answer, so the search goes on rather than stopping at
+// it: --include-path exists so that a name can be found somewhere other than
+// beside the document, and a directory of that name in the first place looked
+// would otherwise hide the file in the second.
+func TestFindLinkTargetPrefersAFileInALaterSearchDirectory(t *testing.T) {
+	first, second := t.TempDir(), t.TempDir()
+
+	require.NoError(t, os.Mkdir(filepath.Join(first, "shared"), 0o755))
+
+	document := filepath.Join(second, "shared")
+	require.NoError(t, os.WriteFile(document, []byte("Body.\n"), 0o600))
+
+	found, why := findLinkTarget([]string{first, second}, "shared")
+	require.Nil(t, why, "the file in the second directory is the answer")
+	assert.Equal(t, document, found)
+}
+
 func TestLinkResolverIgnoresNonTextFiles(t *testing.T) {
 	base := t.TempDir()
 	// A PNG header is enough for http.DetectContentType.


### PR DESCRIPTION
Tests only — no behaviour change. A link to a directory turns out to be handled correctly already, and none of it was covered.

## What a link to a directory does today

`[example](example)` where `example` is a directory: `findLinkTarget` stats each candidate and skips directories, so the `os.ReadFile` that would fail on one is never reached. The link is left as written and the run succeeds. Under `--check-links internal` it is reported as `it is a directory, not a document`, alongside the other five reasons a relative link cannot become a page (not a text file, no metadata, no title, no such file).

`[/example](/example)` — a rooted path — returns before anything on disk is consulted at all. It is not a path in this repository: it is either somewhere on the site the pages are published to, or a name an attachment has already claimed.

## The tests

- **`TestLinkResolverLeavesRootedTargetsAlone`** — the rooted form, with a real directory *and* a real document sitting in the base directory so that a resolver which did look would find them and do something. Neither is looked at. Worth writing down because the obvious reading of "resolve a link" is that it goes and finds something.
- **`TestFindLinkTargetSaysWhichKindOfNothingItFound`** — "it is a directory" and "there is no such file" are distinct, and `--check-links` prints the reason: the wrong one sends somebody hunting a typo in a path that is perfectly correct.
- **`TestFindLinkTargetPrefersAFileInALaterSearchDirectory`** — a directory does not end the search, so a document of the same name further along `--include-path` is still the answer.

The relative case already had coverage (`TestLinkResolverIgnoresDirectories`, and `a link to a directory fails` in `mark_checklinks_test.go`); the rooted case had none.

## One thing worth noting

A rooted link gets a free pass under `--check-links` while a relative link to a directory is reported, though both emit an href Confluence is equally unlikely to follow. That is left exactly as it is here — this PR only writes down what happens — but it may be worth deciding on separately.

`go test ./page/` and `golangci-lint run ./page/...` are clean.