### PR TITLE
fix: resolve a linked file as a name, not as a pattern

### DIFF
--- a/attachment/attachment.go
+++ b/attachment/attachment.go
@@ -208,14 +208,46 @@ func ResolveLocalAttachments(opener vfs.Opener, base string, replacements []stri
 	}
 
 	for i := range attachments {
-		checksum, err := GetChecksum(bytes.NewReader(attachments[i].FileBytes))
-		if err != nil {
-			return nil, fmt.Errorf("unable to get checksum for attachment %q: %w", attachments[i].Name, err)
+		if err := setChecksum(&attachments[i]); err != nil {
+			return nil, err
 		}
-
-		attachments[i].Checksum = checksum
 	}
-	return attachments, err
+
+	return attachments, nil
+}
+
+// ResolveLocalAttachment resolves one path exactly as it was written.
+//
+// Nothing in it is read as a pattern, which is what separates this from
+// ResolveLocalAttachments: a declared attachment may name several files on
+// purpose, while a link points at one. "report[2024].pdf" is an ordinary
+// filename, and globbing it would publish whichever of report2.pdf,
+// report0.pdf or report4.pdf happens to sit beside it -- a different file from
+// the one the link names, under a link that reads as if it were right.
+func ResolveLocalAttachment(opener vfs.Opener, base, name string) (Attachment, error) {
+	attachment, err := prepareAttachment(opener, base, name)
+	if err != nil {
+		return Attachment{}, err
+	}
+
+	if err := setChecksum(&attachment); err != nil {
+		return Attachment{}, err
+	}
+
+	return attachment, nil
+}
+
+// setChecksum records what the file hashes to, which is how a later run
+// recognises an attachment it does not need to upload again.
+func setChecksum(attachment *Attachment) error {
+	checksum, err := GetChecksum(bytes.NewReader(attachment.FileBytes))
+	if err != nil {
+		return fmt.Errorf("unable to get checksum for attachment %q: %w", attachment.Name, err)
+	}
+
+	attachment.Checksum = checksum
+
+	return nil
 }
 
 // prepareAttachements creates an array of attachement objects based on an array of filepaths

--- a/mark_attach_referenced_test.go
+++ b/mark_attach_referenced_test.go
@@ -181,3 +181,39 @@ func onePixelPNG() []byte {
 		0x89,
 	}
 }
+
+// TestAFilenameWithBracketsIsNotAPattern covers the destination that reads as a
+// glob and is not one. A file really called report[2024].pdf is an ordinary
+// name; expanded as a pattern it names one of report2.pdf, report0.pdf and
+// report4.pdf instead, so the page would carry a link that reads as the report
+// and downloads whatever else happened to be sitting beside it. A link points
+// at one file, and it is the one it names.
+func TestAFilenameWithBracketsIsNotAPattern(t *testing.T) {
+	server := confluencetest.New(t)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "files"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "files", "report[2024].pdf"), []byte("the one linked to\n"), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "files", "report2.pdf"), []byte("what the glob would match\n"), 0o600))
+
+	file := writeFile(t, dir, "doc.md",
+		"<!-- Space: DOCS -->\n<!-- Title: Doc -->\n\n# Doc\n\n"+
+			"See [the report](<files/report[2024].pdf>).\n")
+
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+
+	target, err := ProcessFile(file, api, Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: file, AttachReferenced: true, Output: io.Discard,
+	})
+	require.NoError(t, err)
+
+	stored := server.Attachments(target.ID)
+	require.Len(t, stored, 1)
+	assert.Equal(t, "files_report[2024].pdf", stored[0].Filename)
+	assert.Contains(t, server.Page(target.ID).Body, `ri:filename="files_report[2024].pdf"`)
+}

--- a/renderer/internal_test.go
+++ b/renderer/internal_test.go
@@ -66,3 +66,36 @@ func TestFootnoteAnchorNames(t *testing.T) {
 	assert.Equal(t, "footnote-ref-3-1", footnoteRefAnchor(3, 1))
 	assert.Equal(t, "footnote-ref-3-2", footnoteRefAnchor(3, 2))
 }
+
+// TestIsLocalFileReference pins which destinations --attach-referenced will
+// offer to publish, including the ones whose answer cannot be observed on the
+// machine this test runs on: a Windows path is a Windows path from Linux too,
+// and reading one as a relative file would join it onto the document's
+// directory and refuse it as outside the project instead of leaving the link
+// exactly as the author wrote it.
+func TestIsLocalFileReference(t *testing.T) {
+	tests := map[string]bool{
+		"files/report.pdf":           true,
+		"report.pdf":                 true,
+		"files/report[2024].pdf":     true,
+		"":                           false,
+		"#a-heading":                 false,
+		"/files/report.pdf":          false,
+		"C:/docs/report.pdf":         false,
+		`C:\docs\report.pdf`:         false,
+		`c:\docs\report.pdf`:         false,
+		`\docs\report.pdf`:           false,
+		`\\server\share\report.pdf`:  false,
+		"https://example.com/a.pdf":  false,
+		"mailto:someone@example.com": false,
+		"other.md":                   false,
+		"NOTES.markdown":             false,
+		"CHANGELOG":                  false,
+	}
+
+	for destination, want := range tests {
+		t.Run(destination, func(t *testing.T) {
+			assert.Equal(t, want, isLocalFileReference(destination))
+		})
+	}
+}

--- a/renderer/link.go
+++ b/renderer/link.go
@@ -233,8 +233,10 @@ func (r *ConfluenceLinkRenderer) attachReferencedFile(
 	node ast.Node,
 	link *ast.Link,
 ) error {
-	attachments, err := attachment.ResolveLocalAttachments(
-		vfs.LocalOS, filepath.Dir(r.Path), []string{string(link.Destination)},
+	// Resolved as written rather than as a pattern: a link names one file, and
+	// the one it names is the one the reader was promised.
+	attached, err := attachment.ResolveLocalAttachment(
+		vfs.LocalOS, filepath.Dir(r.Path), string(link.Destination),
 	)
 
 	// Refused rather than published as a link to somewhere it should not have
@@ -249,14 +251,7 @@ func (r *ConfluenceLinkRenderer) attachReferencedFile(
 		return err
 	}
 
-	if len(attachments) == 0 {
-		line, col := GetLineCol(source, node.Pos())
-
-		return fmt.Errorf("line %d, col %d: no attachment resolved for %q",
-			line, col, string(link.Destination))
-	}
-
-	r.Attachments.Attach(attachments[0])
+	r.Attachments.Attach(attached)
 
 	//nolint:staticcheck
 	text := string(node.Text(source))
@@ -264,7 +259,7 @@ func (r *ConfluenceLinkRenderer) attachReferencedFile(
 	return r.Stdlib.Templates.ExecuteTemplate(writer, "ac:link:attachment", struct {
 		Name string
 		Text string
-	}{attachments[0].Filename, text})
+	}{attached.Filename, text})
 }
 
 // isLocalFileReference reports whether a destination names a file next to the
@@ -279,7 +274,7 @@ func isLocalFileReference(destination string) bool {
 		return false
 	}
 
-	if strings.HasPrefix(destination, "#") || strings.HasPrefix(destination, "/") {
+	if strings.HasPrefix(destination, "#") || isRooted(destination) {
 		return false
 	}
 
@@ -293,6 +288,33 @@ func isLocalFileReference(destination string) bool {
 	}
 
 	return true
+}
+
+// isRooted reports whether a destination names a place from the root of a
+// filesystem rather than one beside the document.
+//
+// Answered by shape rather than by filepath.IsAbs, which answers for the OS
+// this happens to be running on. A document naming C:\docs\report.pdf names an
+// absolute path whether it is published from Windows or from CI on Linux, and
+// either way it is not a file beside the document. Left alone it keeps the link
+// the author wrote, rather than being joined onto the document's directory and
+// refused as "outside the project" -- an error about a path that was never
+// going to be attached.
+func isRooted(destination string) bool {
+	// A leading backslash covers both the Windows root and the "\\server\share"
+	// of a UNC path.
+	if strings.HasPrefix(destination, "/") || strings.HasPrefix(destination, `\`) {
+		return true
+	}
+
+	// A drive letter -- "C:/docs/report.pdf", "c:\docs\report.pdf".
+	if len(destination) >= 2 && destination[1] == ':' {
+		letter := destination[0]
+
+		return (letter >= 'a' && letter <= 'z') || (letter >= 'A' && letter <= 'Z')
+	}
+
+	return false
 }
 
 // xmlAttrEscape makes a document-derived string safe to interpolate into an XML


### PR DESCRIPTION
Two follow-ups to #1007, both from its review, both reproduced with a test that fails without the fix.

## A destination is not a glob

`ResolveLocalAttachments` expands `*?[{`, which is what a declared attachment wants — it may name a set on purpose. A link names one file.

`report[2024].pdf` is an ordinary filename. Expanded as a pattern it is a character class, and beside a `report2.pdf` it matched that instead:

```console
$ ls files/
report[2024].pdf  report2.pdf
$ mark --attach-referenced --files doc.md    # link: [the report](<files/report[2024].pdf>)
creating attachment: "files/report2.pdf"     # before
creating attachment: "files/report[2024].pdf" # after
```

The page went out carrying a link that reads as the report and downloads something else — worse than a broken link, because nothing about it looks wrong.

There was a second half to it: `attachable()` decides whether to attach at all by `os.Stat` on the literal path, so the file the destination was *checked* against was not always the file it *published*. `ResolveLocalAttachment` resolves one path exactly as written, and the two halves now agree.

## A destination is not relative just because it does not start with `/`

`isLocalFileReference` treated `C:\docs\report.pdf` as a file beside the document. With the flag on, that path was joined onto the document's directory and the publish was refused with `outside the project` — an error about a path that was never going to be attached, on a document that published fine before the flag existed.

`isRooted` answers by shape rather than with `filepath.IsAbs`, which answers for the OS the run happens to be on: a drive letter, a leading `/`, and a leading `\` (which covers `\\server\share` too). A document naming an absolute path names one whether it is published from Windows or from CI on Linux.

## Tests

`TestIsLocalFileReference` is internal, so the Windows cases mean something on Linux — with `filepath.IsAbs` they would silently pass either way.

`TestAFilenameWithBracketsIsNotAPattern` is end-to-end against the fake Confluence: two files beside the document, the link naming the bracketed one, and the assertion that it is the one uploaded. Without the fix it attaches `files_report2.pdf`.

`golangci-lint` clean; `attachment`, `renderer` and the root package pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
