### PR TITLE
feat(attachment): a declared attachment may be a pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,28 @@ with the same path:
 An attached link is [here](<path-to-image>)
 ```
 
+A path may be a pattern, in the same syntax `--files` uses, which uploads every
+file it matches:
+
+```markdown
+<!-- Attachment: images/*.png -->
+<!-- Attachment: media/**/*.svg -->
+```
+
+Each match is attached under the path it was found at, so a link or image in the
+page refers to it exactly as it would have without the pattern —
+`![](images/logo.png)`. A pattern is not reported as an unused attachment when
+the page does not link to all of it, since uploading a directory is the point of
+writing one.
+
+A name with no pattern characters in it is a path, exactly as before. So is one
+whose pattern matches nothing: a file really called `report[2024].pdf` still
+attaches, and a pattern that was meant to match something reports the path as
+written when nothing is there.
+
+A pattern reaches no further than a path does — the document's own directory or
+the one mark is running in — so `../../*.pem` is refused rather than swept up.
+
 **NOTE**: Be careful with `Attachment`! If your path string is a subset of
 another longer string or referenced in text, you may get undesired behavior.
 

--- a/attachment/attachment.go
+++ b/attachment/attachment.go
@@ -15,9 +15,11 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/kovetskiy/mark/v16/confluence"
 	"github.com/kovetskiy/mark/v16/vfs"
 	"github.com/rs/zerolog/log"
@@ -37,6 +39,12 @@ type Attachment struct {
 	Width     string
 	Height    string
 	Replace   string
+
+	// Matched marks an attachment that a pattern found rather than a document
+	// naming it outright. Somebody who wrote "images/*.png" asked for the set,
+	// so being able to say which of them the page never referred to is not
+	// worth a warning per file on every run.
+	Matched bool
 }
 
 type Attacher interface {
@@ -213,16 +221,80 @@ func ResolveLocalAttachments(opener vfs.Opener, base string, replacements []stri
 // prepareAttachements creates an array of attachement objects based on an array of filepaths
 func prepareAttachments(opener vfs.Opener, base string, replacements []string) ([]Attachment, error) {
 	attachments := []Attachment{}
+
 	for _, name := range replacements {
-		attachment, err := prepareAttachment(opener, base, name)
+		matches, matched, err := expand(base, name)
 		if err != nil {
 			return nil, err
 		}
 
-		attachments = append(attachments, attachment)
+		for _, match := range matches {
+			attachment, err := prepareAttachment(opener, base, match)
+			if err != nil {
+				return nil, err
+			}
+
+			attachment.Matched = matched
+			attachments = append(attachments, attachment)
+		}
 	}
 
 	return attachments, nil
+}
+
+// expand turns what a document declared into the files it names, and reports
+// whether a pattern did the naming.
+//
+// A name with nothing to match on is left exactly as it was, so that every
+// document that worked before this still works and still fails in the same
+// words when the file is not there. That matters beyond compatibility: a file
+// really called "report[2024].pdf" is an ordinary name, and reading it as a
+// pattern would turn a document that publishes into one that does not.
+//
+// Which is also why a pattern matching nothing falls back to the literal name.
+// The two cases cannot be told apart from the outside -- a bracket is a
+// character and a syntax at once -- so the answer that keeps working is the
+// right one, and the file that is genuinely missing is reported by the open
+// that follows, naming the path the author wrote.
+func expand(base, name string) (matches []string, matched bool, err error) {
+	if !hasPattern(name) {
+		return []string{name}, false, nil
+	}
+
+	found, err := doublestar.FilepathGlob(filepath.Join(base, name))
+	if err != nil {
+		return nil, false, fmt.Errorf("unable to expand attachment pattern %q: %w", name, err)
+	}
+
+	if len(found) == 0 {
+		return []string{name}, false, nil
+	}
+
+	// Named the way the document would name them, since that is what a link in
+	// it says and what the upload is keyed by.
+	matches = make([]string, 0, len(found))
+
+	for _, path := range found {
+		relative, err := filepath.Rel(base, path)
+		if err != nil {
+			// Outside the base, which prepareAttachment refuses by itself. Kept
+			// as it is so that it is refused by name rather than dropped here.
+			relative = path
+		}
+
+		matches = append(matches, filepath.ToSlash(relative))
+	}
+
+	// The order the files are uploaded in should not depend on how the
+	// directory happens to be laid out.
+	slices.Sort(matches)
+
+	return matches, true, nil
+}
+
+// hasPattern reports whether a declared name is a pattern rather than a path.
+func hasPattern(name string) bool {
+	return strings.ContainsAny(name, "*?[{")
 }
 
 // ErrOutsideProject reports an attachment that resolves outside the directories
@@ -451,6 +523,14 @@ func (r *Resolver) Unused(attachments []Attachment) []string {
 
 	var unused []string
 	for _, attachment := range attachments {
+		// A pattern was asked for the set, not for each file in it: "upload
+		// this directory" is a whole intention, and reporting every file the
+		// page did not happen to link to would be a warning per file, on every
+		// run, for doing what was asked.
+		if attachment.Matched {
+			continue
+		}
+
 		if !r.used[attachment.Replace] {
 			unused = append(unused, attachment.Replace)
 		}

--- a/attachment/glob_test.go
+++ b/attachment/glob_test.go
@@ -1,0 +1,153 @@
+package attachment
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/vfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// write puts a file where a document can name it, and returns nothing: what
+// these tests care about is which files a pattern found, not what is in them.
+func write(t *testing.T, dir, name string) {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("content of "+name), 0o600))
+}
+
+// names returns what each attachment will be referred to by, which is the path
+// the document would write.
+func names(attachments []Attachment) []string {
+	got := make([]string, 0, len(attachments))
+	for _, attachment := range attachments {
+		got = append(got, attachment.Replace)
+	}
+
+	return got
+}
+
+// TestAttachmentPatternUploadsEveryMatch covers the point of the feature: a
+// directory of images is one intention, and writing it out file by file is
+// bookkeeping the document should not have to carry.
+func TestAttachmentPatternUploadsEveryMatch(t *testing.T) {
+	_, docs := project(t)
+
+	write(t, docs, "images/b.png")
+	write(t, docs, "images/a.png")
+	write(t, docs, "images/c.png")
+	write(t, docs, "images/notes.txt")
+
+	got, err := ResolveLocalAttachments(vfs.LocalOS, docs, []string{"images/*.png"})
+	require.NoError(t, err)
+
+	// Sorted, because the order files are uploaded in should not depend on how
+	// the directory happens to be laid out.
+	assert.Equal(t, []string{"images/a.png", "images/b.png", "images/c.png"}, names(got))
+}
+
+// TestAttachmentPatternMatchesRecursively covers ** , which is the syntax
+// --files already uses and so the one people will reach for.
+func TestAttachmentPatternMatchesRecursively(t *testing.T) {
+	_, docs := project(t)
+
+	write(t, docs, "media/a.png")
+	write(t, docs, "media/nested/b.png")
+
+	got, err := ResolveLocalAttachments(vfs.LocalOS, docs, []string{"media/**/*.png"})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"media/a.png", "media/nested/b.png"}, names(got))
+}
+
+// TestAttachmentWithoutAPatternIsUnchanged is the compatibility boundary: an
+// ordinary name is still an ordinary name, and still fails in the same words.
+func TestAttachmentWithoutAPatternIsUnchanged(t *testing.T) {
+	_, docs := project(t)
+	write(t, docs, "logo.png")
+
+	got, err := ResolveLocalAttachments(vfs.LocalOS, docs, []string{"logo.png"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"logo.png"}, names(got))
+
+	_, err = ResolveLocalAttachments(vfs.LocalOS, docs, []string{"missing.png"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing.png")
+}
+
+// TestAttachmentNamedLikeAPatternStillWorks is the reason a pattern that finds
+// nothing falls back to the name as written.
+//
+// A bracket is a character and a syntax at once, and the two cannot be told
+// apart from the outside: a file really called "report[2024].pdf" is an
+// ordinary name that somebody has already attached, and reading it as a pattern
+// would turn a document that publishes into one that does not.
+func TestAttachmentNamedLikeAPatternStillWorks(t *testing.T) {
+	_, docs := project(t)
+	write(t, docs, "report[2024].pdf")
+
+	got, err := ResolveLocalAttachments(vfs.LocalOS, docs, []string{"report[2024].pdf"})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"report[2024].pdf"}, names(got))
+}
+
+// TestAttachmentPatternMatchingNothingIsReportedByName covers the typo, which
+// is what a pattern finding nothing usually is. It is reported by the open that
+// follows, naming the path the author actually wrote.
+func TestAttachmentPatternMatchingNothingIsReportedByName(t *testing.T) {
+	_, docs := project(t)
+	write(t, docs, "images/a.png")
+
+	_, err := ResolveLocalAttachments(vfs.LocalOS, docs, []string{"pictures/*.png"})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "pictures/*.png")
+}
+
+// TestAttachmentPatternCannotReachOutsideTheProject is the one that matters: a
+// pattern is written by a document, and a document is content.
+func TestAttachmentPatternCannotReachOutsideTheProject(t *testing.T) {
+	root, docs := project(t)
+
+	outside := filepath.Dir(root)
+	secret := filepath.Join(outside, "secret-"+filepath.Base(root)+".pem")
+	require.NoError(t, os.WriteFile(secret, []byte("a private key"), 0o600))
+
+	t.Cleanup(func() { _ = os.Remove(secret) })
+
+	_, err := ResolveLocalAttachments(vfs.LocalOS, docs,
+		[]string{filepath.Join("..", "..", "secret-"+filepath.Base(root)+".pem")})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrOutsideProject)
+
+	// And the same reach written as a pattern, which is the form that would
+	// otherwise sweep up whatever it found.
+	_, err = ResolveLocalAttachments(vfs.LocalOS, docs, []string{filepath.Join("..", "..", "*.pem")})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrOutsideProject)
+}
+
+// TestMatchedAttachmentsAreNotReportedUnused covers the noise a pattern would
+// otherwise make. Somebody who wrote "images/*.png" asked for the set: warning
+// about each file the page did not link to would be a line per file, every run,
+// for doing what was asked.
+func TestMatchedAttachmentsAreNotReportedUnused(t *testing.T) {
+	_, docs := project(t)
+
+	write(t, docs, "images/a.png")
+	write(t, docs, "images/b.png")
+	write(t, docs, "named.png")
+
+	got, err := ResolveLocalAttachments(vfs.LocalOS, docs, []string{"images/*.png", "named.png"})
+	require.NoError(t, err)
+
+	resolver := NewResolver(got)
+
+	assert.Equal(t, []string{"named.png"}, resolver.Unused(got),
+		"only what the document named outright is worth reporting")
+}


### PR DESCRIPTION
A page carrying a directory of images had to name every one of them, and name them again whenever one was added. A declared attachment may now be a pattern instead:

```markdown
<!-- Attachment: images/*.png -->
<!-- Attachment: media/**/*.svg -->
```

Same syntax `--files` already uses — `doublestar/v4`, already a direct dependency — so `**` and `{a,b}` work and there is no second pattern language to learn.

Every match is attached under the path it was found at, so a link or image in the page refers to it exactly as it would have without the pattern: `![](images/logo.png)`. Matches are sorted, because the order files upload in should not depend on how a directory happens to be laid out.

## Wildcards rather than regular expressions

Globs read as paths, match how `--files` already behaves, and cannot accidentally match half a filename. A regex in an HTML comment would be a second pattern language in the same tool for no gain.

## Compatibility, in both directions

- A name with **no pattern characters** is a path, exactly as before, and fails in the same words when it is missing.
- A pattern that **matches nothing** falls back to the name as written. A bracket is a character and a syntax at once, and the two cannot be told apart from the outside — so a file genuinely called `report[2024].pdf` still attaches, and a pattern that was meant to find something reports the path the author wrote.

Both have tests, because this is the part that could silently break a document that publishes today.

## Security

Each match is held to the boundary attachments have always been held to — the document’s own directory or the one mark is running in. `../../*.pem` is refused rather than swept up, tested both as a literal path and as a pattern. A pattern is written by a document, and a document is content.

## Unused-attachment warnings

A pattern’s matches are not reported as unused. Somebody who wrote `images/*.png` asked for the set; a line per file the page did not happen to link to, on every run, is a warning for doing what was asked. Files named outright are still reported.

## Two things checked that could have bitten

- **Ordering** is deterministic (sorted), not directory order.
- **Flattened names keep their directory**, so `one/logo.png` and `two/logo.png` become `one_logo.png` and `two_logo.png` — globbing across directories adds no new collision risk.

## Tests

Expansion, `**` recursion, the literal path unchanged, the bracket-named file, a pattern matching nothing, containment for both forms, and unused-reporting.

`golangci-lint` and `markdownlint` clean; `attachment` passes.

One pre-existing flake to note: `markdown/TestAttachmentFilenameAttributeIsEscaped` fails under a full parallel `go test ./...` on this machine and passes in isolation in 4s. It fails the same way on clean master — several packages each launch Chrome concurrently and time each other out.