### PR TITLE
fix(confluence): reach the page APIs with a scoped API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1752,9 +1752,12 @@ with, and the older v1 ones check `read:content-details:confluence` and
 
 out of the first page lookup of the run.
 
-Mark asks v1 first everywhere -- it is the only API Server and Data Center have,
-and it answers in one request what v2 needs several for -- and asks v2 instead
-wherever v1 refuses. Publishing a page through the gateway needs:
+Mark asks v1 first everywhere -- it answers in one request what v2 needs several
+for -- and asks v2 instead wherever v1 refuses. Only on Cloud: Server and Data
+Center have no v2 API at all, and mark settles which it is talking to before
+falling back to anything, so a self-hosted instance is never sent to a path it
+does not have and keeps the v1 error that explains the failure. Publishing a
+page through the gateway needs:
 
 | scope | what it is for |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -1729,6 +1729,55 @@ a warning and not an error, because `--compile-only` has to keep validating
 documents on a machine -- a CI image, typically -- that has no password manager
 on it.
 
+### Scoped API tokens
+
+An Atlassian scoped API token does not authenticate against your site's own
+address at all. It goes through the gateway, which is what the base URL has to
+name:
+
+```toml
+base-url = "https://api.atlassian.com/ex/confluence/<cloud-id>"
+```
+
+The gateway checks the token's granular scopes against the endpoint being
+called, and Confluence's two REST APIs check different scopes for the same
+thing: the v2 endpoints check the page scopes a scoped token is usually minted
+with, and the older v1 ones check `read:content-details:confluence` and
+`write:content:confluence`. A token holding `read:page:confluence` and
+`write:page:confluence` therefore used to get
+
+```text
+401 {"code":401,"message":"Unauthorized; scope does not match"}
+```
+
+out of the first page lookup of the run.
+
+Mark asks v1 first everywhere -- it is the only API Server and Data Center have,
+and it answers in one request what v2 needs several for -- and asks v2 instead
+wherever v1 refuses. Publishing a page through the gateway needs:
+
+| scope | what it is for |
+| --- | --- |
+| `read:space:confluence` | resolving a space key, and finding its home page |
+| `read:page:confluence` | finding a page by title, and reading one by id |
+| `write:page:confluence` | creating and updating pages |
+| `read:content.property:confluence`, `write:content.property:confluence` | the content appearance and emoji title of a page, and the `--track-pages` mapping |
+| `read:attachment:confluence` | listing what is attached to a page, which happens on every run whether or not the document has attachments |
+| `read:label:confluence` | reading the labels a page carries, likewise |
+
+The rest of what mark does has no v2 endpoint to fall back to and stays on v1:
+uploading attachments -- so any image, diagram or formula -- applying `Label`
+headers, `--preserve-comments`, `--on-orphan`, page restrictions, mentions, and
+moving a page among its siblings. Those need the scope Atlassian documents for
+the v1 endpoint behind them, which is the feature's own scope
+(`write:attachment:confluence`, `write:label:confluence`,
+`read:comment:confluence`, `read:user:confluence`) together with the content
+scopes above. Granting `read:content-details:confluence` and
+`write:content:confluence` alongside the page scopes is the simplest way to have
+everything work, and costs a scoped token none of the point of being scoped: it
+is still confined to Confluence, and still to what the account behind it may
+see.
+
 **NOTE**: Labels aren't supported when using `minor-edit`!
 
 **NOTE**: See [Preserving Inline Comments](#preserving-inline-comments) for a detailed description of the `--preserve-comments` flag.

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -530,6 +530,17 @@ func (api *API) fetchHomePage(space string) (*PageInfo, error) {
 	// v1 space endpoint answers 404 and every run aborted here. The fallback is
 	// deliberately not narrowed to 404: a token with partial scopes can also
 	// draw 401/403 from v1 while v2 still answers.
+	//
+	// Server and Data Center have no v2 at all, so there is nothing there to
+	// fall through to and v1's answer is the whole story.
+	if !api.v2Available() {
+		if v1Err == nil {
+			v1Err = newErrorStatusNotOK(v1Request)
+		}
+
+		return nil, v1Err
+	}
+
 	v2Result := struct {
 		Results []struct {
 			ID         string `json:"id"`
@@ -553,7 +564,7 @@ func (api *API) fetchHomePage(space string) (*PageInfo, error) {
 		if v1Err == nil {
 			v1Err = newErrorStatusNotOK(v1Request)
 		}
-		return nil, fmt.Errorf("v1 API: %w (v2 fallback also failed: %w)", v1Err, v2Err)
+		return nil, v1FailedAndSoDidV2(v1Err, v2Err)
 	}
 
 	if len(v2Result.Results) == 0 {
@@ -629,10 +640,11 @@ func (api *API) FindPage(
 			}
 		}
 
-	case v1Refused(request):
+	case v1Refused(request) && api.v2Available():
 		// A scoped API token is not entitled to /rest/api/content, and this is
 		// where a run using one used to end. v2 answers the same question; see
-		// v2fallback.go for why v1 is still asked first.
+		// v2fallback.go for why v1 is still asked first, and why a deployment
+		// without a v2 API is not asked at all.
 		page, v2Err := api.findContentV2(space, title, pageType, "current")
 		if v2Err == nil {
 			found = page
@@ -642,9 +654,7 @@ func (api *API) FindPage(
 		// allow 404 because it's fine if page is not found,
 		// the function will return nil, nil
 		if request.Raw.StatusCode != http.StatusNotFound {
-			return nil, fmt.Errorf(
-				"v1 API: %w (v2 fallback also failed: %w)", newErrorStatusNotOK(request), v2Err,
-			)
+			return nil, v1FailedAndSoDidV2(newErrorStatusNotOK(request), v2Err)
 		}
 
 	default:
@@ -729,7 +739,7 @@ func (api *API) findPageWithStatus(space, title, pageType, status string) (*Page
 	// A scoped API token draws 401 here rather than an answer; v2 can filter by
 	// status too. A 404 keeps its old meaning -- no such page -- when v2 cannot
 	// answer either, since this only ever improves an error message.
-	if v1Refused(request) {
+	if v1Refused(request) && api.v2Available() {
 		page, v2Err := api.findContentV2(space, title, pageType, status)
 		if v2Err == nil {
 			if page != nil && page.Status == "" {
@@ -1013,15 +1023,13 @@ func (api *API) GetAttachments(pageID string) ([]AttachmentInfo, error) {
 		// every document -- so a token that cannot read this listing cannot
 		// publish anything at all. v2 has the listing; it does not have the
 		// upload, which stays on v1.
-		if start == 0 && v1Refused(request) {
+		if start == 0 && v1Refused(request) && api.v2Available() {
 			attachments, v2Err := api.getAttachmentsV2(pageID)
 			if v2Err == nil {
 				return attachments, nil
 			}
 
-			return nil, fmt.Errorf(
-				"v1 API: %w (v2 fallback also failed: %w)", newErrorStatusNotOK(request), v2Err,
-			)
+			return nil, v1FailedAndSoDidV2(newErrorStatusNotOK(request), v2Err)
 		}
 
 		if request.Raw.StatusCode != http.StatusOK {
@@ -1069,15 +1077,13 @@ func (api *API) GetPageByIDExpanded(pageID string, expand string) (*PageInfo, er
 	// What v1 expands in one request, v2 needs several for -- the body comes
 	// from a format parameter and the ancestors from a walk -- so only what the
 	// caller asked to expand is fetched.
-	if v1Refused(request) {
+	if v1Refused(request) && api.v2Available() {
 		page, v2Err := api.getPageByIDV2(pageID, expand)
 		if v2Err == nil {
 			return page, nil
 		}
 
-		return nil, fmt.Errorf(
-			"v1 API: %w (v2 fallback also failed: %w)", newErrorStatusNotOK(request), v2Err,
-		)
+		return nil, v1FailedAndSoDidV2(newErrorStatusNotOK(request), v2Err)
 	}
 
 	if request.Raw.StatusCode != http.StatusOK {
@@ -1180,7 +1186,7 @@ func (api *API) CreatePage(
 	case request.Raw.StatusCode == http.StatusOK:
 		page = request.Response.(*PageInfo)
 
-	case v1Refused(request):
+	case v1Refused(request) && api.v2Available():
 		// A scoped API token may create through v2 and not through v1. The
 		// refusal statuses are the ones no page is created by, so there is
 		// nothing here for a second attempt to duplicate.
@@ -1326,13 +1332,11 @@ func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, ve
 	switch {
 	case request.Raw.StatusCode == http.StatusOK:
 
-	case v1Refused(request):
+	case v1Refused(request) && api.v2Available():
 		if v2Err := api.updateContentV2(
 			page, newContent, minorEdit, versionMessage, nextPageVersion,
 		); v2Err != nil {
-			return fmt.Errorf(
-				"v1 API: %w (v2 fallback also failed: %w)", newErrorStatusNotOK(request), v2Err,
-			)
+			return v1FailedAndSoDidV2(newErrorStatusNotOK(request), v2Err)
 		}
 
 		// Reported once the version this run just wrote has been recorded: the
@@ -1472,15 +1476,13 @@ func (api *API) GetPageLabels(page *PageInfo, prefix string) (*LabelInfo, error)
 		// document declares any, so this listing is on the critical path of a
 		// scoped-token run in the same way the attachment listing is. Adding
 		// and removing labels stays on v1, which has no v2 counterpart.
-		if start == 0 && v1Refused(request) {
+		if start == 0 && v1Refused(request) && api.v2Available() {
 			labels, v2Err := api.getPageLabelsV2(page.ID, prefix)
 			if v2Err == nil {
 				return labels, nil
 			}
 
-			return nil, fmt.Errorf(
-				"v1 API: %w (v2 fallback also failed: %w)", newErrorStatusNotOK(request), v2Err,
-			)
+			return nil, v1FailedAndSoDidV2(newErrorStatusNotOK(request), v2Err)
 		}
 
 		if request.Raw.StatusCode != http.StatusOK {
@@ -1878,6 +1880,19 @@ func (api *API) fetchSpaceID(spaceKey string) (string, error) {
 	request, err := api.v1().Res("space/"+spaceKey, &v1Result).Get()
 	if err == nil && request.Raw.StatusCode == http.StatusOK && v1Result.ID != 0 {
 		return strconv.Itoa(v1Result.ID), nil
+	}
+
+	// Server and Data Center have no v2 spaces endpoint to fall back to, so
+	// whatever v1 said is the answer.
+	if !api.v2Available() {
+		switch {
+		case err != nil:
+			return "", newTransportError(request, "resolve space "+spaceKey, err)
+		case request.Raw.StatusCode == http.StatusOK:
+			return "", fmt.Errorf("space %s: the v1 API answered without an id", spaceKey)
+		default:
+			return "", newErrorStatusNotOK(request)
+		}
 	}
 
 	// Fallback to v2 API with query parameter

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -739,20 +739,22 @@ func (api *API) findPageWithStatus(space, title, pageType, status string) (*Page
 	// A scoped API token draws 401 here rather than an answer; v2 can filter by
 	// status too. A 404 keeps its old meaning -- no such page -- when v2 cannot
 	// answer either, since this only ever improves an error message.
-	if v1Refused(request) && api.v2Available() {
-		page, v2Err := api.findContentV2(space, title, pageType, status)
-		if v2Err == nil {
-			if page != nil && page.Status == "" {
-				page.Status = status
+	if page, ok, err := fallbackV2(api, request, func() (*PageInfo, error) {
+		return api.findContentV2(space, title, pageType, status)
+	}); ok {
+		if err != nil {
+			if request.Raw.StatusCode == http.StatusNotFound {
+				return nil, nil
 			}
-			return page, nil
+
+			return nil, err
 		}
 
-		if request.Raw.StatusCode == http.StatusNotFound {
-			return nil, nil
+		if page != nil && page.Status == "" {
+			page.Status = status
 		}
 
-		return nil, newErrorStatusNotOK(request)
+		return page, nil
 	}
 
 	if request.Raw.StatusCode != http.StatusOK {
@@ -1023,13 +1025,12 @@ func (api *API) GetAttachments(pageID string) ([]AttachmentInfo, error) {
 		// every document -- so a token that cannot read this listing cannot
 		// publish anything at all. v2 has the listing; it does not have the
 		// upload, which stays on v1.
-		if start == 0 && v1Refused(request) && api.v2Available() {
-			attachments, v2Err := api.getAttachmentsV2(pageID)
-			if v2Err == nil {
-				return attachments, nil
+		if start == 0 {
+			if attachments, ok, err := fallbackV2(api, request, func() ([]AttachmentInfo, error) {
+				return api.getAttachmentsV2(pageID)
+			}); ok {
+				return attachments, err
 			}
-
-			return nil, v1FailedAndSoDidV2(newErrorStatusNotOK(request), v2Err)
 		}
 
 		if request.Raw.StatusCode != http.StatusOK {
@@ -1077,13 +1078,10 @@ func (api *API) GetPageByIDExpanded(pageID string, expand string) (*PageInfo, er
 	// What v1 expands in one request, v2 needs several for -- the body comes
 	// from a format parameter and the ancestors from a walk -- so only what the
 	// caller asked to expand is fetched.
-	if v1Refused(request) && api.v2Available() {
-		page, v2Err := api.getPageByIDV2(pageID, expand)
-		if v2Err == nil {
-			return page, nil
-		}
-
-		return nil, v1FailedAndSoDidV2(newErrorStatusNotOK(request), v2Err)
+	if page, ok, err := fallbackV2(api, request, func() (*PageInfo, error) {
+		return api.getPageByIDV2(pageID, expand)
+	}); ok {
+		return page, err
 	}
 
 	if request.Raw.StatusCode != http.StatusOK {
@@ -1476,13 +1474,12 @@ func (api *API) GetPageLabels(page *PageInfo, prefix string) (*LabelInfo, error)
 		// document declares any, so this listing is on the critical path of a
 		// scoped-token run in the same way the attachment listing is. Adding
 		// and removing labels stays on v1, which has no v2 counterpart.
-		if start == 0 && v1Refused(request) && api.v2Available() {
-			labels, v2Err := api.getPageLabelsV2(page.ID, prefix)
-			if v2Err == nil {
-				return labels, nil
+		if start == 0 {
+			if labels, ok, err := fallbackV2(api, request, func() (*LabelInfo, error) {
+				return api.getPageLabelsV2(page.ID, prefix)
+			}); ok {
+				return labels, err
 			}
-
-			return nil, v1FailedAndSoDidV2(newErrorStatusNotOK(request), v2Err)
 		}
 
 		if request.Raw.StatusCode != http.StatusOK {
@@ -2060,57 +2057,36 @@ func (api *API) GetChildPages(parentID string) ([]PageInfo, error) {
 // Stops at the first folder it sees. The answer is a yes or a no, and the rest
 // of the listing cannot change it.
 func (api *API) HasChildFolders(parentID string) (bool, error) {
-	const pageSize = 100
-
-	var cursor string
-	for {
-		result := struct {
-			Results []struct {
-				ID   string `json:"id"`
-				Type string `json:"type"`
-			} `json:"results"`
-
-			Links struct {
-				Next string `json:"next"`
-			} `json:"_links"`
-		}{}
-
-		query := map[string]string{"limit": fmt.Sprintf("%d", pageSize)}
-		if cursor != "" {
-			query["cursor"] = cursor
-		}
-
-		request, err := api.v2().Res(
-			"pages/"+parentID+"/direct-children", &result,
-		).Get(query)
-		if err != nil {
-			return false, fmt.Errorf("unable to list children of %s: %w", parentID, err)
-		}
-
-		// First page only: a 404 partway through is a real failure, and reading
-		// it as "none" would answer from a listing already known to be partial.
-		if request.Raw.StatusCode == http.StatusNotFound && cursor == "" {
-			return false, nil
-		}
-
-		if request.Raw.StatusCode != http.StatusOK {
-			return false, newErrorStatusNotOK(request)
-		}
-
-		for _, child := range result.Results {
-			if child.Type == "folder" {
-				return true, nil
-			}
-		}
-
-		next := nextCursor(result.Links.Next)
-		// A server that hands back the cursor it was given would otherwise keep
-		// this loop going for as long as it keeps answering.
-		if next == "" || next == cursor || len(result.Results) == 0 {
-			return false, nil
-		}
-		cursor = next
+	type childV2 struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
 	}
+
+	var found bool
+
+	err := listPagedV2(
+		api,
+		"pages/"+parentID+"/direct-children",
+		"list children of "+parentID,
+		map[string]string{"limit": "100"},
+		missingIsEmpty,
+		func(children []childV2) bool {
+			for _, child := range children {
+				if child.Type == "folder" {
+					found = true
+
+					return false
+				}
+			}
+
+			return true
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+
+	return found, nil
 }
 
 // MoveContentAfter places a page immediately after one of its siblings.

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -613,9 +613,41 @@ func (api *API) FindPage(
 		return nil, newTransportError(request, fmt.Sprintf("find page %q in space %s", title, space), err)
 	}
 
-	// allow 404 because it's fine if page is not found,
-	// the function will return nil, nil
-	if request.Raw.StatusCode != http.StatusNotFound && request.Raw.StatusCode != http.StatusOK {
+	// found is nil for "no such page", which is not an error: the caller is
+	// asking whether a title is taken, and both APIs may answer that it is not.
+	var found *PageInfo
+
+	switch {
+	case request.Raw.StatusCode == http.StatusOK:
+		if len(result.Results) > 0 {
+			found = &result.Results[0]
+			// Populate the base URL from the response _links.base or fallback to BaseURL
+			if result.Links.Base != "" {
+				found.Links.Base = result.Links.Base
+			} else if found.Links.Base == "" {
+				found.Links.Base = api.BaseURL
+			}
+		}
+
+	case v1Refused(request):
+		// A scoped API token is not entitled to /rest/api/content, and this is
+		// where a run using one used to end. v2 answers the same question; see
+		// v2fallback.go for why v1 is still asked first.
+		page, v2Err := api.findContentV2(space, title, pageType, "current")
+		if v2Err == nil {
+			found = page
+			break
+		}
+
+		// allow 404 because it's fine if page is not found,
+		// the function will return nil, nil
+		if request.Raw.StatusCode != http.StatusNotFound {
+			return nil, fmt.Errorf(
+				"v1 API: %w (v2 fallback also failed: %w)", newErrorStatusNotOK(request), v2Err,
+			)
+		}
+
+	default:
 		return nil, newErrorStatusNotOK(request)
 	}
 
@@ -628,18 +660,12 @@ func (api *API) FindPage(
 		return clonePageInfo(cachedPage), nil
 	}
 
-	if len(result.Results) == 0 {
+	if found == nil {
 		api.setCacheEntry(key, nil)
 		return nil, nil
 	}
 
-	page := result.Results[0]
-	// Populate the base URL from the response _links.base or fallback to BaseURL
-	if result.Links.Base != "" {
-		page.Links.Base = result.Links.Base
-	} else if page.Links.Base == "" {
-		page.Links.Base = api.BaseURL
-	}
+	page := *found
 
 	cacheTitle := title
 	if page.Title != "" {
@@ -700,8 +726,23 @@ func (api *API) findPageWithStatus(space, title, pageType, status string) (*Page
 		)
 	}
 
-	if request.Raw.StatusCode == http.StatusNotFound {
-		return nil, nil
+	// A scoped API token draws 401 here rather than an answer; v2 can filter by
+	// status too. A 404 keeps its old meaning -- no such page -- when v2 cannot
+	// answer either, since this only ever improves an error message.
+	if v1Refused(request) {
+		page, v2Err := api.findContentV2(space, title, pageType, status)
+		if v2Err == nil {
+			if page != nil && page.Status == "" {
+				page.Status = status
+			}
+			return page, nil
+		}
+
+		if request.Raw.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
+
+		return nil, newErrorStatusNotOK(request)
 	}
 
 	if request.Raw.StatusCode != http.StatusOK {
@@ -968,6 +1009,21 @@ func (api *API) GetAttachments(pageID string) ([]AttachmentInfo, error) {
 			return nil, newTransportError(request, "list attachments of page "+pageID, err)
 		}
 
+		// A page with no attachments still gets listed here, on every run, for
+		// every document -- so a token that cannot read this listing cannot
+		// publish anything at all. v2 has the listing; it does not have the
+		// upload, which stays on v1.
+		if start == 0 && v1Refused(request) {
+			attachments, v2Err := api.getAttachmentsV2(pageID)
+			if v2Err == nil {
+				return attachments, nil
+			}
+
+			return nil, fmt.Errorf(
+				"v1 API: %w (v2 fallback also failed: %w)", newErrorStatusNotOK(request), v2Err,
+			)
+		}
+
 		if request.Raw.StatusCode != http.StatusOK {
 			return nil, newErrorStatusNotOK(request)
 		}
@@ -1007,6 +1063,21 @@ func (api *API) GetPageByIDExpanded(pageID string, expand string) (*PageInfo, er
 	).Get(map[string]string{"expand": expand})
 	if err != nil {
 		return nil, newTransportError(request, "read page "+pageID, err)
+	}
+
+	// A scoped API token cannot read /rest/api/content; v2 holds the same page.
+	// What v1 expands in one request, v2 needs several for -- the body comes
+	// from a format parameter and the ancestors from a walk -- so only what the
+	// caller asked to expand is fetched.
+	if v1Refused(request) {
+		page, v2Err := api.getPageByIDV2(pageID, expand)
+		if v2Err == nil {
+			return page, nil
+		}
+
+		return nil, fmt.Errorf(
+			"v1 API: %w (v2 fallback also failed: %w)", newErrorStatusNotOK(request), v2Err,
+		)
 	}
 
 	if request.Raw.StatusCode != http.StatusOK {
@@ -1103,11 +1174,25 @@ func (api *API) CreatePage(
 		)
 	}
 
-	if request.Raw.StatusCode != http.StatusOK {
+	var page *PageInfo
+
+	switch {
+	case request.Raw.StatusCode == http.StatusOK:
+		page = request.Response.(*PageInfo)
+
+	case v1Refused(request):
+		// A scoped API token may create through v2 and not through v1. The
+		// refusal statuses are the ones no page is created by, so there is
+		// nothing here for a second attempt to duplicate.
+		created, v2Err := api.createContentV2(space, pageType, parent, title, body)
+		if v2Err != nil {
+			return nil, api.explainCreateFailure(space, title, pageType, v2Err)
+		}
+		page = created
+
+	default:
 		return nil, api.explainCreateFailure(space, title, pageType, newErrorStatusNotOK(request))
 	}
-
-	page := request.Response.(*PageInfo)
 
 	if parent != nil {
 		ancestors := make([]struct {
@@ -1233,7 +1318,29 @@ func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, ve
 		)
 	}
 
-	if request.Raw.StatusCode != http.StatusOK {
+	// A scoped API token cannot write through /rest/api/content. v2 takes the
+	// content, and the metadata properties above -- which v1 carries inside the
+	// same request -- have to be written separately afterwards.
+	var propertyErr error
+
+	switch {
+	case request.Raw.StatusCode == http.StatusOK:
+
+	case v1Refused(request):
+		if v2Err := api.updateContentV2(
+			page, newContent, minorEdit, versionMessage, nextPageVersion,
+		); v2Err != nil {
+			return fmt.Errorf(
+				"v1 API: %w (v2 fallback also failed: %w)", newErrorStatusNotOK(request), v2Err,
+			)
+		}
+
+		// Reported once the version this run just wrote has been recorded: the
+		// content is published, and a caller told only that the update failed
+		// would try again against a version number that has already moved.
+		propertyErr = api.setContentPropertiesV2(page.ID, propertyValues(properties))
+
+	default:
 		return newErrorStatusNotOK(request)
 	}
 
@@ -1247,6 +1354,14 @@ func (api *API) UpdatePage(page *PageInfo, newContent string, minorEdit bool, ve
 	// one, which Confluence rejects as a duplicate title. Dropping the entry
 	// costs one lookup and keeps the cache from asserting something untrue.
 	api.forgetMissesForTitle(page.Title, page.Type)
+
+	if propertyErr != nil {
+		return fmt.Errorf(
+			"page %q (%s) was updated, but its page properties were not: %w",
+			page.Title, page.ID, propertyErr,
+		)
+	}
+
 	return nil
 }
 
@@ -1351,6 +1466,21 @@ func (api *API) GetPageLabels(page *PageInfo, prefix string) (*LabelInfo, error)
 		})
 		if err != nil {
 			return nil, newTransportError(request, "read labels of page "+page.ID, err)
+		}
+
+		// Labels are read for every page mark publishes, whether or not the
+		// document declares any, so this listing is on the critical path of a
+		// scoped-token run in the same way the attachment listing is. Adding
+		// and removing labels stays on v1, which has no v2 counterpart.
+		if start == 0 && v1Refused(request) {
+			labels, v2Err := api.getPageLabelsV2(page.ID, prefix)
+			if v2Err == nil {
+				return labels, nil
+			}
+
+			return nil, fmt.Errorf(
+				"v1 API: %w (v2 fallback also failed: %w)", newErrorStatusNotOK(request), v2Err,
+			)
 		}
 
 		if request.Raw.StatusCode != http.StatusOK {

--- a/confluence/api_server_test.go
+++ b/confluence/api_server_test.go
@@ -372,7 +372,7 @@ func TestGetSpaceIDFallsBackToV2(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, space.ID, id)
 
-	assert.Equal(t, 1, server.CountRequests("GET", "/api/v2/spaces"),
+	assert.Equal(t, 1, server.CountRequestsMatching("GET", "/api/v2/spaces", "keys=DOCS"),
 		"v2 answers once v1 refuses")
 }
 
@@ -617,7 +617,7 @@ func TestFindHomePageFallsBackToV2(t *testing.T) {
 
 	assert.Equal(t, 1, server.CountRequests("GET", "/rest/api/space/DOCS"),
 		"v1 is still tried first")
-	assert.Equal(t, 1, server.CountRequests("GET", "/api/v2/spaces"),
+	assert.Equal(t, 1, server.CountRequestsMatching("GET", "/api/v2/spaces", "keys=DOCS"),
 		"and v2 resolves the space once v1 refuses")
 }
 

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -652,8 +652,19 @@ func (s *Server) handleV2(w http.ResponseWriter, r *http.Request, path string) {
 	case "/folders":
 		s.createFolder(w, r)
 
-	case "/pages":
-		s.createPageV2(w, r)
+	case "/pages", "/blogposts":
+		pageType := "page"
+		if path == "/blogposts" {
+			pageType = "blogpost"
+		}
+		switch r.Method {
+		case http.MethodGet:
+			s.listContentV2(w, r, pageType)
+		case http.MethodPost:
+			s.createPageV2(w, r, pageType)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
 
 	default:
 		if folderID, ok := strings.CutPrefix(path, "/folders/"); ok && r.Method == http.MethodGet {
@@ -663,16 +674,34 @@ func (s *Server) handleV2(w http.ResponseWriter, r *http.Request, path string) {
 		// /pages/{id}/direct-children -- children of every type, which is what
 		// separates it from the v1 child/page listing.
 		if rest, ok := strings.CutPrefix(path, "/pages/"); ok {
-			if pageID, sub, found := strings.Cut(rest, "/"); found && sub == "direct-children" {
+			pageID, sub, _ := strings.Cut(rest, "/")
+			switch {
+			case sub == "direct-children":
 				s.directChildren(w, r, pageID)
 				return
+			case sub == "labels":
+				s.labelsV2(w, r, pageID)
+				return
+			case sub == "attachments":
+				s.attachmentsV2(w, r, pageID)
+				return
+			case sub == "properties" || strings.HasPrefix(sub, "properties/"):
+				s.spaceProperties(w, r, "pages", pageID, strings.TrimPrefix(strings.TrimPrefix(sub, "properties"), "/"))
+				return
+			case sub == "":
+				s.contentV2ByID(w, r, pageID, "page")
+				return
 			}
+		}
+		if contentID, ok := strings.CutPrefix(path, "/blogposts/"); ok && !strings.Contains(contentID, "/") {
+			s.contentV2ByID(w, r, contentID, "blogpost")
+			return
 		}
 		// /spaces/{id}/properties and /spaces/{id}/properties/{propertyID}
 		if rest, ok := strings.CutPrefix(path, "/spaces/"); ok {
 			spaceID, sub, _ := strings.Cut(rest, "/")
 			if propertyID, ok := strings.CutPrefix(sub, "properties"); ok {
-				s.spaceProperties(w, r, spaceID, strings.TrimPrefix(propertyID, "/"))
+				s.spaceProperties(w, r, "spaces", spaceID, strings.TrimPrefix(propertyID, "/"))
 				return
 			}
 		}
@@ -890,7 +919,7 @@ func (s *Server) contentProperties(w http.ResponseWriter, r *http.Request, conte
 	}
 }
 
-func (s *Server) spaceProperties(w http.ResponseWriter, r *http.Request, ownerID, propertyID string) {
+func (s *Server) spaceProperties(w http.ResponseWriter, r *http.Request, collection, ownerID, propertyID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -922,8 +951,8 @@ func (s *Server) spaceProperties(w http.ResponseWriter, r *http.Request, ownerID
 		links := map[string]any{}
 		if next != "" {
 			links["next"] = fmt.Sprintf(
-				"/api/v2/spaces/%s/properties?cursor=%s&limit=%s",
-				ownerID, next, r.URL.Query().Get("limit"),
+				"/api/v2/%s/%s/properties?cursor=%s&limit=%s",
+				collection, ownerID, next, r.URL.Query().Get("limit"),
 			)
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"results": results, "_links": links})
@@ -1632,20 +1661,250 @@ func (s *Server) createFolder(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, s.folderJSON(f))
 }
 
-// createPageV2 serves the v2 page create mark uses when the parent is a folder.
-func (s *Server) createPageV2(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
+// contentJSONV2 renders a page or blogpost the way v2 does.
+//
+// The differences from the v1 shape are the ones a client has to cope with: the
+// space is an id, the parent is a single id with its type beside it rather than
+// an ancestor chain, and the body arrives only when a format was asked for.
+//
+// Callers must hold s.mu.
+func (s *Server) contentJSONV2(p *Page, withBody bool) map[string]any {
+	spaceID := ""
+	if sp, ok := s.spaces[p.SpaceKey]; ok {
+		spaceID = sp.ID
+	}
+
+	parentType := ""
+	if p.ParentID != "" {
+		parentType = "page"
+		for _, f := range s.folders {
+			if f.ID == p.ParentID {
+				parentType = "folder"
+			}
+		}
+	}
+
+	out := map[string]any{
+		"id":         p.ID,
+		"status":     p.Status(),
+		"title":      p.Title,
+		"spaceId":    spaceID,
+		"parentId":   p.ParentID,
+		"parentType": parentType,
+		"version": map[string]any{
+			"number":  p.Version,
+			"message": p.Message,
+		},
+		"_links": map[string]any{"webui": "/display/" + p.SpaceKey + "/" + p.ID},
+	}
+
+	if withBody {
+		out["body"] = map[string]any{"storage": map[string]any{"value": p.Body}}
+	}
+
+	return out
+}
+
+// labelsV2 serves the v2 label listing, which pages by cursor and hands the
+// label id over as a number where v1 makes it a string.
+func (s *Server) labelsV2(w http.ResponseWriter, r *http.Request, pageID string) {
+	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	p, ok := s.pages[pageID]
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]any{"message": "no content with id " + pageID})
+		return
+	}
+
+	page, next := cursorPage(r, p.Labels)
+
+	results := []map[string]any{}
+	for i, label := range page {
+		results = append(results, map[string]any{
+			"id":     i + 1,
+			"name":   label,
+			"prefix": "global",
+		})
+	}
+
+	links := map[string]any{}
+	if next != "" {
+		links["next"] = fmt.Sprintf("/api/v2/pages/%s/labels?cursor=%s", pageID, next)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"results": results, "_links": links})
+}
+
+// attachmentsV2 serves the v2 attachment listing, which names the comment and
+// the download link at the top level where v1 nests them.
+func (s *Server) attachmentsV2(w http.ResponseWriter, r *http.Request, pageID string) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var owned []*Attachment
+	for _, a := range s.attachments {
+		if a.PageID == pageID {
+			owned = append(owned, a)
+		}
+	}
+
+	page, next := cursorPage(r, owned)
+
+	results := []map[string]any{}
+	for _, a := range page {
+		results = append(results, map[string]any{
+			"id":           a.ID,
+			"title":        a.Filename,
+			"comment":      a.Comment,
+			"downloadLink": "/download/attachments/" + a.PageID + "/" + a.Filename,
+		})
+	}
+
+	links := map[string]any{}
+	if next != "" {
+		links["next"] = fmt.Sprintf("/api/v2/pages/%s/attachments?cursor=%s", pageID, next)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"results": results, "_links": links})
+}
+
+// listContentV2 serves GET /pages and GET /blogposts: a space, a title and a
+// status, where v1 takes a space key and a type.
+func (s *Server) listContentV2(w http.ResponseWriter, r *http.Request, pageType string) {
+	q := r.URL.Query()
+	spaceID, title := q.Get("space-id"), q.Get("title")
+
+	wanted := map[string]bool{}
+	for _, status := range strings.Split(q.Get("status"), ",") {
+		status = strings.TrimSpace(status)
+		if status != "" {
+			wanted[status] = true
+		}
+	}
+	if len(wanted) == 0 {
+		wanted["current"] = true
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var matches []*Page
+	for _, p := range s.pages {
+		if p.Type != pageType {
+			continue
+		}
+		if spaceID != "" {
+			sp, ok := s.spaces[p.SpaceKey]
+			if !ok || sp.ID != spaceID {
+				continue
+			}
+		}
+		if title != "" && p.Title != title {
+			continue
+		}
+		if !wanted[p.Status()] {
+			continue
+		}
+		matches = append(matches, p)
+	}
+	// Deterministic ordering: the client takes results[0].
+	sort.Slice(matches, func(i, j int) bool { return matches[i].ID < matches[j].ID })
+
+	page, next := cursorPage(r, matches)
+
+	results := []map[string]any{}
+	for _, p := range page {
+		results = append(results, s.contentJSONV2(p, false))
+	}
+
+	links := map[string]any{}
+	if next != "" {
+		links["next"] = fmt.Sprintf("/api/v2/%ss?cursor=%s", pageType, next)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"results": results, "_links": links})
+}
+
+// contentV2ByID serves GET and PUT of a single page or blogpost.
+//
+// A page id and a blogpost id come from the same sequence here, as they do in
+// Confluence, so the type is checked rather than assumed: asking /blogposts for
+// a page id has to answer 404, which is what makes a client's fall through from
+// one collection to the other worth having.
+func (s *Server) contentV2ByID(w http.ResponseWriter, r *http.Request, id, pageType string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	p, ok := s.pages[id]
+	if !ok || p.Type != pageType {
+		writeJSON(w, http.StatusNotFound, map[string]any{"message": "no content with id " + id})
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, s.contentJSONV2(p, r.URL.Query().Get("body-format") != ""))
+
+	case http.MethodPut:
+		var payload struct {
+			Title    string `json:"title"`
+			Status   string `json:"status"`
+			ParentID string `json:"parentId"`
+			Version  struct {
+				Number  int64  `json:"number"`
+				Message string `json:"message"`
+			} `json:"version"`
+			Body struct {
+				Value string `json:"value"`
+			} `json:"body"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"message": "bad payload"})
+			return
+		}
+		if payload.Version.Number != p.Version+1 {
+			writeJSON(w, http.StatusConflict, map[string]any{
+				"message": fmt.Sprintf(
+					"version conflict: expected %d, got %d", p.Version+1, payload.Version.Number,
+				),
+			})
+			return
+		}
+		p.Version = payload.Version.Number
+		p.Message = payload.Version.Message
+		p.Body = payload.Body.Value
+		if payload.Title != "" {
+			p.Title = payload.Title
+		}
+		// v2 names the parent directly, and only a real change of parent
+		// re-places the page among its siblings.
+		if payload.ParentID != "" && payload.ParentID != p.ParentID {
+			p.ParentID = payload.ParentID
+			s.placeChild(payload.ParentID, p.ID, "")
+		}
+		writeJSON(w, http.StatusOK, s.contentJSONV2(p, false))
+
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// createPageV2 serves the v2 page create mark uses when the parent is a folder.
+func (s *Server) createPageV2(w http.ResponseWriter, r *http.Request, pageType string) {
 	var payload struct {
 		SpaceID  string `json:"spaceId"`
 		Title    string `json:"title"`
 		ParentID string `json:"parentId"`
 		Body     struct {
-			Storage struct {
-				Value string `json:"value"`
-			} `json:"storage"`
+			Value string `json:"value"`
 		} `json:"body"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -1666,23 +1925,17 @@ func (s *Server) createPageV2(w http.ResponseWriter, r *http.Request) {
 	p := &Page{
 		ID:       s.newID(),
 		Title:    payload.Title,
-		Type:     "page",
+		Type:     pageType,
 		SpaceKey: spaceKey,
 		ParentID: payload.ParentID,
 		Version:  1,
-		Body:     payload.Body.Storage.Value,
+		Body:     payload.Body.Value,
 	}
 	s.pages[p.ID] = p
 	s.placeChild(p.ParentID, p.ID, "")
 	// The version has to come back. Without it the caller computes the version
 	// it is superseding from zero, and its first update is rejected as stale.
-	writeJSON(w, http.StatusOK, map[string]any{
-		"id":      p.ID,
-		"title":   p.Title,
-		"type":    "page",
-		"version": map[string]any{"number": p.Version},
-		"_links":  map[string]any{"webui": "/display/" + spaceKey + "/" + p.ID},
-	})
+	writeJSON(w, http.StatusOK, s.contentJSONV2(p, false))
 }
 
 func (s *Server) searchUser(w http.ResponseWriter, r *http.Request) {

--- a/confluence/confluencetest/server.go
+++ b/confluence/confluencetest/server.go
@@ -178,6 +178,22 @@ func (s *Server) CountRequests(method, substr string) int {
 	return n
 }
 
+// CountRequestsMatching is CountRequests narrowed by the query string as well,
+// which is what tells two requests to the same endpoint apart -- the Cloud
+// probe and the space lookup both go to /api/v2/spaces.
+func (s *Server) CountRequestsMatching(method, pathSubstr, querySubstr string) int {
+	var n int
+	for _, r := range s.Requests() {
+		if r.Method == method &&
+			strings.Contains(r.Path, pathSubstr) &&
+			strings.Contains(r.Query, querySubstr) {
+			n++
+		}
+	}
+
+	return n
+}
+
 // ResetRequests clears the recorded request log.
 func (s *Server) ResetRequests() {
 	s.mu.Lock()

--- a/confluence/property.go
+++ b/confluence/property.go
@@ -177,6 +177,98 @@ func (api *API) SetSpaceProperty(spaceID, key string, value []byte, existing *Pr
 	return propertyWriteResult(request, key, "space "+spaceID, existing == nil)
 }
 
+// ListPageProperties returns every property stored against a page, through v2.
+//
+// The v1 form of this is ListContentProperties, which is the one to use
+// everywhere v1 answers: it exists on Server and Data Center too. This one is
+// for the scoped-token path, where v1 is refused and the properties a page
+// update carries -- content appearance, emoji title -- have nowhere else to go.
+func (api *API) ListPageProperties(pageID string) ([]Property, error) {
+	var all []Property
+	var cursor string
+
+	for {
+		var result struct {
+			Results []Property `json:"results"`
+			Links   struct {
+				Next string `json:"next"`
+			} `json:"_links"`
+		}
+
+		query := map[string]string{"limit": strconv.Itoa(propertyPageSize)}
+		if cursor != "" {
+			query["cursor"] = cursor
+		}
+
+		request, err := api.v2().
+			Res("pages").
+			Res(pageID).
+			Res("properties", &result).
+			Get(query)
+		if err != nil {
+			return nil, newTransportError(request, "read properties of page "+pageID, err)
+		}
+
+		// As with a space: a page with no properties may answer 404 rather than
+		// an empty collection, and only the first page of the listing may read
+		// it that way.
+		if request.Raw.StatusCode == http.StatusNotFound && cursor == "" {
+			return nil, nil
+		}
+
+		if request.Raw.StatusCode != http.StatusOK {
+			return nil, newErrorStatusNotOK(request)
+		}
+
+		all = append(all, result.Results...)
+
+		next := nextCursor(result.Links.Next)
+		// A server that hands back the cursor it was given would otherwise
+		// keep this loop going for as long as it keeps answering.
+		if next == "" || next == cursor {
+			break
+		}
+		cursor = next
+	}
+
+	return all, nil
+}
+
+// SetPageProperty writes value to a page property through v2, creating it if
+// absent. See ListPageProperties for when this is the right API to use.
+func (api *API) SetPageProperty(pageID, key string, value []byte, existing *Property) error {
+	payload := map[string]any{
+		"key":   key,
+		"value": json.RawMessage(value),
+	}
+
+	var (
+		result  Property
+		request *gopencils.Resource
+		err     error
+	)
+
+	page := api.v2().Res("pages").Res(pageID)
+
+	if existing == nil {
+		// The result pointer goes on the collection resource itself: routing it
+		// through a further Res("") would append a trailing slash, which this
+		// API is not reliably forgiving about.
+		request, err = page.Res("properties", &result).Post(payload)
+	} else {
+		// v2 addresses an update by property id.
+		payload["version"] = map[string]any{"number": existing.Version.Number + 1}
+		request, err = page.Res("properties").Res(existing.ID, &result).Put(payload)
+	}
+	if err != nil {
+		return newTransportError(
+			request, fmt.Sprintf("write property %q of page %s", key, pageID), err,
+		)
+	}
+
+	return propertyWriteResult(request, key, "page "+pageID, existing == nil)
+}
+
 // ListContentProperties returns every property stored against a page.
 //
 // Unlike space properties this is a v1 endpoint, present on Server and Data

--- a/confluence/property.go
+++ b/confluence/property.go
@@ -71,55 +71,7 @@ var ErrPropertyUnseen = errors.New("property already exists but was not listed")
 // key. A space with none is not an error: the first run of anything that stores
 // state this way finds nothing, and that is the normal case.
 func (api *API) ListSpaceProperties(spaceID string) ([]Property, error) {
-	var all []Property
-	var cursor string
-
-	for {
-		var result struct {
-			Results []Property `json:"results"`
-			Links   struct {
-				Next string `json:"next"`
-			} `json:"_links"`
-		}
-
-		query := map[string]string{"limit": strconv.Itoa(propertyPageSize)}
-		if cursor != "" {
-			query["cursor"] = cursor
-		}
-
-		request, err := api.v2().
-			Res("spaces").
-			Res(spaceID).
-			Res("properties", &result).
-			Get(query)
-		if err != nil {
-			return nil, newTransportError(request, "read properties of space "+spaceID, err)
-		}
-
-		// A space with no properties at all answers 404 rather than an empty
-		// collection, so both shapes have to mean "none set". First page only:
-		// a 404 partway through is a real failure, and reading it as "none"
-		// would throw away the pages already in hand.
-		if request.Raw.StatusCode == http.StatusNotFound && cursor == "" {
-			return nil, nil
-		}
-
-		if request.Raw.StatusCode != http.StatusOK {
-			return nil, newErrorStatusNotOK(request)
-		}
-
-		all = append(all, result.Results...)
-
-		next := nextCursor(result.Links.Next)
-		// A server that hands back the cursor it was given would otherwise
-		// keep this loop going for as long as it keeps answering.
-		if next == "" || next == cursor {
-			break
-		}
-		cursor = next
-	}
-
-	return all, nil
+	return api.listPropertiesV2("spaces", spaceID, "space "+spaceID)
 }
 
 // nextCursor pulls the cursor out of a v2 _links.next.
@@ -143,8 +95,120 @@ func nextCursor(next string) string {
 	return parsed.Query().Get("cursor")
 }
 
-// SetSpaceProperty writes value to a space property, creating it if absent.
-func (api *API) SetSpaceProperty(spaceID, key string, value []byte, existing *Property) error {
+// missingIsEmpty and missingIsFailure name the two readings of a 404 on the
+// first page of a v2 listing.
+const (
+	// A collection that has never held anything answers 404 rather than an
+	// empty page -- what a space or a page with no properties does.
+	missingIsEmpty = true
+	// A 404 is the object itself being absent, which is worth reporting.
+	missingIsFailure = false
+)
+
+// listPagedV2 walks a cursor-paged v2 collection, handing each page of results
+// to visit. visit returns false to stop before the collection is exhausted.
+//
+// Every v2 listing pages the same way and carries the same three hazards, which
+// is why they are dealt with here rather than once per caller: the collection
+// may answer 404 instead of coming back empty, a 404 partway through is a real
+// failure that must not be read as "none", and a server that hands back the
+// cursor it was given would otherwise keep the loop going for as long as it
+// keeps answering.
+func listPagedV2[T any](
+	api *API,
+	path string,
+	describe string,
+	query map[string]string,
+	absentIsEmpty bool,
+	visit func([]T) bool,
+) error {
+	var cursor string
+
+	for {
+		var result struct {
+			Results []T `json:"results"`
+			Links   struct {
+				Next string `json:"next"`
+			} `json:"_links"`
+		}
+
+		page := make(map[string]string, len(query)+1)
+		for key, value := range query {
+			page[key] = value
+		}
+		if cursor != "" {
+			page["cursor"] = cursor
+		}
+
+		request, err := api.v2().Res(path, &result).Get(page)
+		if err != nil {
+			return newTransportError(request, describe, err)
+		}
+
+		// First page only: reading a later 404 as "none" would throw away the
+		// pages already in hand.
+		if absentIsEmpty && cursor == "" && request.Raw.StatusCode == http.StatusNotFound {
+			return nil
+		}
+
+		if request.Raw.StatusCode != http.StatusOK {
+			return newErrorStatusNotOK(request)
+		}
+
+		if !visit(result.Results) {
+			return nil
+		}
+
+		next := nextCursor(result.Links.Next)
+		if next == "" || next == cursor || len(result.Results) == 0 {
+			return nil
+		}
+		cursor = next
+	}
+}
+
+// collectPagedV2 is listPagedV2 for a caller that wants the whole collection.
+func collectPagedV2[T any](
+	api *API,
+	path string,
+	describe string,
+	query map[string]string,
+	absentIsEmpty bool,
+) ([]T, error) {
+	var all []T
+
+	err := listPagedV2(api, path, describe, query, absentIsEmpty, func(page []T) bool {
+		all = append(all, page...)
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return all, nil
+}
+
+// listPropertiesV2 returns every property stored against one v2 object.
+//
+// owner names it for an error message -- "space 123", "page 456" -- since the
+// collection and the id read as an URL rather than as English.
+func (api *API) listPropertiesV2(collection, ownerID, owner string) ([]Property, error) {
+	return collectPagedV2[Property](
+		api,
+		collection+"/"+ownerID+"/properties",
+		"read properties of "+owner,
+		map[string]string{"limit": strconv.Itoa(propertyPageSize)},
+		missingIsEmpty,
+	)
+}
+
+// setPropertyV2 writes value to a property of one v2 object, creating it if
+// absent.
+func (api *API) setPropertyV2(
+	collection, ownerID, owner, key string,
+	value []byte,
+	existing *Property,
+) error {
 	payload := map[string]any{
 		"key":   key,
 		"value": json.RawMessage(value),
@@ -156,25 +220,30 @@ func (api *API) SetSpaceProperty(spaceID, key string, value []byte, existing *Pr
 		err     error
 	)
 
-	space := api.v2().Res("spaces").Res(spaceID)
+	object := api.v2().Res(collection).Res(ownerID)
 
 	if existing == nil {
 		// The result pointer goes on the collection resource itself: routing it
 		// through a further Res("") would append a trailing slash, which this
 		// API is not reliably forgiving about.
-		request, err = space.Res("properties", &result).Post(payload)
+		request, err = object.Res("properties", &result).Post(payload)
 	} else {
 		// v2 addresses an update by property id.
 		payload["version"] = map[string]any{"number": existing.Version.Number + 1}
-		request, err = space.Res("properties").Res(existing.ID, &result).Put(payload)
+		request, err = object.Res("properties").Res(existing.ID, &result).Put(payload)
 	}
 	if err != nil {
 		return newTransportError(
-			request, fmt.Sprintf("write property %q of space %s", key, spaceID), err,
+			request, fmt.Sprintf("write property %q of %s", key, owner), err,
 		)
 	}
 
-	return propertyWriteResult(request, key, "space "+spaceID, existing == nil)
+	return propertyWriteResult(request, key, owner, existing == nil)
+}
+
+// SetSpaceProperty writes value to a space property, creating it if absent.
+func (api *API) SetSpaceProperty(spaceID, key string, value []byte, existing *Property) error {
+	return api.setPropertyV2("spaces", spaceID, "space "+spaceID, key, value, existing)
 }
 
 // ListPageProperties returns every property stored against a page, through v2.
@@ -184,89 +253,13 @@ func (api *API) SetSpaceProperty(spaceID, key string, value []byte, existing *Pr
 // for the scoped-token path, where v1 is refused and the properties a page
 // update carries -- content appearance, emoji title -- have nowhere else to go.
 func (api *API) ListPageProperties(pageID string) ([]Property, error) {
-	var all []Property
-	var cursor string
-
-	for {
-		var result struct {
-			Results []Property `json:"results"`
-			Links   struct {
-				Next string `json:"next"`
-			} `json:"_links"`
-		}
-
-		query := map[string]string{"limit": strconv.Itoa(propertyPageSize)}
-		if cursor != "" {
-			query["cursor"] = cursor
-		}
-
-		request, err := api.v2().
-			Res("pages").
-			Res(pageID).
-			Res("properties", &result).
-			Get(query)
-		if err != nil {
-			return nil, newTransportError(request, "read properties of page "+pageID, err)
-		}
-
-		// As with a space: a page with no properties may answer 404 rather than
-		// an empty collection, and only the first page of the listing may read
-		// it that way.
-		if request.Raw.StatusCode == http.StatusNotFound && cursor == "" {
-			return nil, nil
-		}
-
-		if request.Raw.StatusCode != http.StatusOK {
-			return nil, newErrorStatusNotOK(request)
-		}
-
-		all = append(all, result.Results...)
-
-		next := nextCursor(result.Links.Next)
-		// A server that hands back the cursor it was given would otherwise
-		// keep this loop going for as long as it keeps answering.
-		if next == "" || next == cursor {
-			break
-		}
-		cursor = next
-	}
-
-	return all, nil
+	return api.listPropertiesV2("pages", pageID, "page "+pageID)
 }
 
 // SetPageProperty writes value to a page property through v2, creating it if
 // absent. See ListPageProperties for when this is the right API to use.
 func (api *API) SetPageProperty(pageID, key string, value []byte, existing *Property) error {
-	payload := map[string]any{
-		"key":   key,
-		"value": json.RawMessage(value),
-	}
-
-	var (
-		result  Property
-		request *gopencils.Resource
-		err     error
-	)
-
-	page := api.v2().Res("pages").Res(pageID)
-
-	if existing == nil {
-		// The result pointer goes on the collection resource itself: routing it
-		// through a further Res("") would append a trailing slash, which this
-		// API is not reliably forgiving about.
-		request, err = page.Res("properties", &result).Post(payload)
-	} else {
-		// v2 addresses an update by property id.
-		payload["version"] = map[string]any{"number": existing.Version.Number + 1}
-		request, err = page.Res("properties").Res(existing.ID, &result).Put(payload)
-	}
-	if err != nil {
-		return newTransportError(
-			request, fmt.Sprintf("write property %q of page %s", key, pageID), err,
-		)
-	}
-
-	return propertyWriteResult(request, key, "page "+pageID, existing == nil)
+	return api.setPropertyV2("pages", pageID, "page "+pageID, key, value, existing)
 }
 
 // ListContentProperties returns every property stored against a page.

--- a/confluence/scopedtoken_test.go
+++ b/confluence/scopedtoken_test.go
@@ -332,7 +332,7 @@ func TestFindPageV2LooksUpTheSpaceOnce(t *testing.T) {
 		require.NotNil(t, page)
 	}
 
-	assert.Equal(t, 1, server.CountRequests("GET", "/api/v2/spaces"),
+	assert.Equal(t, 1, server.CountRequestsMatching("GET", "/api/v2/spaces", "keys=DOCS"),
 		"the space id is cached for the life of the API value")
 }
 
@@ -372,4 +372,95 @@ func TestGetPageLabelsFallsBackToV2(t *testing.T) {
 	require.Len(t, labels.Labels, 1)
 	assert.Equal(t, "from-mark", labels.Labels[0].Name)
 	assert.Equal(t, "global", labels.Labels[0].Prefix)
+}
+
+// dataCenter answers the way Confluence Server and Data Center do: v1 is the
+// only API there is, and every /api/v2 path is a 404 from a route that was
+// never going to exist.
+func dataCenter(v1Status int, v1Path string) confluencetest.FailFunc {
+	return func(r *http.Request) (int, string, bool) {
+		if strings.HasPrefix(r.URL.Path, "/api/v2") {
+			return http.StatusNotFound, `<html>404 Not Found</html>`, true
+		}
+		if v1Path != "" && strings.Contains(r.URL.Path, v1Path) {
+			return v1Status, `{"message":"no"}`, true
+		}
+		return 0, "", false
+	}
+}
+
+// TestDataCenterKeepsTheV1Failure is the reason the fallback is gated rather
+// than merely attempted. A 403 and a 404 mean different things, and mark acts
+// on the difference: page/orphan reads ErrNotFound as "the page is gone", which
+// --on-orphan archives or trashes. Pairing v1's 403 with the 404 that any
+// /api/v2 path answers on Data Center made a permission failure say exactly
+// that.
+func TestDataCenterKeepsTheV1Failure(t *testing.T) {
+	api, server := newAPI(t)
+	page := server.AddPage("DOCS", "Doc", "page", "")
+	server.SetFail(dataCenter(http.StatusForbidden, "/rest/api/content/"+page.ID))
+
+	_, err := api.GetPageByID(page.ID)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, confluence.ErrNotFound,
+		"a page mark may not read is not a page that is gone")
+	assert.Contains(t, err.Error(), "403")
+	assert.NotContains(t, err.Error(), "/api/v2",
+		"a deployment without v2 should not be told about a path it does not have")
+}
+
+// TestDataCenterProbesForV2Once: the probe that settles whether a deployment
+// has a v2 API at all is made once for the life of the API value, however many
+// calls are refused afterwards.
+func TestDataCenterProbesForV2Once(t *testing.T) {
+	api, server := newAPI(t)
+	page := server.AddPage("DOCS", "Doc", "page", "")
+	server.SetFail(dataCenter(http.StatusForbidden, "/rest/api/content/"))
+
+	for range 5 {
+		_, err := api.GetPageByID(page.ID)
+		require.Error(t, err)
+	}
+
+	assert.Equal(t, 1, server.CountRequestsMatching("GET", "/api/v2/spaces", "limit=1"),
+		"one probe decides it, and the answer is remembered")
+	assert.Equal(t, 0, server.CountRequests("GET", "/api/v2/pages"),
+		"and no fallback is attempted against an API that is not there")
+}
+
+// TestDataCenterLookupStillReportsAbsence: the ordinary v1 answers have to go on
+// meaning what they meant, gate or no gate.
+func TestDataCenterLookupStillReportsAbsence(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddSpace("DOCS")
+	server.SetFail(dataCenter(0, ""))
+
+	page, err := api.FindPage("DOCS", "Nope", "page")
+	require.NoError(t, err)
+	assert.Nil(t, page)
+
+	assert.Equal(t, 0, server.CountRequests("GET", "/api/v2/pages"),
+		"v1 answered, and there is no v2 to ask anyway")
+}
+
+// TestDataCenterPublishes walks a whole publish on a deployment that has no v2:
+// the fallbacks must be invisible there.
+func TestDataCenterPublishes(t *testing.T) {
+	api, server := newAPI(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.SetFail(dataCenter(0, ""))
+
+	root, err := api.FindHomePage("DOCS")
+	require.NoError(t, err)
+	require.NotNil(t, root)
+
+	created, err := api.CreatePage("DOCS", "page", root, "Guide", "")
+	require.NoError(t, err)
+	require.NoError(t, api.UpdatePage(created, "<p>guide</p>", false, "", "full-width", ""))
+
+	stored := server.Page(created.ID)
+	require.NotNil(t, stored)
+	assert.Equal(t, "<p>guide</p>", stored.Body)
+	assert.Equal(t, home.ID, stored.ParentID)
 }

--- a/confluence/scopedtoken_test.go
+++ b/confluence/scopedtoken_test.go
@@ -1,0 +1,375 @@
+package confluence_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These cover issue #917: a scoped API token reaches Confluence through the
+// api.atlassian.com gateway, which checks the token's granular scopes against
+// the endpoint being called and refuses every v1 one to a token minted for
+// pages. FindHomePage already fell back to v2 (#341), so a run got past the
+// space lookup and then died on the first page lookup.
+
+// scopedTokenGateway refuses v1 the way the gateway refuses it: with the status
+// and body Atlassian answers a scope check with.
+func scopedTokenGateway() confluencetest.FailFunc {
+	return func(r *http.Request) (int, string, bool) {
+		if strings.HasPrefix(r.URL.Path, "/rest/api") {
+			return http.StatusUnauthorized,
+				`{"code":401,"message":"Unauthorized; scope does not match"}`, true
+		}
+		return 0, "", false
+	}
+}
+
+func TestFindPageFallsBackToV2(t *testing.T) {
+	api, server := newAPI(t)
+	parent := server.AddPage("DOCS", "Parent", "page", "")
+	child := server.AddPage("DOCS", "Child", "page", parent.ID)
+	server.SetFail(scopedTokenGateway())
+
+	page, err := api.FindPage("DOCS", "Child", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+	assert.Equal(t, child.ID, page.ID)
+	assert.Equal(t, "Child", page.Title)
+	assert.Equal(t, "page", page.Type)
+	assert.Equal(t, int64(1), page.Version.Number)
+
+	// The ancestor chain is what mark decides page placement from, and v2 names
+	// only the immediate parent -- so it has to be walked back rather than left
+	// empty, which would read as a page sitting at the root of the space.
+	require.Len(t, page.Ancestors, 1)
+	assert.Equal(t, parent.ID, page.Ancestors[0].ID)
+	assert.Equal(t, "Parent", page.Ancestors[0].Title)
+}
+
+// TestFindPageV2AncestorsAreRootFirst pins the order every caller relies on:
+// the parent is the last entry, not the first.
+func TestFindPageV2AncestorsAreRootFirst(t *testing.T) {
+	api, server := newAPI(t)
+	root := server.AddPage("DOCS", "Root", "page", "")
+	middle := server.AddPage("DOCS", "Middle", "page", root.ID)
+	server.AddPage("DOCS", "Leaf", "page", middle.ID)
+	server.SetFail(scopedTokenGateway())
+
+	page, err := api.FindPage("DOCS", "Leaf", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+
+	require.Len(t, page.Ancestors, 2)
+	assert.Equal(t, "Root", page.Ancestors[0].Title)
+	assert.Equal(t, "Middle", page.Ancestors[1].Title)
+}
+
+// TestFindPageV2StopsAtAFolder: a folder is not an ancestor, and asking the
+// page collection for one answers 404. The chain has to end there rather than
+// fail the lookup.
+func TestFindPageV2StopsAtAFolder(t *testing.T) {
+	api, server := newAPI(t)
+	folder := server.AddFolder("DOCS", "Folder", "", "space")
+	server.AddPage("DOCS", "Inside", "page", folder.ID)
+	server.SetFail(scopedTokenGateway())
+
+	page, err := api.FindPage("DOCS", "Inside", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+	assert.Empty(t, page.Ancestors)
+}
+
+// TestFindPageV2ReportsAbsence: the fallback has to be able to say "no such
+// page" as plainly as v1 does, or every lookup of a page mark is about to
+// create becomes an error.
+func TestFindPageV2ReportsAbsence(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddSpace("DOCS")
+	server.SetFail(scopedTokenGateway())
+
+	page, err := api.FindPage("DOCS", "Nope", "page")
+	require.NoError(t, err)
+	assert.Nil(t, page)
+}
+
+// TestFindPagePrefersV1 pins that the fallback is a fallback: a classic token
+// gets its answer from v1 with no v2 round trip at all.
+func TestFindPagePrefersV1(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddPage("DOCS", "Child", "page", "")
+
+	page, err := api.FindPage("DOCS", "Child", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+
+	assert.Equal(t, 0, server.CountRequests("GET", "/api/v2/pages"),
+		"v1 answered, so v2 must not be consulted")
+}
+
+// TestFindPageReportsV1ErrorWhenV2CannotAnswer: on Server and Data Center there
+// is no v2 at all, so a genuine 401 from v1 must survive the attempt rather
+// than being replaced by a 404 from a path that never existed.
+func TestFindPageReportsV1ErrorWhenV2Unavailable(t *testing.T) {
+	api, server := newAPI(t)
+	server.AddSpace("DOCS")
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if strings.HasPrefix(r.URL.Path, "/rest/api") {
+			return http.StatusUnauthorized, `{"message":"bad credentials"}`, true
+		}
+		if strings.HasPrefix(r.URL.Path, "/api/v2") {
+			return http.StatusNotFound, `<html>404</html>`, true
+		}
+		return 0, "", false
+	})
+
+	_, err := api.FindPage("DOCS", "Child", "page")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+}
+
+func TestGetPageByIDFallsBackToV2(t *testing.T) {
+	api, server := newAPI(t)
+	parent := server.AddPage("DOCS", "Parent", "page", "")
+	child := server.AddPage("DOCS", "Child", "page", parent.ID)
+	server.EditPage(child.ID, "<p>stored</p>")
+	server.SetFail(scopedTokenGateway())
+
+	page, err := api.GetPageByIDExpanded(child.ID, "ancestors,version,body.storage")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+	assert.Equal(t, "Child", page.Title)
+	assert.Equal(t, "<p>stored</p>", page.Body.Storage.Value)
+	require.Len(t, page.Ancestors, 1)
+	assert.Equal(t, parent.ID, page.Ancestors[0].ID)
+}
+
+// TestGetPageByIDV2SkipsWhatWasNotExpanded: v2 charges a request per ancestor
+// level, so a caller that asked for neither the body nor the ancestors must not
+// pay for them.
+func TestGetPageByIDV2SkipsWhatWasNotExpanded(t *testing.T) {
+	api, server := newAPI(t)
+	parent := server.AddPage("DOCS", "Parent", "page", "")
+	child := server.AddPage("DOCS", "Child", "page", parent.ID)
+	server.SetFail(scopedTokenGateway())
+
+	page, err := api.GetPageByIDExpanded(child.ID, "version")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+	assert.Empty(t, page.Ancestors)
+
+	assert.Equal(t, 1, server.CountRequests("GET", "/api/v2/pages/"),
+		"the page itself, and nothing above it")
+}
+
+func TestCreatePageFallsBackToV2(t *testing.T) {
+	api, server := newAPI(t)
+	parentPage := server.AddPage("DOCS", "Parent", "page", "")
+	server.SetFail(scopedTokenGateway())
+
+	parent, err := api.FindPage("DOCS", "Parent", "page")
+	require.NoError(t, err)
+	require.NotNil(t, parent)
+
+	page, err := api.CreatePage("DOCS", "page", parent, "Created", "<p>new</p>")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+	assert.Equal(t, "Created", page.Title)
+
+	stored := server.Page(page.ID)
+	require.NotNil(t, stored)
+	assert.Equal(t, "<p>new</p>", stored.Body)
+	assert.Equal(t, parentPage.ID, stored.ParentID)
+	assert.Equal(t, int64(1), page.Version.Number,
+		"the created version has to come back, or the first update is stale")
+
+	// The ancestors of a created page are the parent's plus the parent, as they
+	// are on v1: the caller updates the page a moment later and moves it to the
+	// root of the space if it thinks it has none.
+	require.Len(t, page.Ancestors, 1)
+	assert.Equal(t, parentPage.ID, page.Ancestors[0].ID)
+}
+
+func TestUpdatePageFallsBackToV2(t *testing.T) {
+	api, server := newAPI(t)
+	parent := server.AddPage("DOCS", "Parent", "page", "")
+	child := server.AddPage("DOCS", "Child", "page", parent.ID)
+	server.SetFail(scopedTokenGateway())
+
+	page, err := api.FindPage("DOCS", "Child", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+
+	require.NoError(t, api.UpdatePage(page, "<p>published</p>", false, "a message", "full-width", ""))
+
+	stored := server.Page(child.ID)
+	require.NotNil(t, stored)
+	assert.Equal(t, "<p>published</p>", stored.Body)
+	assert.Equal(t, int64(2), stored.Version)
+	assert.Equal(t, "a message", stored.Message)
+	assert.Equal(t, parent.ID, stored.ParentID, "an update must not move the page")
+	assert.Equal(t, int64(2), page.Version.Number, "the caller's copy has to move with it")
+}
+
+// TestUpdatePageV2WritesTheProperties: v1 carries content appearance and the
+// emoji title inside the update itself, and v2 has no room for them there. They
+// are page properties, and dropping them would silently ignore
+// --content-appearance and the emoji metadata for every scoped-token run.
+func TestUpdatePageV2WritesTheProperties(t *testing.T) {
+	api, server := newAPI(t)
+	child := server.AddPage("DOCS", "Child", "page", "")
+	server.SetFail(scopedTokenGateway())
+
+	page, err := api.FindPage("DOCS", "Child", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+
+	require.NoError(t, api.UpdatePage(page, "<p>published</p>", false, "", "full-width", "🐧"))
+
+	appearance := server.SpaceProperty(child.ID, "content-appearance-published")
+	require.NotNil(t, appearance)
+	assert.JSONEq(t, `"full-width"`, string(appearance.Value))
+
+	emoji := server.SpaceProperty(child.ID, "emoji-title-published")
+	require.NotNil(t, emoji)
+	assert.JSONEq(t, `"1f427"`, string(emoji.Value))
+}
+
+// TestUpdatePageV2UpdatesAPropertyItAlreadySet: the second run of the same
+// document rewrites a property that exists, which v2 versions -- a create where
+// an update was called for is a conflict, not an overwrite.
+func TestUpdatePageV2UpdatesAPropertyItAlreadySet(t *testing.T) {
+	api, server := newAPI(t)
+	child := server.AddPage("DOCS", "Child", "page", "")
+	server.SetFail(scopedTokenGateway())
+
+	for _, appearance := range []string{"full-width", "default"} {
+		page, err := api.GetPageByID(child.ID)
+		require.NoError(t, err)
+		require.NoError(t, api.UpdatePage(page, "<p>published</p>", false, "", appearance, ""))
+	}
+
+	property := server.SpaceProperty(child.ID, "content-appearance-published")
+	require.NotNil(t, property)
+	assert.JSONEq(t, `"default"`, string(property.Value))
+}
+
+// TestUpdatePageV2ReportsAPropertyFailureAfterPublishing: the content is in by
+// the time the properties are written, so the failure has to say so -- and the
+// version the run just wrote has to be recorded, or the next attempt collides
+// with it.
+func TestUpdatePageV2ReportsAPropertyFailureAfterPublishing(t *testing.T) {
+	api, server := newAPI(t)
+	child := server.AddPage("DOCS", "Child", "page", "")
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if strings.HasPrefix(r.URL.Path, "/rest/api") {
+			return http.StatusUnauthorized, `{"message":"scope does not match"}`, true
+		}
+		if strings.Contains(r.URL.Path, "/properties") {
+			return http.StatusForbidden, `{"message":"no property scope"}`, true
+		}
+		return 0, "", false
+	})
+
+	page, err := api.GetPageByID(child.ID)
+	require.NoError(t, err)
+
+	err = api.UpdatePage(page, "<p>published</p>", false, "", "full-width", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "was updated")
+	assert.Equal(t, int64(2), server.Page(child.ID).Version)
+	assert.Equal(t, int64(2), page.Version.Number)
+}
+
+// TestPublishThroughTheGateway walks the sequence a scoped-token run makes:
+// resolve the space, look the page up, create it, and update it. Each step used
+// to end the run at the first v1 call it reached.
+func TestPublishThroughTheGateway(t *testing.T) {
+	api, server := newAPI(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.SetFail(scopedTokenGateway())
+
+	root, err := api.FindHomePage("DOCS")
+	require.NoError(t, err)
+	require.NotNil(t, root)
+
+	missing, err := api.FindPage("DOCS", "Guide", "page")
+	require.NoError(t, err)
+	require.Nil(t, missing)
+
+	created, err := api.CreatePage("DOCS", "page", root, "Guide", "")
+	require.NoError(t, err)
+	require.NoError(t, api.UpdatePage(created, "<p>guide</p>", false, "", "full-width", ""))
+
+	stored := server.Page(created.ID)
+	require.NotNil(t, stored)
+	assert.Equal(t, "<p>guide</p>", stored.Body)
+	assert.Equal(t, home.ID, stored.ParentID)
+}
+
+func newScopedAPI(t *testing.T) (*confluence.API, *confluencetest.Server) {
+	t.Helper()
+	api, server := newAPI(t)
+	server.SetFail(scopedTokenGateway())
+	return api, server
+}
+
+// TestFindPageV2LooksUpTheSpaceOnce: v2 filters by space id where v1 takes a
+// key, and a lookup per file would be a request per file.
+func TestFindPageV2LooksUpTheSpaceOnce(t *testing.T) {
+	api, server := newScopedAPI(t)
+	server.AddPage("DOCS", "One", "page", "")
+	server.AddPage("DOCS", "Two", "page", "")
+
+	for _, title := range []string{"One", "Two"} {
+		page, err := api.FindPage("DOCS", title, "page")
+		require.NoError(t, err)
+		require.NotNil(t, page)
+	}
+
+	assert.Equal(t, 1, server.CountRequests("GET", "/api/v2/spaces"),
+		"the space id is cached for the life of the API value")
+}
+
+// TestGetAttachmentsFallsBackToV2: the attachment listing is made for every
+// page mark publishes, whether the document has attachments or not, so a token
+// that cannot read it cannot publish at all. The checksum mark recognises an
+// unchanged attachment by lives in the comment, which v2 keeps at the top level
+// rather than under metadata.
+func TestGetAttachmentsFallsBackToV2(t *testing.T) {
+	api, server := newScopedAPI(t)
+	page := server.AddPage("DOCS", "Child", "page", "")
+	server.AddAttachment(page.ID, "diagram.png", "mark:checksum: abc123")
+
+	attachments, err := api.GetAttachments(page.ID)
+	require.NoError(t, err)
+	require.Len(t, attachments, 1)
+	assert.Equal(t, "diagram.png", attachments[0].Filename)
+	assert.Equal(t, "mark:checksum: abc123", attachments[0].Metadata.Comment)
+	assert.Contains(t, attachments[0].Links.Download, "diagram.png")
+	assert.Equal(t, "/wiki", attachments[0].Links.Context,
+		"v2 gives no link context, and Cloud -- the only place v2 exists -- is mounted at /wiki")
+}
+
+// TestGetPageLabelsFallsBackToV2: labels are read for every page too, and v2
+// hands the label id over as a number where v1 makes it a string.
+func TestGetPageLabelsFallsBackToV2(t *testing.T) {
+	api, server := newScopedAPI(t)
+	stored := server.AddPage("DOCS", "Child", "page", "")
+	server.AddLabel(stored.ID, "from-mark")
+
+	page, err := api.FindPage("DOCS", "Child", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+
+	labels, err := api.GetPageLabels(page, "global")
+	require.NoError(t, err)
+	require.Len(t, labels.Labels, 1)
+	assert.Equal(t, "from-mark", labels.Labels[0].Name)
+	assert.Equal(t, "global", labels.Labels[0].Prefix)
+}

--- a/confluence/space_test.go
+++ b/confluence/space_test.go
@@ -43,7 +43,7 @@ func TestFindHomePageCachesFailures(t *testing.T) {
 	}
 
 	assert.Equal(t, 1, server.CountRequests("GET", "/rest/api/space/NOPE"))
-	assert.Equal(t, 1, server.CountRequests("GET", "/api/v2/spaces"))
+	assert.Equal(t, 1, server.CountRequestsMatching("GET", "/api/v2/spaces", "keys=NOPE"))
 }
 
 // TestGetSpaceIDIsCached is the same property for the other space lookup, which

--- a/confluence/v2fallback.go
+++ b/confluence/v2fallback.go
@@ -29,10 +29,11 @@ import (
 // issue #917: FindHomePage already fell back to v2 (#341), so the run got past
 // the space lookup and then died on the very next call.
 //
-// v1 stays the first choice everywhere. It is the only API Server and Data
-// Center have, its answers carry ancestors and a body without extra round
-// trips, and a classic token is entitled to it. v2 is asked only once v1 has
-// refused, so nothing changes for anybody whose token v1 accepts.
+// v1 stays the first choice everywhere. Its answers carry ancestors and a body
+// without extra round trips, and a classic token is entitled to it. v2 is asked
+// only once v1 has refused, and only where a v2 exists to ask -- Server and
+// Data Center have none, so nothing changes there at all, nor for anybody whose
+// token v1 accepts.
 
 // maxAncestorDepth bounds the parent walk that rebuilds a v2 ancestor chain.
 //
@@ -62,6 +63,35 @@ func v1Refused(request *gopencils.Resource) bool {
 	}
 
 	return false
+}
+
+// v2Available reports whether this deployment has a v2 API to fall back to.
+//
+// Server and Data Center do not. Every /api/v2 path there is a 404 from a route
+// that was never going to exist, so asking costs a request per call and buries
+// the v1 answer that actually explains the failure underneath one from a path
+// nobody asked about -- which is worse than useless when the two disagree about
+// what kind of failure it was: a v1 403 paired with a v2 404 reads as
+// ErrNotFound, and "this page is gone" is a conclusion --on-orphan acts on.
+//
+// IsCloud is the test mark already applies to its other Cloud-only features. It
+// answers without a request at all for the hosts a scoped API token goes
+// through, and otherwise probes once for the life of the API value.
+func (api *API) v2Available() bool {
+	return api.IsCloud()
+}
+
+// v1FailedAndSoDidV2 reports a v1 failure together with the v2 attempt that
+// followed it.
+//
+// Only the v1 error is wrapped. The v2 one contributes its text and nothing
+// else, deliberately: a fallback that answers 404 -- which is what any /api/v2
+// path does on a deployment that has none -- would otherwise make
+// errors.Is(err, ErrNotFound) true for a v1 failure that was nothing of the
+// kind, and "this page is gone" is a conclusion --on-orphan acts on.
+func v1FailedAndSoDidV2(v1Err, v2Err error) error {
+	//nolint:errorlint // the v2 error is rendered rather than wrapped on purpose; see above.
+	return fmt.Errorf("v1 API: %w (v2 fallback also failed: %s)", v1Err, v2Err)
 }
 
 // ancestorRef is the shape PageInfo.Ancestors holds. It is an alias rather than

--- a/confluence/v2fallback.go
+++ b/confluence/v2fallback.go
@@ -2,6 +2,7 @@ package confluence
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -92,6 +93,28 @@ func (api *API) v2Available() bool {
 func v1FailedAndSoDidV2(v1Err, v2Err error) error {
 	//nolint:errorlint // the v2 error is rendered rather than wrapped on purpose; see above.
 	return fmt.Errorf("v1 API: %w (v2 fallback also failed: %s)", v1Err, v2Err)
+}
+
+// fallbackV2 answers a refused v1 request with whatever v2 says, and reports
+// whether it took the call over at all.
+//
+// ok is false when v1's answer is v1's to keep -- it was not a refusal, or this
+// deployment has no v2 to ask -- and the caller carries on with the answer it
+// already has. When ok is true the call is settled either way: err is nil and
+// the result is v2's, or err names both failures.
+func fallbackV2[T any](api *API, request *gopencils.Resource, v2 func() (T, error)) (T, bool, error) {
+	var zero T
+
+	if !v1Refused(request) || !api.v2Available() {
+		return zero, false, nil
+	}
+
+	result, err := v2()
+	if err != nil {
+		return zero, true, v1FailedAndSoDidV2(newErrorStatusNotOK(request), err)
+	}
+
+	return result, true, nil
 }
 
 // ancestorRef is the shape PageInfo.Ancestors holds. It is an alias rather than
@@ -218,36 +241,45 @@ func (api *API) findContentV2(space, title, pageType, status string) (*PageInfo,
 // say, a 404 from pages is retried against blogposts -- the same two-step v1
 // spared everybody by having a single /content collection.
 func (api *API) getContentV2(contentID string, withBody bool) (*contentV2, string, error) {
-	for _, collection := range []string{"pages", "blogposts"} {
-		var result contentV2
-
-		query := map[string]string{}
-		if withBody {
-			query["body-format"] = "storage"
-		}
-
-		request, err := api.v2().Res(collection+"/"+contentID, &result).Get(query)
-		if err != nil {
-			return nil, "", newTransportError(request, "read page "+contentID, err)
-		}
-
-		if request.Raw.StatusCode == http.StatusNotFound && collection == "pages" {
-			continue
-		}
-
-		if request.Raw.StatusCode != http.StatusOK {
-			return nil, "", newErrorStatusNotOK(request)
-		}
-
-		pageType := "page"
-		if collection == "blogposts" {
-			pageType = "blogpost"
-		}
-
-		return &result, pageType, nil
+	content, err := api.readContentV2("pages", contentID, withBody)
+	if err == nil {
+		return content, "page", nil
 	}
 
-	return nil, "", fmt.Errorf("no content with id %s: %w", contentID, ErrNotFound)
+	if !errors.Is(err, ErrNotFound) {
+		return nil, "", err
+	}
+
+	content, err = api.readContentV2("blogposts", contentID, withBody)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return content, "blogpost", nil
+}
+
+// readContentV2 reads one object out of a named v2 collection.
+//
+// A 404 comes back wrapping ErrNotFound, which is what lets getContentV2 tell
+// "not in this collection" apart from a failure worth reporting.
+func (api *API) readContentV2(collection, contentID string, withBody bool) (*contentV2, error) {
+	var result contentV2
+
+	query := map[string]string{}
+	if withBody {
+		query["body-format"] = "storage"
+	}
+
+	request, err := api.v2().Res(collection+"/"+contentID, &result).Get(query)
+	if err != nil {
+		return nil, newTransportError(request, "read page "+contentID, err)
+	}
+
+	if request.Raw.StatusCode != http.StatusOK {
+		return nil, newErrorStatusNotOK(request)
+	}
+
+	return &result, nil
 }
 
 // getPageByIDV2 is GetPageByIDExpanded against v2.
@@ -298,7 +330,9 @@ func (api *API) ancestorsV2(content contentV2) ([]ancestorRef, error) {
 		}
 		seen[parentID] = true
 
-		parent, _, err := api.getContentV2(parentID, false)
+		// A page, never a blogpost -- so this asks the one collection rather
+		// than paying getContentV2's 404-then-retry for every level.
+		parent, err := api.readContentV2("pages", parentID, false)
 		if err != nil {
 			// An ancestor that cannot be read at all is reported: answering
 			// with a chain known to be short would tell the caller the page
@@ -333,61 +367,38 @@ const cloudContextPath = "/wiki"
 // scopes in its documentation rather than pretending v2 is enough for
 // everything.
 func (api *API) getAttachmentsV2(pageID string) ([]AttachmentInfo, error) {
-	const pageSize = 100
-
-	var all []AttachmentInfo
-	var cursor string
-
-	for {
-		var result struct {
-			Results []struct {
-				ID           string `json:"id"`
-				Title        string `json:"title"`
-				Comment      string `json:"comment"`
-				DownloadLink string `json:"downloadLink"`
-			} `json:"results"`
-
-			Links struct {
-				Next string `json:"next"`
-			} `json:"_links"`
-		}
-
-		query := map[string]string{"limit": fmt.Sprintf("%d", pageSize)}
-		if cursor != "" {
-			query["cursor"] = cursor
-		}
-
-		request, err := api.v2().Res("pages/"+pageID+"/attachments", &result).Get(query)
-		if err != nil {
-			return nil, newTransportError(request, "list attachments of page "+pageID, err)
-		}
-
-		if request.Raw.StatusCode != http.StatusOK {
-			return nil, newErrorStatusNotOK(request)
-		}
-
-		for _, attachment := range result.Results {
-			info := AttachmentInfo{Filename: attachment.Title, ID: attachment.ID}
-			// The checksum mark recognises an unchanged attachment by lives in
-			// the comment, which v2 keeps at the top level rather than under
-			// metadata.
-			info.Metadata.Comment = attachment.Comment
-			info.Links.Context = cloudContextPath
-			info.Links.Download = attachment.DownloadLink
-
-			all = append(all, info)
-		}
-
-		next := nextCursor(result.Links.Next)
-		// A server that hands back the cursor it was given would otherwise keep
-		// this loop going for as long as it keeps answering.
-		if next == "" || next == cursor || len(result.Results) == 0 {
-			break
-		}
-		cursor = next
+	type attachmentV2 struct {
+		ID           string `json:"id"`
+		Title        string `json:"title"`
+		Comment      string `json:"comment"`
+		DownloadLink string `json:"downloadLink"`
 	}
 
-	return all, nil
+	found, err := collectPagedV2[attachmentV2](
+		api,
+		"pages/"+pageID+"/attachments",
+		"list attachments of page "+pageID,
+		map[string]string{"limit": "100"},
+		missingIsFailure,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var attachments []AttachmentInfo
+
+	for _, attachment := range found {
+		info := AttachmentInfo{Filename: attachment.Title, ID: attachment.ID}
+		// The checksum mark recognises an unchanged attachment by lives in the
+		// comment, which v2 keeps at the top level rather than under metadata.
+		info.Metadata.Comment = attachment.Comment
+		info.Links.Context = cloudContextPath
+		info.Links.Download = attachment.DownloadLink
+
+		attachments = append(attachments, info)
+	}
+
+	return attachments, nil
 }
 
 // getPageLabelsV2 is GetPageLabels against v2.
@@ -396,59 +407,38 @@ func (api *API) getAttachmentsV2(pageID string) ([]AttachmentInfo, error) {
 // over with a string id and v2 with an integer one, and everything downstream
 // reads the name rather than the id.
 func (api *API) getPageLabelsV2(pageID, prefix string) (*LabelInfo, error) {
-	const pageSize = 50
-
-	var all []Label
-	var cursor string
-
-	for {
-		var result struct {
-			Results []struct {
-				ID     json.Number `json:"id"`
-				Name   string      `json:"name"`
-				Prefix string      `json:"prefix"`
-			} `json:"results"`
-
-			Links struct {
-				Next string `json:"next"`
-			} `json:"_links"`
-		}
-
-		query := map[string]string{"limit": fmt.Sprintf("%d", pageSize)}
-		if prefix != "" {
-			query["prefix"] = prefix
-		}
-		if cursor != "" {
-			query["cursor"] = cursor
-		}
-
-		request, err := api.v2().Res("pages/"+pageID+"/labels", &result).Get(query)
-		if err != nil {
-			return nil, newTransportError(request, "read labels of page "+pageID, err)
-		}
-
-		if request.Raw.StatusCode != http.StatusOK {
-			return nil, newErrorStatusNotOK(request)
-		}
-
-		for _, label := range result.Results {
-			all = append(all, Label{
-				ID:     label.ID.String(),
-				Name:   label.Name,
-				Prefix: label.Prefix,
-			})
-		}
-
-		next := nextCursor(result.Links.Next)
-		// A server that hands back the cursor it was given would otherwise keep
-		// this loop going for as long as it keeps answering.
-		if next == "" || next == cursor || len(result.Results) == 0 {
-			break
-		}
-		cursor = next
+	type labelV2 struct {
+		ID     json.Number `json:"id"`
+		Name   string      `json:"name"`
+		Prefix string      `json:"prefix"`
 	}
 
-	return &LabelInfo{Labels: all, Size: len(all)}, nil
+	query := map[string]string{"limit": "50"}
+	if prefix != "" {
+		query["prefix"] = prefix
+	}
+
+	found, err := collectPagedV2[labelV2](
+		api,
+		"pages/"+pageID+"/labels",
+		"read labels of page "+pageID,
+		query,
+		missingIsFailure,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	labels := make([]Label, 0, len(found))
+	for _, label := range found {
+		labels = append(labels, Label{
+			ID:     label.ID.String(),
+			Name:   label.Name,
+			Prefix: label.Prefix,
+		})
+	}
+
+	return &LabelInfo{Labels: labels, Size: len(labels)}, nil
 }
 
 // createContentV2 is CreatePage against v2.

--- a/confluence/v2fallback.go
+++ b/confluence/v2fallback.go
@@ -1,0 +1,574 @@
+package confluence
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/kovetskiy/gopencils"
+)
+
+// This file holds the v2 half of every call that mark makes against v1 and can
+// also make against v2.
+//
+// The reason it exists is Atlassian's scoped API tokens. A scoped token carries
+// granular scopes -- read:page:confluence, write:page:confluence and the like
+// -- and reaches Confluence through the api.atlassian.com gateway. The gateway
+// checks the scopes of the token against the endpoint being called, and the v1
+// endpoints are not covered by the page scopes: they check the older
+// content-shaped ones (read:content-details:confluence,
+// write:content:confluence). A token minted for pages therefore gets
+//
+//	401 {"code":401,"message":"Unauthorized; scope does not match"}
+//	X-Failure-Category: FAILURE_CLIENT_SCOPE_CHECK
+//
+// out of /rest/api/content while /api/v2/pages answers perfectly well. That is
+// issue #917: FindHomePage already fell back to v2 (#341), so the run got past
+// the space lookup and then died on the very next call.
+//
+// v1 stays the first choice everywhere. It is the only API Server and Data
+// Center have, its answers carry ancestors and a body without extra round
+// trips, and a classic token is entitled to it. v2 is asked only once v1 has
+// refused, so nothing changes for anybody whose token v1 accepts.
+
+// maxAncestorDepth bounds the parent walk that rebuilds a v2 ancestor chain.
+//
+// v2 names only the immediate parent, so the chain costs a request per level.
+// The bound is not about a plausible page tree -- it is about not walking
+// forever if an instance ever answers with a cycle this walk's seen-set cannot
+// already see.
+const maxAncestorDepth = 100
+
+// v1Refused reports whether a v1 response is the gateway turning the endpoint
+// down rather than Confluence answering about the content.
+//
+// 401 and 403 are what the scope check produces. 404 is included because that
+// is what the v1 space endpoint answers a scoped token with -- the case #341
+// was reported as -- and because a deployment that does not route v1 at all
+// looks the same from here. The cost of reading a genuine 404 as a refusal is
+// one extra request that answers the same way; the cost of not reading a
+// refusal as one is the run aborting.
+func v1Refused(request *gopencils.Resource) bool {
+	if request == nil || request.Raw == nil {
+		return false
+	}
+
+	switch request.Raw.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		return true
+	}
+
+	return false
+}
+
+// ancestorRef is the shape PageInfo.Ancestors holds. It is an alias rather than
+// a definition so that a value of it can be assigned to the anonymous struct
+// type that field is declared with.
+type ancestorRef = struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+}
+
+// contentV2 is a page or blogpost as v2 returns it.
+//
+// The differences from PageInfo that matter: the space is an id rather than a
+// key, the parent is a single id rather than an ancestor chain, and the body is
+// keyed by the representation that was asked for.
+type contentV2 struct {
+	ID         string `json:"id"`
+	Status     string `json:"status"`
+	Title      string `json:"title"`
+	SpaceID    string `json:"spaceId"`
+	ParentID   string `json:"parentId"`
+	ParentType string `json:"parentType"`
+
+	Version struct {
+		Number  int64  `json:"number"`
+		Message string `json:"message"`
+	} `json:"version"`
+
+	Body struct {
+		Storage struct {
+			Value string `json:"value"`
+		} `json:"storage"`
+	} `json:"body"`
+
+	Links struct {
+		WebUI string `json:"webui"`
+	} `json:"_links"`
+}
+
+// pageInfo converts a v2 content object into the shape the rest of mark reads.
+//
+// pageType comes from the caller because v2 says nothing about it: the type is
+// which collection the object was fetched from.
+func (content contentV2) pageInfo(pageType, baseURL string) *PageInfo {
+	page := &PageInfo{
+		ID:     content.ID,
+		Title:  content.Title,
+		Type:   pageType,
+		Status: content.Status,
+	}
+
+	page.Version.Number = content.Version.Number
+	page.Version.Message = content.Version.Message
+	page.Body.Storage.Value = content.Body.Storage.Value
+	page.Links.Full = content.Links.WebUI
+	page.Links.Base = baseURL
+
+	return page
+}
+
+// v2Collection names the v2 collection that holds a v1 content type.
+func v2Collection(pageType string) string {
+	if pageType == "blogpost" {
+		return "blogposts"
+	}
+
+	return "pages"
+}
+
+// findContentV2 is FindPage against v2: a title within a space, in one status.
+//
+// v2 filters by space id where v1 filters by space key, so this pays for a
+// space lookup -- one per space per run, since GetSpaceID caches -- before it
+// can ask its own question.
+func (api *API) findContentV2(space, title, pageType, status string) (*PageInfo, error) {
+	spaceID, err := api.GetSpaceID(space)
+	if err != nil {
+		return nil, fmt.Errorf("unable to resolve space %s for the v2 page lookup: %w", space, err)
+	}
+
+	var result struct {
+		Results []contentV2 `json:"results"`
+	}
+
+	query := map[string]string{
+		"space-id": spaceID,
+		"status":   status,
+		"limit":    "250",
+	}
+	if title != "" {
+		query["title"] = title
+	}
+
+	request, err := api.v2().Res(v2Collection(pageType), &result).Get(query)
+	if err != nil {
+		return nil, newTransportError(
+			request, fmt.Sprintf("find page %q in space %s", title, space), err,
+		)
+	}
+
+	if request.Raw.StatusCode != http.StatusOK {
+		return nil, newErrorStatusNotOK(request)
+	}
+
+	if len(result.Results) == 0 {
+		return nil, nil
+	}
+
+	page := result.Results[0].pageInfo(pageType, api.BaseURL)
+
+	ancestors, err := api.ancestorsV2(result.Results[0])
+	if err != nil {
+		return nil, err
+	}
+	page.Ancestors = ancestors
+
+	return page, nil
+}
+
+// getContentV2 reads one page or blogpost by id.
+//
+// A page id and a blogpost id live in different v2 collections, and the callers
+// of GetPageByID hold an id without always knowing which. Rather than make them
+// say, a 404 from pages is retried against blogposts -- the same two-step v1
+// spared everybody by having a single /content collection.
+func (api *API) getContentV2(contentID string, withBody bool) (*contentV2, string, error) {
+	for _, collection := range []string{"pages", "blogposts"} {
+		var result contentV2
+
+		query := map[string]string{}
+		if withBody {
+			query["body-format"] = "storage"
+		}
+
+		request, err := api.v2().Res(collection+"/"+contentID, &result).Get(query)
+		if err != nil {
+			return nil, "", newTransportError(request, "read page "+contentID, err)
+		}
+
+		if request.Raw.StatusCode == http.StatusNotFound && collection == "pages" {
+			continue
+		}
+
+		if request.Raw.StatusCode != http.StatusOK {
+			return nil, "", newErrorStatusNotOK(request)
+		}
+
+		pageType := "page"
+		if collection == "blogposts" {
+			pageType = "blogpost"
+		}
+
+		return &result, pageType, nil
+	}
+
+	return nil, "", fmt.Errorf("no content with id %s: %w", contentID, ErrNotFound)
+}
+
+// getPageByIDV2 is GetPageByIDExpanded against v2.
+//
+// The v1 expand list is honoured rather than ignored: v2 charges for both of
+// the things it names -- the body by a wider response, the ancestors by a
+// request per level -- and every caller that wants neither would otherwise pay
+// for both.
+func (api *API) getPageByIDV2(pageID, expand string) (*PageInfo, error) {
+	content, pageType, err := api.getContentV2(pageID, strings.Contains(expand, "body.storage"))
+	if err != nil {
+		return nil, err
+	}
+
+	page := content.pageInfo(pageType, api.BaseURL)
+
+	if strings.Contains(expand, "ancestors") {
+		ancestors, err := api.ancestorsV2(*content)
+		if err != nil {
+			return nil, err
+		}
+		page.Ancestors = ancestors
+	}
+
+	return page, nil
+}
+
+// ancestorsV2 rebuilds the ancestor chain v1 hands over for free.
+//
+// v2 names the immediate parent and nothing above it, so the chain is walked a
+// level at a time. It is worth the requests: mark decides where a page belongs
+// by comparing the titles of its ancestors against the ancestry the document
+// declares, and a page that arrives with no ancestors at all reads as one
+// sitting at the root of the space -- which is an invitation to move it there.
+//
+// A parent that is not a page ends the walk. Folders are v2 entities that a
+// page can sit in, and Confluence does not count them as ancestors; UpdatePage
+// relies on that same rule when it decides whether an update names a parent.
+func (api *API) ancestorsV2(content contentV2) ([]ancestorRef, error) {
+	var chain []ancestorRef
+
+	seen := map[string]bool{content.ID: true}
+	parentID, parentType := content.ParentID, content.ParentType
+
+	for parentID != "" && (parentType == "" || parentType == "page") {
+		if seen[parentID] || len(chain) >= maxAncestorDepth {
+			break
+		}
+		seen[parentID] = true
+
+		parent, _, err := api.getContentV2(parentID, false)
+		if err != nil {
+			// An ancestor that cannot be read at all is reported: answering
+			// with a chain known to be short would tell the caller the page
+			// sits somewhere it does not.
+			return nil, fmt.Errorf("unable to read ancestor %s: %w", parentID, err)
+		}
+
+		chain = append(chain, ancestorRef{ID: parent.ID, Title: parent.Title})
+		parentID, parentType = parent.ParentID, parent.ParentType
+	}
+
+	// The walk collects leaf-first; Confluence returns ancestors root-first,
+	// and everything reading the chain takes the last entry as the parent.
+	slices.Reverse(chain)
+
+	return chain, nil
+}
+
+// cloudContextPath is where Confluence Cloud serves itself under, and what v1
+// reports as an attachment's link context.
+//
+// v2 gives a download link without one. Hardcoding it is safe in exactly this
+// spot: v2 is Cloud-only, and Cloud is always mounted at /wiki. On Server and
+// Data Center -- the deployments that mount elsewhere -- there is no v2 for
+// this to be reached through.
+const cloudContextPath = "/wiki"
+
+// getAttachmentsV2 is GetAttachments against v2.
+//
+// Only the listing has a v2 form. Uploading an attachment is a v1 endpoint with
+// no v2 equivalent at all, which is why mark asks for the classic content
+// scopes in its documentation rather than pretending v2 is enough for
+// everything.
+func (api *API) getAttachmentsV2(pageID string) ([]AttachmentInfo, error) {
+	const pageSize = 100
+
+	var all []AttachmentInfo
+	var cursor string
+
+	for {
+		var result struct {
+			Results []struct {
+				ID           string `json:"id"`
+				Title        string `json:"title"`
+				Comment      string `json:"comment"`
+				DownloadLink string `json:"downloadLink"`
+			} `json:"results"`
+
+			Links struct {
+				Next string `json:"next"`
+			} `json:"_links"`
+		}
+
+		query := map[string]string{"limit": fmt.Sprintf("%d", pageSize)}
+		if cursor != "" {
+			query["cursor"] = cursor
+		}
+
+		request, err := api.v2().Res("pages/"+pageID+"/attachments", &result).Get(query)
+		if err != nil {
+			return nil, newTransportError(request, "list attachments of page "+pageID, err)
+		}
+
+		if request.Raw.StatusCode != http.StatusOK {
+			return nil, newErrorStatusNotOK(request)
+		}
+
+		for _, attachment := range result.Results {
+			info := AttachmentInfo{Filename: attachment.Title, ID: attachment.ID}
+			// The checksum mark recognises an unchanged attachment by lives in
+			// the comment, which v2 keeps at the top level rather than under
+			// metadata.
+			info.Metadata.Comment = attachment.Comment
+			info.Links.Context = cloudContextPath
+			info.Links.Download = attachment.DownloadLink
+
+			all = append(all, info)
+		}
+
+		next := nextCursor(result.Links.Next)
+		// A server that hands back the cursor it was given would otherwise keep
+		// this loop going for as long as it keeps answering.
+		if next == "" || next == cursor || len(result.Results) == 0 {
+			break
+		}
+		cursor = next
+	}
+
+	return all, nil
+}
+
+// getPageLabelsV2 is GetPageLabels against v2.
+//
+// The id is decoded as a number and rendered back as a string: v1 hands labels
+// over with a string id and v2 with an integer one, and everything downstream
+// reads the name rather than the id.
+func (api *API) getPageLabelsV2(pageID, prefix string) (*LabelInfo, error) {
+	const pageSize = 50
+
+	var all []Label
+	var cursor string
+
+	for {
+		var result struct {
+			Results []struct {
+				ID     json.Number `json:"id"`
+				Name   string      `json:"name"`
+				Prefix string      `json:"prefix"`
+			} `json:"results"`
+
+			Links struct {
+				Next string `json:"next"`
+			} `json:"_links"`
+		}
+
+		query := map[string]string{"limit": fmt.Sprintf("%d", pageSize)}
+		if prefix != "" {
+			query["prefix"] = prefix
+		}
+		if cursor != "" {
+			query["cursor"] = cursor
+		}
+
+		request, err := api.v2().Res("pages/"+pageID+"/labels", &result).Get(query)
+		if err != nil {
+			return nil, newTransportError(request, "read labels of page "+pageID, err)
+		}
+
+		if request.Raw.StatusCode != http.StatusOK {
+			return nil, newErrorStatusNotOK(request)
+		}
+
+		for _, label := range result.Results {
+			all = append(all, Label{
+				ID:     label.ID.String(),
+				Name:   label.Name,
+				Prefix: label.Prefix,
+			})
+		}
+
+		next := nextCursor(result.Links.Next)
+		// A server that hands back the cursor it was given would otherwise keep
+		// this loop going for as long as it keeps answering.
+		if next == "" || next == cursor || len(result.Results) == 0 {
+			break
+		}
+		cursor = next
+	}
+
+	return &LabelInfo{Labels: all, Size: len(all)}, nil
+}
+
+// createContentV2 is CreatePage against v2.
+func (api *API) createContentV2(
+	space string,
+	pageType string,
+	parent *PageInfo,
+	title string,
+	body string,
+) (*PageInfo, error) {
+	spaceID, err := api.GetSpaceID(space)
+	if err != nil {
+		return nil, fmt.Errorf("unable to resolve space %s for the v2 page create: %w", space, err)
+	}
+
+	payload := map[string]any{
+		"spaceId": spaceID,
+		"status":  "current",
+		"title":   title,
+		"body": map[string]any{
+			"representation": "storage",
+			"value":          body,
+		},
+	}
+
+	// A blogpost has no parent, and naming one is rejected rather than ignored.
+	if parent != nil && pageType != "blogpost" {
+		payload["parentId"] = parent.ID
+	}
+
+	var result contentV2
+
+	request, err := api.v2().Res(v2Collection(pageType), &result).Post(payload)
+	if err != nil {
+		return nil, newTransportError(
+			request, fmt.Sprintf("create page %q in space %s", title, space), err,
+		)
+	}
+
+	if request.Raw.StatusCode != http.StatusOK && request.Raw.StatusCode != http.StatusCreated {
+		return nil, newErrorStatusNotOK(request)
+	}
+
+	return result.pageInfo(pageType, api.BaseURL), nil
+}
+
+// updateContentV2 is UpdatePage against v2.
+//
+// The one thing v2 cannot do in the same request is the metadata v1 carries in
+// `metadata.properties`: the published content appearance and the emoji title
+// are content properties, and v2 keeps properties on an endpoint of their own.
+// They are written afterwards, by the caller, so that a page whose content went
+// in is not reported as unpublished because its width did not.
+func (api *API) updateContentV2(
+	page *PageInfo,
+	newContent string,
+	minorEdit bool,
+	versionMessage string,
+	nextVersion int64,
+) error {
+	payload := map[string]any{
+		"id":     page.ID,
+		"status": "current",
+		"title":  page.Title,
+		"body": map[string]any{
+			"representation": "storage",
+			"value":          newContent,
+		},
+		"version": map[string]any{
+			"number":    nextVersion,
+			"minorEdit": minorEdit,
+			"message":   versionMessage,
+		},
+	}
+
+	// As on v1, the parent goes in only when there is one to name: a page whose
+	// parent is a folder has no ancestors, and naming no parent at all is how
+	// v2 is asked to move a page to the root of its space.
+	if page.Type != "blogpost" && len(page.Ancestors) > 0 {
+		payload["parentId"] = page.Ancestors[len(page.Ancestors)-1].ID
+	}
+
+	request, err := api.v2().Res(
+		v2Collection(page.Type)+"/"+page.ID, &map[string]any{},
+	).Put(payload)
+	if err != nil {
+		return newTransportError(
+			request, fmt.Sprintf("update page %q (%s)", page.Title, page.ID), err,
+		)
+	}
+
+	if request.Raw.StatusCode != http.StatusOK {
+		return newErrorStatusNotOK(request)
+	}
+
+	return nil
+}
+
+// propertyValues flattens the shape v1 takes properties in -- a key naming a
+// {"value": ...} object -- into the key/value pairs the v2 property API wants.
+//
+// Anything whose value is not a string is dropped rather than guessed at: every
+// property mark sets is a string, and inventing an encoding for one that is not
+// would be writing something nobody asked for.
+func propertyValues(properties map[string]any) map[string]string {
+	values := make(map[string]string, len(properties))
+
+	for key, wrapper := range properties {
+		object, ok := wrapper.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if value, ok := object["value"].(string); ok {
+			values[key] = value
+		}
+	}
+
+	return values
+}
+
+// setContentPropertiesV2 writes the properties that v1 carries inside the page
+// update itself.
+//
+// Each key is read before it is written because a property update has to name
+// the version it supersedes, and creating one that already exists is a
+// conflict rather than an overwrite.
+func (api *API) setContentPropertiesV2(pageID string, properties map[string]string) error {
+	existing, err := api.ListPageProperties(pageID)
+	if err != nil {
+		return fmt.Errorf("unable to read properties of page %s: %w", pageID, err)
+	}
+
+	byKey := map[string]*Property{}
+	for i, property := range existing {
+		byKey[property.Key] = &existing[i]
+	}
+
+	// Sorted, so that a failure part way through leaves the same page in the
+	// same state every time rather than one of two.
+	for _, key := range slices.Sorted(maps.Keys(properties)) {
+		value, err := json.Marshal(properties[key])
+		if err != nil {
+			return fmt.Errorf("unable to encode property %q: %w", key, err)
+		}
+
+		if err := api.SetPageProperty(pageID, key, value, byKey[key]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/mark_parents_test.go
+++ b/mark_parents_test.go
@@ -2,6 +2,7 @@ package mark
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
@@ -13,16 +14,26 @@ import (
 // answer every later one normally, which is what a network blip looks like from
 // here.
 func failOnceLookingUp(server *confluencetest.Server, title string) {
-	failed := false
+	// Once per API: a page lookup that v1 refuses is retried against v2, for
+	// the sake of scoped API tokens, so failing only the v1 half is a blip the
+	// run recovers from rather than the failure this is about.
+	failed := map[string]bool{}
 	server.SetFail(func(r *http.Request) (int, string, bool) {
-		if failed || r.Method != http.MethodGet {
+		if r.Method != http.MethodGet {
 			return 0, "", false
 		}
 		if r.URL.Query().Get("title") != title {
 			return 0, "", false
 		}
 
-		failed = true
+		api := "v1"
+		if strings.HasPrefix(r.URL.Path, "/api/v2") {
+			api = "v2"
+		}
+		if failed[api] {
+			return 0, "", false
+		}
+		failed[api] = true
 
 		return http.StatusForbidden, `{"message":"nope"}`, true
 	})

--- a/mark_scopedtoken_test.go
+++ b/mark_scopedtoken_test.go
@@ -1,0 +1,91 @@
+package mark
+
+import (
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kovetskiy/mark/v16/confluence"
+	"github.com/kovetskiy/mark/v16/confluence/confluencetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scopedTokenGateway refuses every v1 endpoint the way the api.atlassian.com
+// gateway refuses one to an Atlassian scoped API token: the token carries the
+// granular page scopes, the v1 endpoints check the older content ones, and the
+// gateway answers the mismatch before Confluence ever sees the request.
+func scopedTokenGateway() confluencetest.FailFunc {
+	return func(r *http.Request) (int, string, bool) {
+		if strings.HasPrefix(r.URL.Path, "/rest/api") {
+			return http.StatusUnauthorized,
+				`{"code":401,"message":"Unauthorized; scope does not match"}`, true
+		}
+		return 0, "", false
+	}
+}
+
+// TestPublishWithAScopedToken is issue #917 end to end: a run that resolves the
+// space, creates the page and publishes into it without v1 answering anything.
+func TestPublishWithAScopedToken(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.SetFail(scopedTokenGateway())
+
+	dir := t.TempDir()
+	writeFile(t, dir, "guide.md",
+		"<!-- Space: DOCS -->\n<!-- Title: Guide -->\n\nA guide.\n")
+
+	require.NoError(t, Run(Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		Output: io.Discard,
+	}))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	page, err := api.FindPage("DOCS", "Guide", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+
+	stored := server.Page(page.ID)
+	require.NotNil(t, stored)
+	assert.Contains(t, stored.Body, "A guide.")
+	assert.Equal(t, home.ID, stored.ParentID)
+}
+
+// TestRepublishWithAScopedToken: the second run finds the page it made and
+// updates it rather than trying to create it again.
+func TestRepublishWithAScopedToken(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.SetFail(scopedTokenGateway())
+
+	dir := t.TempDir()
+	writeFile(t, dir, "guide.md",
+		"<!-- Space: DOCS -->\n<!-- Title: Guide -->\n\nA guide.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+
+	writeFile(t, dir, "guide.md",
+		"<!-- Space: DOCS -->\n<!-- Title: Guide -->\n\nA revised guide.\n")
+	require.NoError(t, Run(config))
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	page, err := api.FindPage("DOCS", "Guide", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+
+	stored := server.Page(page.ID)
+	require.NotNil(t, stored)
+	assert.Contains(t, stored.Body, "A revised guide.")
+	assert.Equal(t, home.ID, stored.ParentID, "a republish must not move the page")
+}

--- a/mark_scopedtoken_test.go
+++ b/mark_scopedtoken_test.go
@@ -89,3 +89,41 @@ func TestRepublishWithAScopedToken(t *testing.T) {
 	assert.Contains(t, stored.Body, "A revised guide.")
 	assert.Equal(t, home.ID, stored.ParentID, "a republish must not move the page")
 }
+
+// TestPublishAgainstDataCenter is the counterpart: Server and Data Center have
+// no v2 API, so the fallbacks added for scoped tokens must be invisible there.
+// Every /api/v2 path answers as one that does not exist, and the run has to be
+// exactly the run it always was.
+func TestPublishAgainstDataCenter(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.SetFail(func(r *http.Request) (int, string, bool) {
+		if strings.HasPrefix(r.URL.Path, "/api/v2") {
+			return http.StatusNotFound, `<html>404 Not Found</html>`, true
+		}
+		return 0, "", false
+	})
+
+	dir := t.TempDir()
+	writeFile(t, dir, "guide.md",
+		"<!-- Space: DOCS -->\n<!-- Title: Guide -->\n<!-- Label: from-mark -->\n\nA guide.\n")
+
+	config := Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: filepath.Join(dir, "*.md"), Features: []string{"mention"},
+		Output: io.Discard,
+	}
+	require.NoError(t, Run(config))
+	require.NoError(t, Run(config), "and again, against the page it made")
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	page, err := api.FindPage("DOCS", "Guide", "page")
+	require.NoError(t, err)
+	require.NotNil(t, page)
+
+	stored := server.Page(page.ID)
+	require.NotNil(t, stored)
+	assert.Contains(t, stored.Body, "A guide.")
+	assert.Equal(t, []string{"from-mark"}, stored.Labels)
+}

--- a/page/lookup_failure_test.go
+++ b/page/lookup_failure_test.go
@@ -38,8 +38,12 @@ func TestInScopeReportsARealFailure(t *testing.T) {
 	home := server.AddPage("DOCS", "Home", "page", "")
 	page := server.AddPage("DOCS", "Doc", "page", home.ID)
 
+	// Both APIs, because a v1 read that is refused falls back to v2 for the
+	// sake of scoped API tokens: a page a caller may not read is refused by
+	// whichever one it asks.
 	server.SetFail(func(r *http.Request) (int, string, bool) {
-		if strings.Contains(r.URL.Path, "/content/"+page.ID) {
+		if strings.Contains(r.URL.Path, "/content/"+page.ID) ||
+			strings.Contains(r.URL.Path, "/pages/"+page.ID) {
 			return http.StatusForbidden, `{"message":"no"}`, true
 		}
 


### PR DESCRIPTION
## Problem

Fixes #917.

An Atlassian scoped API token reaches Confluence through the `api.atlassian.com` gateway, which checks the token's granular scopes against the endpoint being called. Confluence's two REST APIs check different scopes for the same thing: v2 checks the page scopes a scoped token is minted with (`read:page:confluence`, `write:page:confluence`), while the older v1 endpoints check `read:content-details:confluence` and `write:content:confluence`. So `/rest/api/content` answered

```text
401 {"code":401,"message":"Unauthorized; scope does not match"}
X-Failure-Category: FAILURE_CLIENT_SCOPE_CHECK
```

while `/api/v2/pages` answered perfectly well. #798 gave `FindHomePage` a v2 fallback, so a run got past the space lookup and then died on the very next call — the page lookup.

## Fix

Every v1 call on the publish path now falls back to v2 when v1 refuses it (401, 403 or 404), in `confluence/v2fallback.go`:

| call | v2 endpoint |
| --- | --- |
| `FindPage`, `findPageWithStatus` | `GET /pages` (or `/blogposts`) by `space-id`, `title`, `status` |
| `GetPageByIDExpanded` | `GET /pages/{id}`, honouring the v1 expand list |
| `CreatePage` | `POST /pages` |
| `UpdatePage` | `PUT /pages/{id}`, plus the page properties |
| `GetAttachments` | `GET /pages/{id}/attachments` |
| `GetPageLabels` | `GET /pages/{id}/labels` |

Two details worth a look:

- **Ancestors.** v2 names only the immediate parent, so the chain is walked back a level at a time. Leaving it empty would read as a page sitting at the root of its space, which is an invitation to move it there. The walk stops at a parent that is not a page, which is how folders already behave on the v1 path.
- **Page properties.** v1 carries content appearance and the emoji title inside the update request; v2 keeps properties on an endpoint of its own. They are written after the content, and a failure there is reported as "the page was updated, but its properties were not" — with the new version recorded first, so a retry does not collide with it.

v1 stays the first choice everywhere: it answers in one request what v2 needs several for. Nothing changes for a token v1 accepts, and a test pins that no v2 request is made in that case.

**Server and Data Center have no v2 API**, so every fallback is gated on `IsCloud()` — the same test mark already applies to its other Cloud-only features, free for the gateway and the Cloud hosts it knows by name, one probe for the life of the API value otherwise. Without the gate a self-hosted instance paid a wasted request per refused call, and got something worse than noise back: `/api/v2/...` answers 404 there, and a v1 403 wrapped together with that 404 satisfied `errors.Is(err, ErrNotFound)` — which `page/orphan.go` reads as "the page is gone" and `--on-orphan` archives or trashes. Only the v1 error is wrapped now; the v2 one contributes its text and no sentinels. The two fallbacks that predate this PR (`FindHomePage`, `GetSpaceID`) are gated on the same test, so a Data Center run that cannot resolve a space gets v1's error instead of that error paired with a 404 from a path it does not have.

Uploading attachments, writing labels, inline comments, restrictions and moves have no v2 endpoint at all and stay on v1. README gains a "Scoped API tokens" section saying which scopes the v2 path needs and which features still need the content scopes.

## Testing

- `confluence/scopedtoken_test.go`: the fallbacks, the ancestor walk, absence, the v1-preferred path, and the error a Server deployment (no v2 at all) must still see.
- `mark_scopedtoken_test.go`: a publish and a republish end to end with every `/rest/api` endpoint answering 401, which is issue #917 as reported.
- `confluencetest` grew the v2 endpoints those need: `GET /pages`, `GET|PUT /pages/{id}`, `/pages/{id}/labels`, `/pages/{id}/attachments`, `/pages/{id}/properties`.
- Data Center coverage: a fake that answers 404 for every `/api/v2` path — a v1 403 must not read as `ErrNotFound`, the probe happens once however many calls are refused, no fallback is attempted, and a whole publish and republish (labels included) goes through untouched.
- Two existing tests that injected a v1-only failure now fail both APIs — a v1 blip alone is something the run recovers from.
- `go test ./...`, `golangci-lint run ./...`, `markdownlint-cli2` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
