### PR TITLE
fix(transformer): adjacent details sections do not nest

### DIFF
--- a/markdown/details_adjacent_test.go
+++ b/markdown/details_adjacent_test.go
@@ -1,0 +1,69 @@
+package mark
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/stdlib"
+	"github.com/kovetskiy/mark/v16/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAdjacentDetailsDoNotNest covers two sections written one after the other
+// with nothing between them.
+//
+// The fragment joining them closes one element and opens the next, which nets
+// to zero -- and a decision made on the net change reads that as a
+// self-contained tree and hands it to html.Parse, which drops the closer it has
+// nothing to match. The sections telescope: the second is published empty,
+// inside the first, and the content that belonged to it lands in the first as
+// well.
+//
+// What makes it worth a test of its own is that the result is well-formed, so
+// nothing downstream objects: the page publishes, wrong, in silence.
+func TestAdjacentDetailsDoNotNest(t *testing.T) {
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	// Distinctive words, because a letter of their own would match inside the
+	// markup: "rich-text-body" contains a "d".
+	document := "<details><summary>title a</summary>\n\nFIRSTBODY\n\n" +
+		"</details><details><summary>title c</summary>\n\nSECONDBODY\n\n</details>\n"
+
+	out, _, err := CompileMarkdown([]byte(document), std, "test.md", types.MarkConfig{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, strings.Count(out, `ac:name="expand"`), "both sections should be published")
+
+	// Siblings, not one inside the other: the first section's body ends before
+	// the second one starts.
+	firstBody := strings.Index(out, "<ac:rich-text-body>")
+	firstEnd := strings.Index(out, "</ac:rich-text-body>")
+	secondStart := strings.Index(out[firstEnd:], `ac:name="expand"`)
+
+	require.Positive(t, firstBody)
+	require.Positive(t, firstEnd)
+	require.Positive(t, secondStart, "the second section must begin after the first one closes")
+
+	// And each carries its own content.
+	assert.Contains(t, out[firstBody:firstEnd], "FIRSTBODY", "the first section keeps its own body")
+	assert.NotContains(t, out[firstBody:firstEnd], "SECONDBODY", "and not the second one's")
+
+	require.NoError(t, CheckWellFormed(out))
+}
+
+// TestAdjacentDetailsOnOneLineStillPublishBoth is the same shape without the
+// blank lines, where the fragments are whole rather than split.
+func TestAdjacentDetailsOnOneLineStillPublishBoth(t *testing.T) {
+	std, err := stdlib.New(nil)
+	require.NoError(t, err)
+
+	document := "<details><summary>a</summary>\nb\n</details>\n" +
+		"<details><summary>c</summary>\nd\n</details>\n"
+
+	out, _, err := CompileMarkdown([]byte(document), std, "test.md", types.MarkConfig{})
+	require.NoError(t, err)
+
+	require.NoError(t, CheckWellFormed(out))
+}

--- a/transformer/details.go
+++ b/transformer/details.go
@@ -232,17 +232,24 @@ func (t *DetailsTransformer) transformDetailsMarkup(rawContent []byte, depth *in
 		return rawContent, false
 	}
 
-	balance := detailsBalance(rawContent)
+	balance, lowest := detailsBalance(rawContent)
 
 	// A fragment with unmatched <details> tags cannot survive html.Parse, which
 	// would auto-close the dangling element and strand the body outside the
 	// macro. This happens whenever the body contains a blank line, since that
 	// ends the HTML block and splits the element across sibling AST nodes.
 	// Rewrite those fragments token-by-token instead.
-	if balance != 0 {
+	// Decided on nesting rather than on the net change. A fragment that closes
+	// one element and opens another nets to zero while being no more
+	// self-contained than one that only closes: html.Parse drops the closer it
+	// cannot match, and the sections telescope -- the second published empty,
+	// inside the first, with the content that belonged to it landing in the
+	// first as well. That output is well-formed, so nothing downstream objects
+	// and the wrong page is published in silence.
+	if balance != 0 || lowest < 0 {
 		// A closing tag with nothing open is stray markup, not part of a split
 		// element. Leave it untouched so we never invent an unmatched macro end.
-		if balance < 0 && *depth+balance < 0 {
+		if *depth+lowest < 0 {
 			return rawContent, false
 		}
 		out, changed := rewriteUnbalancedDetails(rawContent)

--- a/transformer/details_split.go
+++ b/transformer/details_split.go
@@ -19,10 +19,18 @@ import (
 // the body out of the macro and leaking a literal </details> into the output --
 // which Confluence then rejects with "Unexpected close tag </details>".
 // Detecting the imbalance lets us rewrite such fragments tag-by-tag instead.
-func detailsBalance(raw []byte) int {
+//
+// The lowest depth reached along the way is reported with it, because the net
+// change alone cannot tell a self-contained element from a fragment that closes
+// one and opens another. "</details><details>" nets to zero and is nothing of
+// the sort: html.Parse drops the closer it has nothing to match, and the two
+// sections telescope, the second ending up empty and inside the first. A
+// fragment whose depth ever goes below where it started has closed something
+// opened before it, whatever it does afterwards.
+func detailsBalance(raw []byte) (balance, lowest int) {
 	lower := bytes.ToLower(raw)
 	if !bytes.Contains(lower, []byte("<details")) && !bytes.Contains(lower, []byte("</details")) {
-		return 0
+		return 0, 0
 	}
 
 	depth := 0
@@ -30,7 +38,7 @@ func detailsBalance(raw []byte) int {
 	for {
 		switch z.Next() {
 		case html.ErrorToken:
-			return depth
+			return depth, lowest
 		case html.StartTagToken:
 			if name, _ := z.TagName(); string(name) == "details" {
 				depth++
@@ -38,6 +46,7 @@ func detailsBalance(raw []byte) int {
 		case html.EndTagToken:
 			if name, _ := z.TagName(); string(name) == "details" {
 				depth--
+				lowest = min(lowest, depth)
 			}
 		}
 	}


### PR DESCRIPTION
Reported in an audit, reproduced before fixing. **This is the one that publishes a wrong page rather than rejecting it.**

## The defect

`transformDetailsMarkup` chooses between the DOM path and the token rewrite on the *net* change in `<details>` depth. A fragment that closes one element and opens another nets to zero — which reads as a self-contained tree and is nothing of the sort. `html.Parse` drops the closing tag it has nothing to match, and the sections telescope.

Two expandable sections written one after the other:

```console
$ mark --compile-only --files doc.md
<ac:structured-macro ac:name="expand">…title a…<ac:rich-text-body>
<p>b</p>
<ac:structured-macro ac:name="expand">…title c…<ac:rich-text-body>
</ac:rich-text-body></ac:structured-macro><p>d</p>
</ac:rich-text-body></ac:structured-macro>
```

Section **c is empty and inside a**, and **d’s content lands in a**.

The output is well-formed, so `CheckWellFormed` is satisfied and the page publishes without a word. Everything else in this audit produces a refusal; this produces a wrong page.

## The fix

Decide on nesting rather than on the net change, as the audit suggested. `detailsBalance` now also reports the lowest depth it reached: a fragment that ever goes below where it started has closed something opened before it, whatever it does afterwards.

The stray-closer guard reads that same number — `*depth + lowest < 0` — which is what it was reaching for by way of the net change.

After:

```console
<ac:structured-macro …title a…><ac:rich-text-body>
<p>b</p>
</ac:rich-text-body></ac:structured-macro><ac:structured-macro …title c…><ac:rich-text-body>
<p>d</p>
</ac:rich-text-body></ac:structured-macro>
```

Siblings, each with its own content.

## Why no test caught it

The existing test puts a blank line between the two sections, which splits them into fragments that are each unbalanced on their own — and so takes the other branch entirely.

The new test asserts both sections are published, that the second begins after the first closes, and that each carries its own body. I checked it fails without the fix rather than assuming it.

One thing the first draft got wrong, worth mentioning: I asserted the first body did not contain `"d"` — which matched the `d` inside `rich-text-bo**d**y`. The test now uses distinctive words.

`golangci-lint` clean; `transformer` and `markdown` pass.