### PR TITLE
fix(includes): a document may not include a file it may not read

### DIFF
--- a/attachment/attachment.go
+++ b/attachment/attachment.go
@@ -227,7 +227,9 @@ func prepareAttachments(opener vfs.Opener, base string, replacements []string) (
 
 // ErrOutsideProject reports an attachment that resolves outside the directories
 // mark is publishing from.
-var ErrOutsideProject = errors.New("attachment is outside the project")
+// Named for the boundary rather than for attachments: an include is held to it
+// too, and a file a document may not read is a file a document may not read.
+var ErrOutsideProject = errors.New("outside the project")
 
 // checkAttachmentPath refuses an attachment that resolves outside both the
 // document's own directory and the directory mark is running in.

--- a/includes/containment_test.go
+++ b/includes/containment_test.go
@@ -1,0 +1,116 @@
+package includes
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"text/template"
+
+	"github.com/kovetskiy/mark/v16/attachment"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIncludeOutsideTheProjectIsRefused covers a directive naming a file the
+// document has no business reading.
+//
+// An include becomes page content, so a path that climbs out of the repository
+// publishes whatever it lands on -- and the same path written as an image has
+// always been refused, which makes this the asymmetry rather than the decision.
+func TestIncludeOutsideTheProjectIsRefused(t *testing.T) {
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	require.NoError(t, os.WriteFile(secret, []byte("a private thing\n"), 0o600))
+
+	// Its own directory, so that neither it nor the working directory contains
+	// the file being reached for.
+	project := t.TempDir()
+	document := filepath.Join(project, "docs")
+	require.NoError(t, os.Mkdir(document, 0o755))
+
+	t.Chdir(project)
+
+	// Written as a climb rather than as an absolute path, which is the form
+	// that reaches anything: a directive naming "/etc/hostname" is joined to
+	// the document's directory and lands nowhere, while "../../.." is cleaned
+	// on the way and lands exactly where it says.
+	reference := filepath.Join("..", "..", filepath.Base(outside), "secret.txt")
+
+	_, _, _, err := ProcessIncludes(
+		document, "", []byte("<!-- Include: "+reference+" -->"), template.New("test"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, attachment.ErrOutsideProject)
+}
+
+// TestIncludeOfAnAbsolutePathFindsNothing pins the other form, which was never
+// a way out: it is joined to the document's directory like any other name, so
+// it names a file below the document that does not exist.
+func TestIncludeOfAnAbsolutePathFindsNothing(t *testing.T) {
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	require.NoError(t, os.WriteFile(secret, []byte("a private thing\n"), 0o600))
+
+	project := t.TempDir()
+	t.Chdir(project)
+
+	_, _, _, err := ProcessIncludes(
+		project, "", []byte("<!-- Include: "+secret+" -->"), template.New("test"))
+	require.Error(t, err)
+
+	assert.NotContains(t, err.Error(), "a private thing")
+}
+
+// TestIncludeBesideTheDocumentStillWorks is the ordinary case, and the boundary
+// the refusal above rests on.
+func TestIncludeBesideTheDocumentStillWorks(t *testing.T) {
+	project := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(project, "fragment.md"), []byte("included\n"), 0o600))
+
+	_, output, _, err := ProcessIncludes(
+		project, "", []byte("<!-- Include: fragment.md -->"), template.New("test"))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(output), "included")
+}
+
+// TestIncludeUnderTheIncludePathStillWorks covers the directory the operator
+// chose rather than the document: --include-path is a permitted root because
+// somebody publishing the run named it, which is the whole of what it is for.
+func TestIncludeUnderTheIncludePathStillWorks(t *testing.T) {
+	shared := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(shared, "shared.md"), []byte("from the shared directory\n"), 0o600))
+
+	project := t.TempDir()
+	t.Chdir(project)
+
+	_, output, _, err := ProcessIncludes(
+		project, shared, []byte("<!-- Include: shared.md -->"), template.New("test"))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(output), "from the shared directory")
+}
+
+// TestIncludePathDoesNotOpenTheWholeDisk is its boundary: naming a directory to
+// look in does not make everything above it readable too.
+func TestIncludePathDoesNotOpenTheWholeDisk(t *testing.T) {
+	outside := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outside, "secret.txt"), []byte("a private thing\n"), 0o600))
+
+	shared := t.TempDir()
+
+	project := t.TempDir()
+	document := filepath.Join(project, "docs")
+	require.NoError(t, os.Mkdir(document, 0o755))
+
+	t.Chdir(project)
+
+	reference := filepath.Join("..", "..", filepath.Base(outside), "secret.txt")
+
+	_, _, _, err := ProcessIncludes(
+		document, shared, []byte("<!-- Include: "+reference+" -->"), template.New("test"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, attachment.ErrOutsideProject)
+}

--- a/includes/templates.go
+++ b/includes/templates.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/kovetskiy/mark/v16/attachment"
 	"github.com/kovetskiy/mark/v16/metadata"
 	"github.com/rs/zerolog/log"
 	"go.yaml.in/yaml/v3"
@@ -135,6 +136,37 @@ func resolveTemplatePath(base, includePath, path string) string {
 	return absolute(candidate)
 }
 
+// allowedTemplatePath reports whether a document may include the file it named.
+//
+// The document's own directory, or the one mark is running in -- which for a
+// run at the root of a repository is the repository -- and --include-path
+// besides. That directory is a permitted root because the operator chose it and
+// the document did not: it is the one place a document is invited to reach that
+// is not its own.
+func allowedTemplatePath(base, includePath, resolved string) error {
+	err := attachment.CheckReadable(base, resolved)
+	if err == nil {
+		return nil
+	}
+
+	if includePath != "" && attachment.CheckReadable(includePath, resolved) == nil {
+		return nil
+	}
+
+	// Reported in the words of what was asked for. The check is the one
+	// attachments use and says so in its own message, which names an attachment
+	// nobody wrote: what this document wrote was an include.
+	where := fmt.Sprintf("%q", base)
+	if includePath != "" {
+		where = fmt.Sprintf("%q, %q", base, includePath)
+	}
+
+	return fmt.Errorf(
+		"%w: %s is outside %s and the directory mark is running in, so it is not this document's to include",
+		attachment.ErrOutsideProject, resolved, where,
+	)
+}
+
 // absolute makes a path the key of exactly one file, whatever directory the
 // run was started from. A path that cannot be made absolute is returned as it
 // was: it is still a better key than the bare name, and the read that follows
@@ -183,6 +215,14 @@ func LoadTemplate(
 
 	if template := templates.Lookup(cacheName); template != nil {
 		return template, nil
+	}
+
+	// Held to the boundary an attachment is held to, and for the same reason.
+	// A directive names a file and the file becomes page content, so
+	// "../../../../etc/hostname" publishes it -- while the same path written as
+	// an image is refused, which is the asymmetry rather than the decision.
+	if err := allowedTemplatePath(base, includePath, resolved); err != nil {
+		return nil, err
 	}
 
 	body, err := os.ReadFile(resolved)


### PR DESCRIPTION
Security fix. Reported in an audit, reproduced here before fixing.

## The defect

`<!-- Include: -->` resolved through a bare `filepath.Join` with no containment check. `Join` cleans as it goes, so a climbing path leaves the repository and lands exactly where it says — and what it lands on becomes page content. No flags, default configuration:

```console
$ cat docs/deep.md
<!-- Space: TEST --><!-- Title: Deep -->
# Deep
<!-- Include: ../../../../../../../../etc/hostname -->

$ mark --compile-only --files deep.md
<h1 id="Deep">Deep</h1>
<p>abel</p>              # the contents of /etc/hostname
```

`<!-- Macro: --><!-- Template: -->` reads through the same loader (`macro.go:354` → `includes.LoadTemplate`) and so reached the same files. The fix is inside the loader, so it covers both.

## Why a defect and not a decision

The same path written as an image has always been refused, and the check that refuses it spells out this exact threat model — *"a contributor could point an image at `../../../../home/runner/.aws/credentials`"*. Includes are a reader like any other, and were the one that never asked.

## The fix

`attachment.CheckReadable` before the read, against the boundary attachments already use: the document’s own directory, or the one mark is running in — which for a run at the root of a repository is the repository. Symlinks are resolved on both sides, which that check already handled.

`--include-path` is a permitted root besides, because the operator chose that directory and the document did not. Naming it does not open what is above it.

The `ErrOutsideProject` sentinel loses the word "attachment", since it is no longer only about those. Nothing asserts on its text.

## One thing the reproduction corrected

Not every form was a way out. An **absolute** include is joined to the document’s directory like any other name (`Join("/docs", "/etc/passwd")` → `/docs/etc/passwd`) and lands below it, where nothing is — so it never resolved at all. My first test used that form and failed for the wrong reason. The climbing form is the one that reaches anything; both are now pinned, so a later change to path resolution cannot quietly turn the absolute one into a way out.

## Tests

A climb out of the project (refused), an absolute path (finds nothing), a file beside the document (works), a file under `--include-path` (works), and `--include-path` not opening what is above it.

`golangci-lint` clean; `includes`, `attachment`, `macro` and `markdown` pass.