### PR TITLE
fix(manifest): recording a page keeps the version it was published at

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -652,7 +652,26 @@ func (s *Store) Record(spaceKey, path, pageID, title, hash string) error {
 		return nil
 	}
 
-	sh.pages[path] = Entry{PageID: pageID, Title: title, Hash: hash, Glob: s.runGlob}
+	entry := Entry{PageID: pageID, Title: title, Hash: hash, Glob: s.runGlob}
+
+	// The version is carried across rather than rebuilt away. It is written by
+	// RecordVersion alone, and this rebuilds the entry from its arguments --
+	// none of which is the version -- so recording anything about a page
+	// silently forgot which version of it mark had written.
+	//
+	// What that cost is --no-overwrite: the run that finds a page edited in
+	// Confluence records the document as seen, so it is not mistaken for an
+	// orphan, and by doing so erased the very baseline it had just reported
+	// against. The next run read a zero, concluded nothing had drifted, and
+	// overwrote the edit it had refused to touch the run before.
+	//
+	// Zeroed only when the page id changes, where a version belonging to a
+	// different page would mean nothing.
+	if ok && existing.PageID == pageID {
+		entry.Version = existing.Version
+	}
+
+	sh.pages[path] = entry
 	state.byPage[pageID] = path
 	sh.dirty = true
 	return nil

--- a/mark_nooverwrite_test.go
+++ b/mark_nooverwrite_test.go
@@ -124,3 +124,36 @@ func TestNoOverwriteRequiresTrackPages(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--track-pages")
 }
+
+// TestNoOverwriteSurvivesTheRunThatReportsIt covers the run after the warning,
+// which is where the protection used to end.
+//
+// Reporting drift records the document as seen, so it is not mistaken for an
+// orphan and deleted -- and recording it rebuilt the entry without the version,
+// erasing the very baseline just reported against. The next run read a zero,
+// concluded nothing had drifted, and overwrote the edit it had refused to touch
+// the run before.
+//
+// The file has to change between the runs: an unchanged one takes an early
+// return that never records, which is why the existing tests never saw this.
+func TestNoOverwriteSurvivesTheRunThatReportsIt(t *testing.T) {
+	server, id, config := noOverwriteFixture(t)
+
+	server.EditPage(id, "<p>Written by a person.</p>")
+
+	// The run that reports the drift, with the document edited too.
+	writeFile(t, filepath.Dir(config.Files), "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Doc -->\n\nSecond version.\n")
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, "<p>Written by a person.</p>", server.Page(id).Body,
+		"the page must be left alone on the run that reports it")
+
+	// And the run after that, which had the baseline it needed taken away.
+	writeFile(t, filepath.Dir(config.Files), "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Parent: Parent -->\n<!-- Title: Doc -->\n\nThird version.\n")
+	require.NoError(t, Run(config))
+
+	assert.Equal(t, "<p>Written by a person.</p>", server.Page(id).Body,
+		"the hand-written page must still be there")
+}


### PR DESCRIPTION
Reported in an audit. `--no-overwrite` protected a page for exactly one run, then overwrote it.

## The defect

`Store.Record` rebuilds the entry from its arguments, and the version is not one of them. `Version` is `omitempty`, so it was persisted as absent — every caller that recorded anything about a page silently forgot which version mark had last written.

The `--no-overwrite` skip path records the document as seen, so it is not mistaken for an orphan and deleted. That record erased the baseline it had just reported against:

```
run 1   records {Hash: H1, Version: 5}
        someone edits the page in Confluence (version 6); the author edits the file
run 2   "leaving it alone" — then rewrites the entry as {Hash: H2, Version: 0}
run 3   hasDrifted sees version 0, returns false, and the hand-written body is gone
```

`hasDrifted` treats `Version == 0` as "nothing can be concluded", which is right — a zero really does mean mark never recorded one. The bug is that a zero got written.

## The fix

Carry the stored version across in `Record`, leaving `RecordVersion` its only writer. Zeroed only where the page id changes, since a version belonging to a different page means nothing.

## Why no test caught it

The file has to change between the two runs. An unchanged file takes an early return that never calls `Record` at all — which is the shape every existing `--no-overwrite` test had.

The new test runs the full three-run sequence, and I checked it fails without the fix rather than assuming it:

```
Error: Not equal:
  expected: "<p>Written by a person.</p>"
  actual  : "<p>Third version.</p>\\n"
```

`golangci-lint` clean; `manifest` and the `--no-overwrite` suite pass.