### PR TITLE
fix(page): a dry run does not move a folder

### DIFF
--- a/page/ancestry.go
+++ b/page/ancestry.go
@@ -63,8 +63,16 @@ func cachedFolderID(space, contextID, title string) (string, bool) {
 	return id, ok
 }
 
+// resolveFolder finds the folder a title names, and may move one that an
+// earlier sync left at the space root.
+//
+// It takes dryRun because that move is a write, and it happens while the
+// ancestry is still being worked out -- long before the guard that decides
+// whether this run writes anything. A run that promises to write nothing was
+// reparenting a folder, and every page inside it with it.
 func resolveFolder(
 	api *confluence.API,
+	dryRun bool,
 	space, title, underID string,
 	anchorPageID *string,
 ) (*confluence.FolderInfo, error) {
@@ -96,6 +104,17 @@ func resolveFolder(
 			return nil, nil
 		}
 		if folder.ParentID != *anchorPageID {
+			if dryRun {
+				// Reported rather than done, and the folder is given back as it
+				// actually is: saying where it would end up is the dry run's
+				// job, and moving it there is not.
+				log.Info().Msgf(
+					"folder %q would be moved under the page named by --parents", title,
+				)
+
+				return folder, nil
+			}
+
 			if err := api.MoveContentAppend(folder.ID, *anchorPageID); err != nil {
 				return nil, fmt.Errorf("move folder %q under MARK_PARENTS page: %w", title, err)
 			}
@@ -207,7 +226,7 @@ func EnsureFolderAncestry(
 		if id, ok := cachedFolderID(space, underID, title); ok {
 			folder, err = api.GetFolderByID(id)
 		} else {
-			folder, err = resolveFolder(api, space, title, underID, anchorPageID)
+			folder, err = resolveFolder(api, dryRun, space, title, underID, anchorPageID)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("error finding folder with title %q: %w", title, err)
@@ -326,7 +345,7 @@ func EnsureFolderAncestry(
 				if id, ok := cachedFolderID(space, underID, title); ok {
 					folder, err = api.GetFolderByID(id)
 				} else {
-					folder, err = resolveFolder(api, space, title, underID, anchorPageID)
+					folder, err = resolveFolder(api, dryRun, space, title, underID, anchorPageID)
 				}
 				if err != nil || folder == nil {
 					return nil, fmt.Errorf(

--- a/page/dryrun_folder_test.go
+++ b/page/dryrun_folder_test.go
@@ -1,0 +1,77 @@
+package page_test
+
+import (
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/page"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDryRunDoesNotMoveAFolder covers the one write a dry run was still making.
+//
+// A folder left at the space root by an earlier sync is moved under the page
+// --parents names. That happens while the ancestry is being worked out, which
+// is long before the guard deciding whether this run writes anything -- so the
+// mode that promises to write nothing reparented a folder, and every page
+// inside it went with it.
+func TestDryRunDoesNotMoveAFolder(t *testing.T) {
+	page.ResetFolderCache()
+
+	api, server := newAPI(t)
+	anchor := server.AddPage("DOCS", "Anchor", "page", "")
+
+	// At the space root, where an earlier sync left it: no page or folder
+	// parent, which is what makes it a candidate for the move.
+	server.AddFolder("DOCS", "Manuals", "", "")
+
+	var moved atomic.Bool
+
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if strings.Contains(r.URL.Path, "/move/") {
+			moved.Store(true)
+		}
+
+		return 0, "", false
+	})
+
+	_, err := page.EnsureFolderAncestry(true, api, "DOCS", []string{"Manuals"}, &anchor.ID, nil)
+	require.NoError(t, err)
+
+	assert.False(t, moved.Load(), "a dry run must not move anything")
+
+	folders := server.Folders()
+	require.Len(t, folders, 1)
+	assert.Empty(t, folders[0].ParentID, "the folder must still be where it was")
+}
+
+// TestARealRunStillAsksToMoveTheFolder is the control: the move is wanted, and
+// only the mode that writes nothing should be without it.
+//
+// The request is what is asserted rather than the folder's new parent, because
+// the fake Confluence moves pages and not folders -- so the move is observed
+// going out, and whatever it answers is beside the point here.
+func TestARealRunStillAsksToMoveTheFolder(t *testing.T) {
+	page.ResetFolderCache()
+
+	api, server := newAPI(t)
+	anchor := server.AddPage("DOCS", "Anchor", "page", "")
+	server.AddFolder("DOCS", "Manuals", "", "")
+
+	var moved atomic.Bool
+
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if strings.Contains(r.URL.Path, "/move/") {
+			moved.Store(true)
+		}
+
+		return 0, "", false
+	})
+
+	_, _ = page.EnsureFolderAncestry(false, api, "DOCS", []string{"Manuals"}, &anchor.ID, nil)
+
+	assert.True(t, moved.Load(), "a real run asks to move the folder")
+}


### PR DESCRIPTION
Reported in an audit. `--dry-run` could issue a real write.

## The defect

`resolveFolder` moves a folder that an earlier sync left at the space root, putting it under the page `--parents` names. It takes no `dryRun` parameter, and it is called from `EnsureFolderAncestry`’s discovery loop — which runs roughly 190 lines before the `if !dryRun` guard. So the `PUT …/move/append/{anchor}` went out on a dry run like any other.

## Why it matters

Reparenting a folder takes every page inside it along. A document carrying both `Folders:` and `Parents:`, published against a space where a folder of that title already sits at the root from an earlier sync, is all it takes. The mode whose entire promise is to write nothing was writing — and moving a subtree while doing it.

## The fix

Thread `dryRun` into `resolveFolder`, as the audit suggested; the caller already holds it. Where the move would have happened, the run says so instead:

```text
INFO folder "Manuals" would be moved under the page named by --parents
```

The folder is returned as it actually is, unmoved. Reporting where it would end up is a dry run’s job; putting it there is not.

The second call site is already inside the `!dryRun` block, so it is unaffected either way.

## Tests

- a dry run issues no `/move/` request, and the folder keeps its parent;
- a real run still asks for the move.

The control asserts the *request* rather than the folder’s new parent, because the fake Confluence moves pages and not folders — so the move is observed going out, and what it answers is beside the point. That is noted in the test.

`golangci-lint` clean; `page` passes.