### PR TITLE
fix: --check-links reports under --compile-only and --dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1125,6 +1125,13 @@ ERR unable to compile markdown: link "./architecure.md" does not resolve:
     there is no such file
 ```
 
+It reports in every mode, including `--compile-only` and `--dry-run`, so a pull
+request gate can check links without Confluence credentials:
+
+```bash
+mark --compile-only --check-links all --files "docs/**/*.md"
+```
+
 | Value | Checks |
 | --- | --- |
 | `internal` | relative links to other Markdown files in the repository |

--- a/mark.go
+++ b/mark.go
@@ -808,6 +808,16 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 			return nil, nil, err
 		}
 
+		// Said here too, and for the same reason the check above is. The links
+		// were resolved while the document was walked either way; this branch
+		// simply returned without ever reading what that found, so a run told
+		// to check them reported nothing and exited 0 -- on precisely the
+		// credential-free invocation --compile-only exists for, and the one a
+		// pull request gate is most likely to use.
+		if err := reportBrokenLinks(resolver.Broken(), file, config.CheckLinksWarnOnly); err != nil {
+			return nil, nil, err
+		}
+
 		return nil, nil, nil
 	}
 

--- a/mark_checklinks_test.go
+++ b/mark_checklinks_test.go
@@ -321,3 +321,83 @@ func TestCheckLinksFailureIsAnnotatedAsAnError(t *testing.T) {
 	assert.Contains(t, out.String(), "::error")
 	assert.NotContains(t, out.String(), "::warning")
 }
+
+// TestCheckLinksUnderCompileOnly covers the invocation the flag is most likely
+// to be used with, and the one where it did nothing at all.
+//
+// --compile-only is what validates documents in CI without Confluence
+// credentials, so a pull request gate reading "mark --compile-only
+// --check-links all" is the ordinary way to ask for this. The links were
+// resolved either way; the branch simply returned before anything read what
+// that found, and the run said nothing and exited 0.
+func TestCheckLinksUnderCompileOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Title: Doc -->\n\nSee [other](./missing.md).\n")
+
+	err := Run(Config{
+		BaseURL: "https://confluence.example.invalid", Username: "user", Password: "token",
+		Files:       filepath.Join(dir, "doc.md"),
+		CompileOnly: true,
+		CheckLinks:  []string{"internal"},
+		Output:      io.Discard,
+	})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "./missing.md")
+	assert.Contains(t, err.Error(), "there is no such file")
+}
+
+// TestCheckLinksUnderDryRunReportsToo covers the other half of the same branch.
+func TestCheckLinksUnderDryRunReportsToo(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Title: Doc -->\n\nSee [other](./missing.md).\n")
+
+	err := Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files:      filepath.Join(dir, "doc.md"),
+		DryRun:     true,
+		CheckLinks: []string{"internal"},
+		Output:     io.Discard,
+	})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "./missing.md")
+}
+
+// TestCompileOnlyWithoutCheckLinksIsSilent is the boundary: a broken link is
+// only an error when the run asked about links, whichever mode it is in.
+func TestCompileOnlyWithoutCheckLinksIsSilent(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Title: Doc -->\n\nSee [other](./missing.md).\n")
+
+	require.NoError(t, Run(Config{
+		BaseURL: "https://confluence.example.invalid", Username: "user", Password: "token",
+		Files:       filepath.Join(dir, "doc.md"),
+		CompileOnly: true,
+		Output:      io.Discard,
+	}))
+}
+
+// TestCompileOnlyWarnOnlyDoesNotFail covers the third combination, since
+// warn-only is how a team adopts the check before the build starts failing.
+func TestCompileOnlyWarnOnlyDoesNotFail(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Title: Doc -->\n\nSee [other](./missing.md).\n")
+
+	require.NoError(t, Run(Config{
+		BaseURL: "https://confluence.example.invalid", Username: "user", Password: "token",
+		Files:              filepath.Join(dir, "doc.md"),
+		CompileOnly:        true,
+		CheckLinks:         []string{"internal"},
+		CheckLinksWarnOnly: true,
+		Output:             io.Discard,
+	}))
+}


### PR DESCRIPTION
Reported in an audit, reproduced before fixing.

## The defect

The compile-and-dry-run branch returns before anything reads what the link resolver found, so a run told to check links checked them and discarded the answer:

```console
$ mark --compile-only --check-links internal --files "docs/*.md"
INFO processing docs/b.md
<h1 id="B">B</h1>
<p>See <a href="./architecure.md">Arch</a> and <a href="./missing.md">Gone</a>.</p>
EXIT=0
```

Two links leading nowhere, nothing said, exit 0.

## Why this combination matters

`--compile-only` exists to validate documents in CI without Confluence credentials — the code says so in as many words. That makes `mark --compile-only --check-links all` the natural shape of a pull request gate, and it is exactly the invocation where the check did nothing. A team using it believes their links are checked. None are.

The README’s link-checking section did not mention the exclusion either, because it was not intended.

## The fix

The links were resolved either way, by the same walk that renders the document; only the reporting was missing. `reportBrokenLinks` now runs on that path too, beside the well-formedness check that is there for the same reason.

After:

```console
$ mark --compile-only --check-links internal --files "docs/*.md"
FATAL 2 links do not resolve:
  link "./architecure.md" does not resolve: there is no such file
  link "./missing.md" does not resolve: there is no such file
EXIT=1
```

Verified across the combinations: broken links exit 1; a clean document exits 0; `--check-links-warn-only` exits 0; and without `--check-links` nothing is reported at all.

## Tests

`--compile-only` and `--dry-run` each report, plus the two boundaries — no `--check-links` stays silent, and warn-only does not fail. The existing tests all covered the publish path, which is why this survived.

Also documents the combination in the README’s link-checking section.

`go build ./...`, the full `go test ./...`, `golangci-lint` and `markdownlint` are clean.