### PR TITLE
feat(metadata): set page restrictions from front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,36 @@ attachments:
 labels:
   - <label 1>
   - <label 2>
+restrictions:
+  read:
+    users:
+      - <user name>
+    groups:
+      - <group name>
+  update:
+    users:
+      - <user name>
+    groups:
+      - <group name>
 image-align: <left|center|right>
 order: <whole number>
 ---
 
 <page contents>
 ```
+
+Page restrictions work only through YAML front matter and require both the
+`frontmatter` and `page-restrictions` features:
+
+```shell
+mark --features=mermaid --features=mention --features=frontmatter \
+  --features=page-restrictions
+```
+
+Each operation replaces its existing restrictions; omit the whole mapping to
+leave page restrictions unchanged. An empty operation removes its restrictions.
+Confluence requires anyone named under `update` to also be able to read the
+page.
 
 The legacy HTML header format is also supported:
 

--- a/confluence/api.go
+++ b/confluence/api.go
@@ -25,6 +25,12 @@ type User struct {
 	Username  string `json:"username,omitempty"`
 }
 
+type PageRestriction struct {
+	Operation string
+	Users     []string
+	Groups    []string
+}
+
 type API struct {
 	rest *gopencils.Resource
 	// v2 API for newer endpoints like folders
@@ -1572,6 +1578,59 @@ func (api *API) RestrictPageUpdates(
 		if !api.IsCloud() && (request.Raw.StatusCode == http.StatusNotFound || request.Raw.StatusCode == http.StatusMethodNotAllowed) {
 			return fmt.Errorf("confluence server/datacenter version is too old to support page edit restrictions via REST API (requires Confluence 8.8.0 or newer; status: %d)", request.Raw.StatusCode)
 		}
+		return newErrorStatusNotOK(request)
+	}
+
+	return nil
+}
+
+// SetPageRestrictions replaces the named read or update restrictions on a page.
+func (api *API) SetPageRestrictions(page *PageInfo, restrictions []PageRestriction) error {
+	payload := make([]map[string]any, 0, len(restrictions))
+
+	for _, restriction := range restrictions {
+		users := make([]map[string]any, 0, len(restriction.Users))
+		for _, name := range restriction.Users {
+			user := map[string]any{"type": "known"}
+			if api.IsCloud() {
+				resolved, err := api.GetUserByName(name)
+				if err != nil {
+					return fmt.Errorf("unable to resolve restricted user %q: %w", name, err)
+				}
+				if resolved.AccountID == "" {
+					return fmt.Errorf("resolved restricted user %q has no accountId", name)
+				}
+				user["accountId"] = resolved.AccountID
+			} else {
+				user["username"] = name
+			}
+			users = append(users, user)
+		}
+
+		groups := make([]map[string]any, 0, len(restriction.Groups))
+		for _, name := range restriction.Groups {
+			groups = append(groups, map[string]any{"type": "group", "name": name})
+		}
+
+		payload = append(payload, map[string]any{
+			"operation": restriction.Operation,
+			"restrictions": map[string]any{
+				"user":  users,
+				"group": groups,
+			},
+		})
+	}
+
+	var result any
+	request, err := api.v1().
+		Res("content").
+		Id(page.ID).
+		Res("restriction", &result).
+		Put(payload)
+	if err != nil {
+		return newTransportError(request, "set restrictions on page "+page.ID, err)
+	}
+	if request.Raw.StatusCode != http.StatusOK && request.Raw.StatusCode != http.StatusNoContent {
 		return newErrorStatusNotOK(request)
 	}
 

--- a/confluence/api_test.go
+++ b/confluence/api_test.go
@@ -1,13 +1,43 @@
 package confluence
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestSetPageRestrictions(t *testing.T) {
+	var body []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/spaces" {
+			http.NotFound(w, r)
+			return
+		}
+		var err error
+		body, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	api := NewAPI(server.URL, "username", "password", true)
+	err := api.SetPageRestrictions(&PageInfo{ID: "123"}, []PageRestriction{
+		{Operation: "read", Groups: []string{"docs-readers"}},
+		{Operation: "update", Users: []string{"jdoe"}},
+	})
+	require.NoError(t, err)
+
+	require.JSONEq(t, `[
+		{"operation":"read","restrictions":{"user":[],"group":[{"type":"group","name":"docs-readers"}]}},
+		{"operation":"update","restrictions":{"user":[{"type":"known","username":"jdoe"}],"group":[]}}
+	]`, string(body))
+}
 
 func TestPageCache(t *testing.T) {
 	api := &API{

--- a/mark.go
+++ b/mark.go
@@ -666,6 +666,13 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 		meta = nil
 	}
 
+	if meta != nil && meta.Restrictions != nil &&
+		!slices.Contains(config.Features, "page-restrictions") {
+		return nil, nil, fmt.Errorf(
+			"page restrictions in %q require --features=page-restrictions", file,
+		)
+	}
+
 	// Before anything is asked of Confluence: a document that has opted out
 	// should cost nothing, not a page lookup and an attachment upload it will
 	// not use.
@@ -956,6 +963,25 @@ func processFile(file string, api *confluence.API, config Config, std *stdlib.Li
 			}
 
 			return target, nil, nil
+		}
+	}
+
+	// Apply access controls before uploading attachments or page content so a
+	// newly created restricted page is never populated while still unrestricted.
+	if meta != nil && meta.Restrictions != nil {
+		var restrictions []confluence.PageRestriction
+		if subjects := meta.Restrictions.Read; subjects != nil {
+			restrictions = append(restrictions, confluence.PageRestriction{
+				Operation: "read", Users: subjects.Users, Groups: subjects.Groups,
+			})
+		}
+		if subjects := meta.Restrictions.Update; subjects != nil {
+			restrictions = append(restrictions, confluence.PageRestriction{
+				Operation: "update", Users: subjects.Users, Groups: subjects.Groups,
+			})
+		}
+		if err := api.SetPageRestrictions(target, restrictions); err != nil {
+			return nil, nil, fmt.Errorf("unable to set page restrictions: %w", err)
 		}
 	}
 

--- a/mark_process_test.go
+++ b/mark_process_test.go
@@ -161,10 +161,10 @@ restrictions:
 
 	restrictionIndex, contentIndex := -1, -1
 	for i, request := range server.Requests() {
-		if request.Method == "PUT" && strings.HasSuffix(request.Path, "/restriction") {
+		if request.Method == http.MethodPut && strings.HasSuffix(request.Path, "/restriction") {
 			restrictionIndex = i
 		}
-		if request.Method == "PUT" && strings.HasSuffix(request.Path, "/content/"+target.ID) {
+		if request.Method == http.MethodPut && strings.HasSuffix(request.Path, "/content/"+target.ID) {
 			contentIndex = i
 		}
 	}

--- a/mark_process_test.go
+++ b/mark_process_test.go
@@ -133,6 +133,64 @@ Some **content**.
 	assert.Equal(t, parent.ID, stored.ParentID)
 }
 
+func TestProcessFileAppliesFrontMatterRestrictions(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	home := server.AddPage("DOCS", "Home", "page", "")
+	server.SetHomepage("DOCS", home.ID)
+	server.AddPage("DOCS", "Parent", "page", home.ID)
+
+	file := writeFile(t, t.TempDir(), "doc.md", `---
+space: DOCS
+parents: [Parent]
+title: Restricted
+restrictions:
+  read:
+    groups: [docs-readers]
+---
+
+# Restricted
+`)
+
+	target, err := ProcessFile(file, api, Config{
+		BaseURL: server.URL, Username: "user", Password: "token",
+		Files: file, Features: []string{"frontmatter", "page-restrictions"}, Output: io.Discard,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, server.CountRequests("PUT", "/restriction"))
+
+	restrictionIndex, contentIndex := -1, -1
+	for i, request := range server.Requests() {
+		if request.Method == "PUT" && strings.HasSuffix(request.Path, "/restriction") {
+			restrictionIndex = i
+		}
+		if request.Method == "PUT" && strings.HasSuffix(request.Path, "/content/"+target.ID) {
+			contentIndex = i
+		}
+	}
+	assert.Less(t, restrictionIndex, contentIndex,
+		"restrictions must be set before content is uploaded")
+}
+
+func TestProcessFileRequiresPageRestrictionsFeature(t *testing.T) {
+	server := confluencetest.New(t)
+	api := confluence.NewAPI(server.URL, "user", "token", false)
+	file := writeFile(t, t.TempDir(), "doc.md", `---
+space: DOCS
+title: Restricted
+restrictions:
+  read: {}
+---
+`)
+
+	_, err := ProcessFile(file, api, Config{
+		Features: []string{"frontmatter"}, Output: io.Discard,
+	})
+	require.EqualError(t, err,
+		`page restrictions in "`+file+`" require --features=page-restrictions`)
+	assert.Empty(t, server.Requests())
+}
+
 // markdownWithTitle is the document under test, parameterised on its title.
 func markdownWithTitle(title string) string {
 	return `<!-- Space: DOCS -->

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -168,6 +168,7 @@ type Meta struct {
 	Attachments       []string
 	Labels            []string
 	ContentAppearance string
+	Restrictions      *Restrictions
 
 	// Synchronized is whether the document is published at all. Nil means it
 	// said nothing, which is not the same as false: a pointer keeps the
@@ -190,6 +191,18 @@ type Meta struct {
 	// sorting them to the front.
 	Order      *int
 	ImageAlign string
+}
+
+// Restrictions declares who may read or update a Confluence page.
+// A nil operation leaves that operation unchanged; an empty operation clears it.
+type Restrictions struct {
+	Read   *RestrictionSubjects
+	Update *RestrictionSubjects
+}
+
+type RestrictionSubjects struct {
+	Users  []string
+	Groups []string
 }
 
 const (
@@ -276,6 +289,80 @@ func toStringMap(val any) map[string]any {
 	default:
 		return nil
 	}
+}
+
+func restrictionSubjects(operation string, val any) (*RestrictionSubjects, error) {
+	values := toStringMap(val)
+	if values == nil {
+		return nil, fmt.Errorf("restrictions.%s must be a mapping", operation)
+	}
+
+	subjects := &RestrictionSubjects{}
+	for key, value := range values {
+		items, ok := value.([]any)
+		if !ok {
+			return nil, fmt.Errorf("restrictions.%s.%s must be a list", operation, key)
+		}
+
+		parsed := make([]string, 0, len(items))
+		for _, item := range items {
+			name, ok := item.(string)
+			if !ok || strings.TrimSpace(name) == "" {
+				return nil, fmt.Errorf(
+					"restrictions.%s.%s entries must be non-empty strings",
+					operation, key,
+				)
+			}
+			parsed = append(parsed, strings.TrimSpace(name))
+		}
+
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "users":
+			subjects.Users = parsed
+		case "groups":
+			subjects.Groups = parsed
+		default:
+			return nil, fmt.Errorf(
+				"restrictions.%s supports only users and groups, got %q",
+				operation, key,
+			)
+		}
+	}
+
+	return subjects, nil
+}
+
+func parseRestrictions(val any) (*Restrictions, error) {
+	values := toStringMap(val)
+	if values == nil {
+		return nil, fmt.Errorf("restrictions must be a mapping")
+	}
+
+	restrictions := &Restrictions{}
+	for key, value := range values {
+		operation := strings.ToLower(strings.TrimSpace(key))
+		subjects, err := restrictionSubjects(operation, value)
+		if err != nil {
+			return nil, err
+		}
+
+		switch operation {
+		case "read":
+			restrictions.Read = subjects
+		case "update":
+			restrictions.Update = subjects
+		default:
+			return nil, fmt.Errorf(
+				"restrictions supports only read and update, got %q", key,
+			)
+		}
+	}
+
+	if restrictions.Read == nil && restrictions.Update == nil {
+		return nil, fmt.Errorf("restrictions must include read or update")
+	}
+
+	return restrictions, nil
 }
 
 func toString(val any) string {
@@ -430,6 +517,12 @@ func ExtractMeta(data []byte, spaceFromCli string, titleFromH1 bool, titleFromFi
 					}
 					meta.Properties[key] = value
 				}
+			case "restrictions":
+				restrictions, err := parseRestrictions(v)
+				if err != nil {
+					return nil, nil, err
+				}
+				meta.Restrictions = restrictions
 
 			default:
 				unknown = append(unknown, k)

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -160,6 +160,13 @@ attachments:
 labels:
   - alpha
   - beta
+restrictions:
+  read:
+    groups:
+      - docs-readers
+  update:
+    users:
+      - Jane Doe
 content-appearance: default
 image-align: center
 ---
@@ -169,20 +176,35 @@ image-align: center
 	meta, body, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", true)
 	assert.NoError(t, err)
 	assert.Equal(t, &Meta{
-		Parents:           []string{"Parent 1", "Parent 2"},
-		Folders:           []string{"Folder 1", "Folder 2"},
-		Space:             "DOCS",
-		Type:              "page",
-		Title:             "Test Page",
-		Layout:            "article",
-		Sidebar:           "<p>Side</p>",
-		Emoji:             "rocket",
-		Attachments:       []string{"image.png"},
-		Labels:            []string{"alpha", "beta"},
+		Parents:     []string{"Parent 1", "Parent 2"},
+		Folders:     []string{"Folder 1", "Folder 2"},
+		Space:       "DOCS",
+		Type:        "page",
+		Title:       "Test Page",
+		Layout:      "article",
+		Sidebar:     "<p>Side</p>",
+		Emoji:       "rocket",
+		Attachments: []string{"image.png"},
+		Labels:      []string{"alpha", "beta"},
+		Restrictions: &Restrictions{
+			Read: &RestrictionSubjects{
+				Groups: []string{"docs-readers"},
+			},
+			Update: &RestrictionSubjects{
+				Users: []string{"Jane Doe"},
+			},
+		},
 		ContentAppearance: DefaultContentAppearance,
 		ImageAlign:        "center",
 	}, meta)
 	assert.Equal(t, "# Content\n", string(body))
+}
+
+func TestExtractMetaYAMLFrontMatterRejectsInvalidRestrictions(t *testing.T) {
+	markdown := "---\nspace: DOCS\ntitle: Test\nrestrictions:\n  write:\n    users: [Jane Doe]\n---\n"
+
+	_, _, err := ExtractMeta([]byte(markdown), "", false, false, "", nil, false, "", true)
+	require.EqualError(t, err, `restrictions supports only read and update, got "write"`)
 }
 
 func TestExtractMetaYAMLFrontMatterScalarAliases(t *testing.T) {

--- a/util/flags.go
+++ b/util/flags.go
@@ -36,6 +36,7 @@ var KnownFeatures = []string{
 	"mention",
 	"mermaid",
 	"mkdocsadmonitions",
+	"page-restrictions",
 	"plantuml",
 }
 


### PR DESCRIPTION
## Summary

- Add YAML front matter support for per-page Confluence restrictions.
- Support `read` and `update` restrictions for users and groups.
- Add the opt-in `page-restrictions` feature gate.
- Fail with an actionable error when restriction metadata is present without the
  feature enabled.
- Apply restrictions before uploading attachments or page content.
- Document that page restrictions are supported only through YAML front matter.

Example:

~~~yaml
restrictions:
  read:
    users:
      - jdoe
    groups:
      - docs-readers
  update:
    users:
      - jdoe
    groups:
      - docs-editors
~~~

This requires both features:

~~~shell
mark \
  --features=frontmatter \
  --features=page-restrictions
~~~

## Validation

- `go test ./... -count=1`
- `git diff --check`
- Verified that restrictions are applied before page content is uploaded.
- Verified that Mark fails without `--features=page-restrictions` when
  restriction metadata is present.
- Verified parsing and validation of `read` and `update` user/group
  restrictions.