### PR TITLE
fix(transformer): a layout directive only opens what can be closed

### DIFF
--- a/markdown/layout_containers_test.go
+++ b/markdown/layout_containers_test.go
@@ -1,0 +1,63 @@
+package mark
+
+import (
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLayoutDirectiveInsideAContainerIsLeftAlone covers a directive written
+// somewhere its pair cannot follow it.
+//
+// A layout directive opens an element that a later directive closes, and both
+// have to end up side by side. Inside a list item, a blockquote or a table
+// cell, whatever contains it closes first: the page stops being well-formed
+// XML, which Confluence rejects in its entirety, and mark refuses its own
+// output with an error naming XML and never the directive -- leaving the author
+// nothing to go on.
+func TestLayoutDirectiveInsideAContainerIsLeftAlone(t *testing.T) {
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	for name, document := range map[string]string{
+		"list item":  "- <!-- ac:layout-cell -->\n- second\n",
+		"blockquote": "> <!-- ac:layout-cell -->\n",
+		"table cell": "| a |\n| --- |\n| <!-- ac:layout-cell --> |\n",
+		"paragraph":  "text <!-- ac:layout-cell --> more text\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			out, _, err := CompileMarkdown([]byte(document), std, "test.md", types.MarkConfig{})
+			require.NoError(t, err)
+
+			assert.NotContains(t, out, "<ac:layout-cell>",
+				"a directive whose pair cannot follow it must not open an element")
+			require.NoError(t, CheckWellFormed(out),
+				"and whatever is published has to be something Confluence accepts")
+		})
+	}
+}
+
+// TestLayoutDirectiveAtDocumentLevelStillConverts is the boundary: the whole
+// point of the directives is the layout they build, and that is unaffected.
+func TestLayoutDirectiveAtDocumentLevelStillConverts(t *testing.T) {
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	document := "<!-- ac:layout -->\n" +
+		"<!-- ac:layout-section type:two_equal -->\n" +
+		"<!-- ac:layout-cell -->\nleft\n<!-- ac:layout-cell end -->\n" +
+		"<!-- ac:layout-cell -->\nright\n<!-- ac:layout-cell end -->\n" +
+		"<!-- ac:layout-section end -->\n" +
+		"<!-- ac:layout end -->\n"
+
+	out, _, err := CompileMarkdown([]byte(document), std, "test.md", types.MarkConfig{})
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "<ac:layout>")
+	assert.Contains(t, out, "<ac:layout-section")
+	assert.Contains(t, out, "<ac:layout-cell>")
+	require.NoError(t, CheckWellFormed(out))
+}

--- a/transformer/layout.go
+++ b/transformer/layout.go
@@ -35,6 +35,17 @@ func (t *LayoutTransformer) Transform(doc *ast.Document, reader text.Reader, pc 
 
 		switch n := node.(type) {
 		case *ast.HTMLBlock, *ast.RawHTML, *ast.Text, *ast.String:
+			// Only where the pair can survive. A layout directive opens an
+			// element that the next directive closes, and both have to end up
+			// side by side in the output: inside a list item, a blockquote, a
+			// table cell or a paragraph, whatever contains it closes first and
+			// the page is no longer well-formed XML, which Confluence rejects
+			// whole. mark then refuses its own output with an error naming XML
+			// and never the directive, leaving the author nothing to go on.
+			if !atDocumentLevel(node) {
+				return ast.WalkContinue, nil
+			}
+
 			// Text inside an inline code span is literal: `<!-- ac:layout -->` in
 			// prose documents the directive, it does not open a layout. Rewriting
 			// it also destroyed the text outright, because the replacement Text
@@ -70,6 +81,20 @@ func (t *LayoutTransformer) Transform(doc *ast.Document, reader text.Reader, pc 
 			parent.RemoveChild(parent, item.node)
 		}
 	}
+}
+
+// atDocumentLevel reports whether a node stands on its own in the document
+// rather than inside something that will close around it.
+//
+// Nothing between it and the document, not even a paragraph: a directive with
+// prose beside it on the same line is held by one, and "text <!-- ac:layout-cell
+// --> more" would open an element that </p> closes. A directive meant to build
+// a layout stands alone on its line, which is how it becomes a block of its own
+// and how it has always had to be written for the pair to work.
+func atDocumentLevel(node ast.Node) bool {
+	parent := node.Parent()
+
+	return parent != nil && parent.Kind() == ast.KindDocument
 }
 
 func (t *LayoutTransformer) transformLayoutComments(raw []byte) ([]byte, bool) {


### PR DESCRIPTION
Reported in an audit, reproduced before fixing.

## The defect

A layout directive was converted wherever it appeared — in `RawHTML` and `Text` nodes as readily as in a block of its own — with nothing checking that the element it opens can be closed where it stands. Inside a container, whatever holds it closes first:

```console
$ cat doc.md
- <!-- ac:layout-cell -->
- second

$ mark --compile-only --files doc.md
FATAL the rendered page is not well-formed XML, which Confluence rejects in
its entirety: line 5: element <layout-cell> closed by </li>
```

The same for a blockquote, a table cell, or prose on the same line. mark refuses its own output, and the error names XML and never the directive — so the author has nothing to go on.

## The fix

Convert only where nothing stands between the directive and the document.

Not even a paragraph, which is the part worth stating: a paragraph is what holds a directive that has prose beside it, so `text <!-- ac:layout-cell --> more` would open an element that `</p>` closes. My first attempt walked *through* paragraphs on the theory that a directive on its own line might arrive as one — the mid-paragraph test caught that, and it turns out the allowance was not needed: a directive meant to build a layout stands alone on its line, which is how it becomes a block of its own and how it has always had to be written for its pair to reach it.

## Tests

Four containers — list item, blockquote, table cell, mid-paragraph — each asserting the directive does not convert *and* that what would be published is well-formed. Plus the boundary: a complete layout at document level still renders `<ac:layout>`, `<ac:layout-section>` and `<ac:layout-cell>` as before.

Every existing layout test still passes, including the inline-code guard.

`golangci-lint` clean; `transformer`, `markdown` and `renderer` pass.