### PR TITLE
feat(metadata): say so when front matter names a key mark does not read

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ When both formats are present, HTML headers override matching scalar front
 matter values. Repeatable parents, folders, attachments, and labels are
 appended to the values from front matter.
 
+Note that the front matter keys are plural where the HTML headers are singular:
+`attachments`, `parents`, `folders`, `labels` and `properties`. A key mark does
+not read is ignored, and warned about:
+
+```console
+WARNING doc.md: front matter key "attachment" is not read by mark and was ignored
+```
+
+Front matter shared with another tool -- a static site generator's `date` and
+`draft` in the same block -- is reported the same way, since mark cannot tell a
+key meant for something else from one meant for mark and misspelled.
+
 ```markdown
 <!-- Space: <space key> -->
 <!-- Parent: <parent 1> -->

--- a/metadata/frontmatter_unknown_test.go
+++ b/metadata/frontmatter_unknown_test.go
@@ -1,0 +1,138 @@
+package metadata
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// extractWithFrontMatter reads a document and returns whatever was logged while
+// doing it.
+func extractWithFrontMatter(t *testing.T, frontMatter string) (*Meta, string) {
+	t.Helper()
+
+	var logged bytes.Buffer
+
+	restore := log.Logger
+	log.Logger = zerolog.New(&logged)
+
+	t.Cleanup(func() { log.Logger = restore })
+
+	document := "---\nspace: DOCS\ntitle: Doc\n" + frontMatter + "---\n\nBody.\n"
+
+	meta, _, err := ExtractMeta([]byte(document), "", false, false, "doc.md", nil, false, "", true)
+	require.NoError(t, err)
+
+	return meta, logged.String()
+}
+
+// TestFrontMatterWarnsAboutMarksOwnSingularNames covers the mistake mark's own
+// documentation invites: the HTML headers are singular, so somebody who has
+// been writing <!-- Attachment: --> for years writes attachment in front matter
+// and is told nothing at all, by a run that publishes perfectly happily with
+// the attachment missing.
+func TestFrontMatterWarnsAboutMarksOwnSingularNames(t *testing.T) {
+	for _, singular := range []string{"attachment", "parent", "folder", "label"} {
+		t.Run(singular, func(t *testing.T) {
+			meta, logged := extractWithFrontMatter(t, singular+":\n  - something\n")
+
+			assert.Contains(t, logged, singular)
+			assert.Contains(t, logged, "was ignored")
+			assert.Empty(t, meta.Attachments)
+			assert.Empty(t, meta.Labels)
+		})
+	}
+}
+
+// TestFrontMatterWarnsAboutATypo covers a key that is nobody's convention, only
+// fingers.
+func TestFrontMatterWarnsAboutATypo(t *testing.T) {
+	_, logged := extractWithFrontMatter(t, "attachmnets:\n  - a.png\n")
+
+	assert.Contains(t, logged, "attachmnets")
+	assert.Contains(t, logged, "was ignored")
+}
+
+// TestFrontMatterWarnsAboutEveryKeyItDoesNotRead covers the keys that belong to
+// something else -- a static site generator's, sitting in the same block.
+//
+// They are reported too. mark cannot tell a key written for another tool from
+// one written for mark and misspelled, and the second kind is a setting that
+// silently did not happen: the cost of saying so about both is a line per key,
+// where the cost of saying nothing is a document that publishes wrong.
+func TestFrontMatterWarnsAboutEveryKeyItDoesNotRead(t *testing.T) {
+	for _, key := range []string{
+		"date: 2024-01-01\n",
+		"draft: true\n",
+		"weight: 10\n",
+		"description: a page\n",
+		"slug: a-page\n",
+		"author: someone\n",
+		"tags:\n  - one\n",
+		"aliases:\n  - /old/path\n",
+	} {
+		name := key[:strings.IndexByte(key, ':')]
+
+		t.Run(name, func(t *testing.T) {
+			_, logged := extractWithFrontMatter(t, key)
+
+			assert.Contains(t, logged, name)
+			assert.Contains(t, logged, "was ignored")
+		})
+	}
+}
+
+// TestFrontMatterWarnsAboutEveryUnknownKeyOnce covers a document carrying
+// several at once, which is what a shared front matter block looks like.
+func TestFrontMatterWarnsAboutEveryUnknownKeyOnce(t *testing.T) {
+	_, logged := extractWithFrontMatter(t, "date: 2024-01-01\ndraft: true\nweight: 10\n")
+
+	for _, key := range []string{"date", "draft", "weight"} {
+		// The log escapes its quotes, so the key is matched with the words
+		// that follow it rather than by the quoting around it.
+		assert.Equal(t, 1, strings.Count(logged, key+`\" is not read by mark`),
+			"%q should be reported exactly once", key)
+	}
+}
+
+// TestFrontMatterSaysNothingAboutWhatItRead is the boundary the others rest on:
+// a document written correctly, including the spellings that are meant to work.
+func TestFrontMatterSaysNothingAboutWhatItRead(t *testing.T) {
+	meta, logged := extractWithFrontMatter(t,
+		"attachments:\n  - a.png\nimage-align: center\nContent_Appearance: full-width\n")
+
+	assert.Empty(t, logged)
+	assert.Equal(t, []string{"a.png"}, meta.Attachments)
+	assert.Equal(t, "center", meta.ImageAlign)
+}
+
+// TestFrontMatterWarningNamesTheDocument covers the part of the warning that
+// makes it actionable when a run is publishing hundreds of files -- and the
+// caller that has no name to give, since ExtractMeta is reached from a library
+// where a document need not be a file.
+func TestFrontMatterWarningNamesTheDocument(t *testing.T) {
+	_, logged := extractWithFrontMatter(t, "draft: true\n")
+	assert.Contains(t, logged, "doc.md: front matter key")
+
+	var buffer bytes.Buffer
+
+	restore := log.Logger
+	log.Logger = zerolog.New(&buffer)
+
+	t.Cleanup(func() { log.Logger = restore })
+
+	_, _, err := ExtractMeta(
+		[]byte("---\nspace: DOCS\ntitle: Doc\ndraft: true\n---\n\nBody.\n"),
+		"", false, false, "", nil, false, "", true,
+	)
+	require.NoError(t, err)
+
+	assert.Contains(t, buffer.String(), "front matter key")
+	assert.NotContains(t, buffer.String(), `": front matter`,
+		"a document with no name should not be reported as one called \": \"")
+}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -298,6 +299,43 @@ func setContentAppearance(meta *Meta, value string) {
 	}
 }
 
+// normaliseFrontMatterKey is how a key written in a document is matched against
+// the ones mark reads: a title is a Title is a TITLE, and image-align,
+// image_align and imagealign are one setting.
+func normaliseFrontMatterKey(key string) string {
+	key = strings.ToLower(key)
+	key = strings.ReplaceAll(key, "-", "")
+
+	return strings.ReplaceAll(key, "_", "")
+}
+
+// warnAboutUnknownKeys says so about every front matter key that was ignored.
+//
+// Front matter is shared with whatever else reads the file, so some of these
+// belong to somebody else and are meant to be passed over. They are still
+// reported: mark cannot tell a key written for another tool from one written
+// for mark and misspelled, and the second kind is a setting that silently did
+// not happen -- the HTML headers are singular where front matter is plural, so
+// attachment for attachments is a mistake mark's own documentation invites.
+func warnAboutUnknownKeys(keys []string, filename string) {
+	slices.Sort(keys)
+
+	// A caller with nothing to call the document -- ExtractMeta takes the name
+	// for the title and a library caller need not have one -- would otherwise
+	// be told about a key in a file called ": ".
+	where := filename + ": "
+	if filename == "" {
+		where = ""
+	}
+
+	for _, key := range keys {
+		log.Warn().Msgf(
+			"%sfront matter key %q is not read by mark and was ignored",
+			where, key,
+		)
+	}
+}
+
 func stripFrontMatter(data []byte) ([]byte, error) {
 	delimiter, rest, ok := bytes.Cut(data, []byte("\n"))
 	if !ok {
@@ -339,10 +377,10 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 		meta = &Meta{}
 		meta.Type = "page" // Default type
 
+		var unknown []string
+
 		for k, v := range parsed {
-			normKey := strings.ToLower(k)
-			normKey = strings.ReplaceAll(normKey, "-", "")
-			normKey = strings.ReplaceAll(normKey, "_", "")
+			normKey := normaliseFrontMatterKey(k)
 
 			switch normKey {
 			case "parents":
@@ -392,8 +430,13 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 					}
 					meta.Properties[key] = value
 				}
+
+			default:
+				unknown = append(unknown, k)
 			}
 		}
+
+		warnAboutUnknownKeys(unknown, filename)
 
 		// Presence of a non-empty sidebar forces the article layout, regardless of map key iteration order.
 		if meta.Sidebar != "" {


### PR DESCRIPTION
Answering "can attachments be listed in front matter as well?" — they can, under `attachments`, and it is documented. But checking turned up a silent failure worth closing.

## The trap

mark’s HTML headers are **singular** and its front matter keys are **plural**:

```markdown
<!-- Attachment: img/a.png -->     # the header
attachments:                        # the front matter
  - img/a.png
```

A key front matter does not know was dropped without a word, so someone moving from headers to front matter writes `attachment:` and gets a run that publishes perfectly happily with the attachment missing, and nothing anywhere saying why. Same for `parent`, `folder`, `label` and `property`.

## What this does

Warns about every front matter key mark does not read:

```console
WARNING doc.md: front matter key "attachment" is not read by mark and was ignored
WARNING doc.md: front matter key "draft" is not read by mark and was ignored
```

Each key is reported once, in a settled order, and the document is named — except where the caller has no name to give, since `ExtractMeta` is reachable from a library where a document need not be a file.

A key mark *does* read stays silent, including the spellings meant to work: `image-align`, `image_align` and `imagealign` are one setting.

## Keys belonging to another tool

Reported too. Front matter is often shared — a static site generator’s `date`, `draft`, `tags` and `weight` sit in the same block — and nothing here can tell a key written for another tool from one written for mark and misspelled. The second kind is a setting that silently did not happen, so both are worth a line.

That is a deliberate choice rather than an oversight: it means a warning per foreign key on every run. If that turns out to be too noisy in practice, the alternative is to report only keys that resemble one mark reads, which is a smaller change than it sounds.

## Verified

| key | result |
|---|---|
| `attachment`, `parent`, `folder`, `label` | warns |
| `attachmnets` (typo) | warns |
| `date`, `draft`, `tags`, `weight`, `description`, `slug`, `author`, `aliases` | warns |
| `attachments`, `image-align`, `Content_Appearance` | silent, and read |

## Not included

`attachments: img/a.png` written as a scalar rather than a list is also silently dropped — `toStringSlice` returns nil for anything that is not a YAML list — and the same is true of `parents`, `folders` and `labels`. So the singular-key mistake has a twin: the right key written the wrong shape. That is a behaviour change rather than a diagnostic, so it is not in here. Happy to do it separately.

`go build ./...`, `golangci-lint` and `markdownlint` are clean; `metadata`, `page` and `report` pass. The full `go test ./...` on this machine is unreliable for reasons unrelated to this change — several packages each launch Chrome concurrently and time each other out; master fails the same way.